### PR TITLE
Reapply "Propagate file distribution permission-denied as a permanent error"

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServer.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServer.java
@@ -13,6 +13,7 @@ import com.yahoo.net.HostName;
 import com.yahoo.security.tls.Capability;
 import com.yahoo.vespa.filedistribution.FileDownloader;
 import com.yahoo.vespa.filedistribution.FileReferenceDownload;
+import com.yahoo.vespa.filedistribution.FileReferenceDownloadPermissionDeniedException;
 
 import java.io.File;
 import java.util.Map;
@@ -78,6 +79,7 @@ class FileDistributionRpcServer {
     private static final int baseFileProviderErrorCode = baseErrorCode + 0x1000;
 
     private static final int fileReferenceNotFound = baseFileProviderErrorCode;
+    private static final int fileReferencePermissionDenied = baseFileProviderErrorCode + 1;
 
     private void getFile(Request req) {
         req.detach();
@@ -106,14 +108,19 @@ class FileDistributionRpcServer {
     private void downloadFile(Request req) {
         FileReference fileReference = new FileReference(req.parameters().get(0).asString());
         log.log(Level.FINE, () -> "getFile() called for file reference '" + fileReference.value() + "'");
-        Optional<File> file = downloader.getFile(new FileReferenceDownload(fileReference, HostName.getLocalhost()));
-        if (file.isPresent()) {
-            new RequestTracker().trackRequest(file.get().getParentFile());
-            req.returnValues().add(new StringValue(file.get().getAbsolutePath()));
-            log.log(Level.FINE, () -> "File reference '" + fileReference.value() + "' available at " + file.get());
-        } else {
-            log.log(Level.INFO, "File reference '" + fileReference.value() + "' not found");
-            req.setError(fileReferenceNotFound, "File reference '" + fileReference.value() + "' not found");
+        try {
+            Optional<File> file = downloader.getFile(new FileReferenceDownload(fileReference, HostName.getLocalhost()));
+            if (file.isPresent()) {
+                new RequestTracker().trackRequest(file.get().getParentFile());
+                req.returnValues().add(new StringValue(file.get().getAbsolutePath()));
+                log.log(Level.FINE, () -> "File reference '" + fileReference.value() + "' available at " + file.get());
+            } else {
+                log.log(Level.INFO, "File reference '" + fileReference.value() + "' not found");
+                req.setError(fileReferenceNotFound, "File reference '" + fileReference.value() + "' not found");
+            }
+        } catch (FileReferenceDownloadPermissionDeniedException e) {
+            log.log(Level.INFO, "File reference '" + fileReference.value() + "' download denied: " + e.getMessage());
+            req.setError(fileReferencePermissionDenied, "File reference '" + fileReference.value() + "' access denied: " + e.getMessage());
         }
 
         req.returnRequest();

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServerTest.java
@@ -1,0 +1,135 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.config.proxy.filedistribution;
+
+import com.yahoo.jrt.Acceptor;
+import com.yahoo.jrt.ListenFailedException;
+import com.yahoo.jrt.Request;
+import com.yahoo.jrt.RequestWaiter;
+import com.yahoo.jrt.Spec;
+import com.yahoo.jrt.StringValue;
+import com.yahoo.jrt.Supervisor;
+import com.yahoo.jrt.Target;
+import com.yahoo.jrt.Transport;
+import com.yahoo.vespa.config.Connection;
+import com.yahoo.vespa.config.ConnectionPool;
+import com.yahoo.vespa.filedistribution.FileDownloader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author hmusum
+ */
+public class FileDistributionRpcServerTest {
+
+    // Duplicated from FileDistributionRpcServer/FileAcquirerImpl.FileDistributionErrorCode
+    private static final int fileReferencePermissionDenied = 0x11001;
+
+    // Duplicated from MultiTenantRpcAuthorizer.JrtErrorCode / FileReferenceDownloader
+    private static final int jrtErrorUnauthorized = 0x20001;
+
+    @TempDir
+    public File downloadDirectory;
+
+    private Supervisor serverSupervisor;
+    private Supervisor clientSupervisor;
+    private Acceptor acceptor;
+    private FileDistributionRpcServer rpcServer;
+    private FakeConnection fakeConnection;
+    private Target target;
+
+    @BeforeEach
+    public void setup() throws ListenFailedException {
+        fakeConnection = new FakeConnection();
+        FileDownloader downloader = new FileDownloader(new FakeConnectionPool(fakeConnection),
+                                                        new Supervisor(new Transport()),
+                                                        downloadDirectory,
+                                                        Duration.ofSeconds(30), // Much longer than this test should ever take
+                                                        Duration.ofMillis(10));
+        serverSupervisor = new Supervisor(new Transport());
+        rpcServer = new FileDistributionRpcServer(serverSupervisor, downloader);
+        acceptor = serverSupervisor.listen(new Spec(0));
+
+        clientSupervisor = new Supervisor(new Transport());
+        target = clientSupervisor.connect(new Spec(acceptor.port()));
+    }
+
+    @AfterEach
+    public void teardown() {
+        target.close();
+        clientSupervisor.transport().shutdown().join();
+        acceptor.shutdown().join();
+        rpcServer.close();
+        serverSupervisor.transport().shutdown().join();
+    }
+
+    @Test
+    void permissionDeniedIsReturnedImmediatelyAsPermanentError() {
+        Request req = new Request("waitFor");
+        req.parameters().add(new StringValue("myFileReference"));
+        target.invokeSync(req, Duration.ofSeconds(10));
+
+        assertTrue(req.isError(), "Expected an error response, got: " + req.returnValues());
+        assertEquals(fileReferencePermissionDenied, req.errorCode());
+        assertTrue(req.errorMessage().contains("Peer is not allowed to access file reference"), req.errorMessage());
+
+        // Must fail fast - a single RPC round trip to the (fake) source, not retried for the full download timeout
+        assertEquals(1, fakeConnection.requestCount);
+    }
+
+    private static class FakeConnection implements Connection {
+
+        int requestCount = 0;
+
+        @Override
+        public void invokeAsync(Request request, Duration jrtTimeout, RequestWaiter requestWaiter) {
+            invokeSync(request, jrtTimeout);
+            requestWaiter.handleRequestDone(request);
+        }
+
+        @Override
+        public void invokeSync(Request request, Duration jrtTimeout) {
+            if (request.methodName().equals("filedistribution.serveFile")) {
+                requestCount++;
+                request.setError(jrtErrorUnauthorized,
+                                  "Peer is not allowed to access file reference " + request.parameters().get(0).asString());
+            }
+        }
+
+        @Override
+        public String getAddress() { return "localhost"; }
+
+    }
+
+    private static class FakeConnectionPool implements ConnectionPool {
+
+        private final Connection connection;
+
+        FakeConnectionPool(Connection connection) { this.connection = connection; }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public Connection getCurrent() { return connection; }
+
+        @Override
+        public Connection switchConnection(Connection failingConnection) { return connection; }
+
+        @Override
+        public int getSize() { return 1; }
+
+        @Override
+        public List<Connection> connections() { return List.of(connection); }
+
+    }
+
+}

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServerTest.java
@@ -53,7 +53,9 @@ public class FileDistributionRpcServerTest {
                                                         new Supervisor(new Transport()),
                                                         downloadDirectory,
                                                         Duration.ofSeconds(30), // Much longer than this test should ever take
-                                                        Duration.ofMillis(10));
+                                                        Duration.ofMillis(10),
+                                                        0,
+                                                        Duration.ZERO); // No permission-denied grace period: fail on the first denial
         serverSupervisor = new Supervisor(new Transport());
         rpcServer = new FileDistributionRpcServer(serverSupervisor, downloader);
         acceptor = serverSupervisor.listen(new Spec(0));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/security/MultiTenantRpcAuthorizerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/security/MultiTenantRpcAuthorizerTest.java
@@ -48,7 +48,10 @@ import java.util.concurrent.Executor;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -142,8 +145,14 @@ public class MultiTenantRpcAuthorizerTest {
         exceptionRule.expectMessage("Peer is not allowed to access file reference other-file-reference. Peer is owned by mytenant.myapplication. File references owned by this application: [file 'myfilereference']");
         exceptionRule.expectCause(instanceOf(AuthorizationException.class));
 
-        authorizer.authorizeFileRequest(fileRequest)
-                .get();
+        try {
+            authorizer.authorizeFileRequest(fileRequest).get();
+        } finally {
+            // Denial must be sent back to the client immediately, as a permanent (non-timeout) error -
+            // this is what allows FileReferenceDownloader/FileAcquirerImpl to fail fast instead of retrying.
+            verify(fileRequest).setError(eq(0x20001), anyString()); // JrtErrorCode.UNAUTHORIZED
+            verify(fileRequest).returnRequest();
+        }
     }
 
     @Test
@@ -162,8 +171,12 @@ public class MultiTenantRpcAuthorizerTest {
         exceptionRule.expectMessage("Peer is not allowed to access config owned by mytenant.myapplication. Peer is owned by malice.malice-app");
         exceptionRule.expectCause(instanceOf(AuthorizationException.class));
 
-        authorizer.authorizeConfigRequest(configRequest)
-                .get();
+        try {
+            authorizer.authorizeConfigRequest(configRequest).get();
+        } finally {
+            verify(configRequest).setError(eq(0x20001), anyString()); // JrtErrorCode.UNAUTHORIZED
+            verify(configRequest).returnRequest();
+        }
     }
 
     @Test

--- a/container-disc/src/main/java/com/yahoo/container/core/config/ApplicationBundleLoader.java
+++ b/container-disc/src/main/java/com/yahoo/container/core/config/ApplicationBundleLoader.java
@@ -64,6 +64,11 @@ public class ApplicationBundleLoader {
     public synchronized void useBundles(List<FileReference> newFileReferences) {
         if (! readyForNewBundles)
             throw new IllegalStateException("Bundles must be committed or reverted before using new bundles.");
+        // Must be cleared before mutating state below: if installBundles() throws partway through (e.g. one
+        // of several bundles fails to download), completeGeneration() still needs to see this generation as
+        // in progress, so it reverts to a consistent state instead of silently skipping cleanup and leaving
+        // orphaned/untracked bundles behind.
+        readyForNewBundles = false;
 
         obsoleteBundles = removeObsoleteReferences(newFileReferences);
         osgi.allowDuplicateBundles(obsoleteBundles.values());
@@ -72,8 +77,6 @@ public class ApplicationBundleLoader {
         BundleStarter.startBundles(activeBundles.values());
 
         if (obsoleteBundles.size() > 0 || newFileReferences.size() > 0) log.info(installedBundlesMessage());
-
-        readyForNewBundles = false;
     }
 
     /**
@@ -166,7 +169,11 @@ public class ApplicationBundleLoader {
 
     private Map<FileReference, Bundle> installWithFileDistribution(Set<FileReference> bundlesToInstall,
                                                                    FileAcquirerBundleInstaller bundleInstaller) {
-        var newBundles = new LinkedHashMap<FileReference, Bundle>();
+        // Assign directly to the field - rather than only via the return value on full success - so that if
+        // installing one bundle throws partway through the loop, completeGeneration() can still see (and
+        // revert) exactly the bundles installed so far in this attempt, instead of losing track of them.
+        var newBundles = new LinkedHashMap<FileReference, Bundle>(bundlesFromNewGeneration);
+        bundlesFromNewGeneration = newBundles;
 
         for (FileReference reference : bundlesToInstall) {
             try {

--- a/container-disc/src/test/java/com/yahoo/container/core/config/ApplicationBundleLoaderTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/core/config/ApplicationBundleLoaderTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.core.config;
 
+import com.yahoo.config.FileReference;
 import com.yahoo.container.di.Osgi.GenerationStatus;
 import com.yahoo.jdisc.application.BsnVersion;
 import org.junit.jupiter.api.BeforeEach;
@@ -171,6 +172,38 @@ public class ApplicationBundleLoaderTest {
         Collection<Bundle> obsoleteBundles = bundleLoader.completeGeneration(GenerationStatus.SUCCESS);
         assertTrue(obsoleteBundles.isEmpty());
         assertEquals(1, osgi.getCurrentBundles().size());
+    }
+
+    @Test
+    void a_failed_install_partway_through_a_reconfig_does_not_corrupt_state_for_the_next_one() {
+        bundleLoader.useBundles(List.of(BUNDLE_1_REF));
+        bundleLoader.completeGeneration(GenerationStatus.SUCCESS);
+
+        FileReference unknownRef = new FileReference("unknown-bundle");
+
+        // Reconfig tries to add a bundle that fails to install (e.g. simulating a file distribution
+        // download failure) alongside one that succeeds - useBundles() must abort with a RuntimeException
+        // partway through the loop, regardless of which of the two is attempted first.
+        assertThrows(RuntimeException.class,
+                     () -> bundleLoader.useBundles(List.of(BUNDLE_2_REF, unknownRef)));
+
+        // The failure must actually be handled as a generation failure - not silently skipped, which would
+        // leave readyForNewBundles stuck as "ready" and any bundle installed so far in this attempt
+        // orphaned/untracked, corrupting state for the next reconfig.
+        bundleLoader.completeGeneration(GenerationStatus.FAILURE);
+
+        // Only the previous generation's bundle-1 is active again.
+        assertEquals(1, bundleLoader.getActiveFileReferences().size());
+        assertEquals(BUNDLE_1_REF, bundleLoader.getActiveFileReferences().get(0));
+
+        // A later reconfig attempt (e.g. once the underlying issue is resolved) must not be blocked by
+        // leftover state from the failed attempt.
+        bundleLoader.useBundles(List.of(BUNDLE_1_REF, BUNDLE_2_REF));
+        Collection<Bundle> obsoleteBundles = bundleLoader.completeGeneration(GenerationStatus.SUCCESS);
+        assertTrue(obsoleteBundles.isEmpty());
+        assertEquals(2, bundleLoader.getActiveFileReferences().size());
+        assertEquals(BUNDLE_1_REF, bundleLoader.getActiveFileReferences().get(0));
+        assertEquals(BUNDLE_2_REF, bundleLoader.getActiveFileReferences().get(1));
     }
 
 }

--- a/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
+++ b/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
@@ -42,6 +42,7 @@ class FileAcquirerImpl implements FileAcquirer {
         public static final int baseErrorCode = 0x10000;
         public static final int baseFileProviderErrorCode = baseErrorCode + 0x1000;
         public static final int fileReferenceNotFound = baseFileProviderErrorCode;
+        public static final int fileReferencePermissionDenied = baseFileProviderErrorCode + 1;
 
     }
 

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -87,6 +87,27 @@ public class FileDownloader implements AutoCloseable {
             log.log(Level.INFO, "Force download of file references (download even if file reference exists on disk)");
     }
 
+    // For tests: allows overriding the permission-denied grace period.
+    public FileDownloader(ConnectionPool connectionPool,
+                          Supervisor supervisor,
+                          File downloadDirectory,
+                          Duration timeout,
+                          Duration backoffInitialTime,
+                          int maxTimeoutsBeforeClose,
+                          Duration permissionDeniedGracePeriod) {
+        this.connectionPool = connectionPool;
+        this.supervisor = supervisor;
+        this.downloadDirectory = downloadDirectory;
+        this.timeout = timeout;
+        // Needed to receive RPC receiveFile* calls from server after starting download of file reference
+        new FileReceiver(supervisor, downloads, downloadDirectory);
+        this.fileReferenceDownloader = new FileReferenceDownloader(connectionPool, downloads, timeout,
+                                                                    backoffInitialTime, downloadDirectory,
+                                                                    maxTimeoutsBeforeClose, permissionDeniedGracePeriod);
+        if (forceDownload)
+            log.log(Level.INFO, "Force download of file references (download even if file reference exists on disk)");
+    }
+
     public Optional<File> getFile(FileReferenceDownload fileReferenceDownload) {
         try {
             return getFutureFile(fileReferenceDownload).get(timeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -90,7 +90,12 @@ public class FileDownloader implements AutoCloseable {
     public Optional<File> getFile(FileReferenceDownload fileReferenceDownload) {
         try {
             return getFutureFile(fileReferenceDownload).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (ExecutionException e) {
+            fileReferenceDownloader.failedDownloading(fileReferenceDownload.fileReference());
+            if (e.getCause() instanceof FileReferenceDownloadPermissionDeniedException permissionDenied)
+                throw permissionDenied;
+            return Optional.empty();
+        } catch (InterruptedException | TimeoutException e) {
             fileReferenceDownloader.failedDownloading(fileReferenceDownload.fileReference());
             return Optional.empty();
         }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -56,16 +56,8 @@ public class FileDownloader implements AutoCloseable {
                           File downloadDirectory,
                           Duration timeout,
                           Duration backoffInitialTime) {
-        this.connectionPool = connectionPool;
-        this.supervisor = supervisor;
-        this.downloadDirectory = downloadDirectory;
-        this.timeout = timeout;
-        // Needed to receive RPC receiveFile* calls from server after starting download of file reference
-        new FileReceiver(supervisor, downloads, downloadDirectory);
-        this.fileReferenceDownloader = new FileReferenceDownloader(connectionPool, downloads, timeout,
-                                                                    backoffInitialTime, downloadDirectory);
-        if (forceDownload)
-            log.log(Level.INFO, "Force download of file references (download even if file reference exists on disk)");
+        this(connectionPool, supervisor, downloadDirectory, timeout, backoffInitialTime,
+             FileReferenceDownloader.defaultMaxTimeoutsBeforeClose);
     }
 
     public FileDownloader(ConnectionPool connectionPool,
@@ -74,17 +66,8 @@ public class FileDownloader implements AutoCloseable {
                           Duration timeout,
                           Duration backoffInitialTime,
                           int maxTimeoutsBeforeClose) {
-        this.connectionPool = connectionPool;
-        this.supervisor = supervisor;
-        this.downloadDirectory = downloadDirectory;
-        this.timeout = timeout;
-        // Needed to receive RPC receiveFile* calls from server after starting download of file reference
-        new FileReceiver(supervisor, downloads, downloadDirectory);
-        this.fileReferenceDownloader = new FileReferenceDownloader(connectionPool, downloads, timeout,
-                                                                    backoffInitialTime, downloadDirectory,
-                                                                    maxTimeoutsBeforeClose);
-        if (forceDownload)
-            log.log(Level.INFO, "Force download of file references (download even if file reference exists on disk)");
+        this(connectionPool, supervisor, downloadDirectory, timeout, backoffInitialTime, maxTimeoutsBeforeClose,
+             FileReferenceDownloader.defaultPermissionDeniedGracePeriod);
     }
 
     // For tests: allows overriding the permission-denied grace period.

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloadPermissionDeniedException.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloadPermissionDeniedException.java
@@ -1,0 +1,19 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.filedistribution;
+
+import com.yahoo.config.FileReference;
+
+/**
+ * Thrown when a peer (e.g. config server) has denied a request to download a file reference,
+ * typically because the requesting peer is unknown or not authorized to access that file reference.
+ * This is a permanent failure and should not be retried.
+ *
+ * @author hmusum
+ */
+public class FileReferenceDownloadPermissionDeniedException extends RuntimeException {
+
+    public FileReferenceDownloadPermissionDeniedException(FileReference fileReference, String reason) {
+        super("Download of " + fileReference + " denied: " + reason);
+    }
+
+}

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -59,10 +59,17 @@ public class FileReferenceDownloader {
     // ownership for a just-activated application generation, rather than a durable authorization problem.
     // Retry through this grace period before treating the denial as permanent.
     // Undocumented on purpose, might change or be removed at any time
-    private static final Duration defaultPermissionDeniedGracePeriod;
+    static final Duration defaultPermissionDeniedGracePeriod;
     static {
         var graceSeconds = System.getenv("VESPA_FILE_DOWNLOAD_PERMISSION_DENIED_GRACE_PERIOD_SECONDS");
         defaultPermissionDeniedGracePeriod = Duration.ofSeconds(graceSeconds == null ? 10 : Long.parseLong(graceSeconds));
+    }
+
+    // Undocumented on purpose, might change or be removed at any time
+    static final int defaultMaxTimeoutsBeforeClose;
+    static {
+        var maxTimeouts = System.getenv("VESPA_FILE_DOWNLOAD_MAX_TIMEOUTS_BEFORE_CLOSE");
+        defaultMaxTimeoutsBeforeClose = maxTimeouts == null ? 0 : Integer.parseInt(maxTimeouts);
     }
 
     private final ExecutorService downloadExecutor =
@@ -83,10 +90,7 @@ public class FileReferenceDownloader {
                             Duration timeout,
                             Duration backoffInitialTime,
                             File downloadDirectory) {
-        this(connectionPool, downloads, timeout, backoffInitialTime, downloadDirectory,
-             Optional.ofNullable(System.getenv("VESPA_FILE_DOWNLOAD_MAX_TIMEOUTS_BEFORE_CLOSE"))
-                     .map(Integer::parseInt)
-                     .orElse(0));
+        this(connectionPool, downloads, timeout, backoffInitialTime, downloadDirectory, defaultMaxTimeoutsBeforeClose);
     }
 
     FileReferenceDownloader(ConnectionPool connectionPool,

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -128,6 +128,8 @@ public class FileReferenceDownloader {
         FileReference fileReference = fileReferenceDownload.fileReference();
         int retryCount = 0;
         int timeoutCount = 0;
+        // Intentionally not reset on a non-denial result: the clock bounds how long we tolerate any sign of a
+        // denial for this download attempt, regardless of what other retries/connections report in between.
         Instant permissionDeniedSince = null;
         Connection connection = connectionPool.getCurrent();
         do {

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -40,7 +40,20 @@ public class FileReferenceDownloader {
     private static final Logger log = Logger.getLogger(FileReferenceDownloader.class.getName());
     private static final Set<CompressionType> defaultAcceptedCompressionTypes = Set.of(lz4, none, zstd);
 
-    private enum DownloadResult { SUCCESS, TIMEOUT, FAILURE }
+    private enum DownloadResult { SUCCESS, TIMEOUT, FAILURE, PERMISSION_DENIED }
+
+    private record RpcResult(DownloadResult result, String message) {
+        private static RpcResult of(DownloadResult result) { return new RpcResult(result, null); }
+    }
+
+    // Duplicated from MultiTenantRpcAuthorizer.JrtErrorCode (configserver module; this module can't depend on it)
+    // TODO: Consider moving this to a common module to avoid duplication
+    static final int jrtErrorUnauthorized = 0x20001;
+    static final int jrtErrorAuthorizationFailed = 0x20002;
+
+    private static boolean isAuthorizationError(int errorCode) {
+        return errorCode == jrtErrorUnauthorized || errorCode == jrtErrorAuthorizationFailed;
+    }
 
     private final ExecutorService downloadExecutor =
             Executors.newFixedThreadPool(Math.max(8, Runtime.getRuntime().availableProcessors()),
@@ -100,9 +113,15 @@ public class FileReferenceDownloader {
             log.log(Level.FINE, "Wait until download of " + fileReference + " has started, retryCount " + retryCount +
                     ", timeout " + timeout + " (request from " + fileReferenceDownload.client() + ")");
             if ( ! timeout.isNegative()) {
-                var result = startDownloadRpc(fileReferenceDownload, retryCount, connection, timeout);
-                if (result == DownloadResult.SUCCESS) return;
-                if (result == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
+                var rpcResult = startDownloadRpc(fileReferenceDownload, retryCount, connection, timeout);
+                if (rpcResult.result() == DownloadResult.SUCCESS) return;
+                if (rpcResult.result() == DownloadResult.PERMISSION_DENIED) {
+                    fileReferenceDownload.future().completeExceptionally(
+                            new FileReferenceDownloadPermissionDeniedException(fileReference, rpcResult.message()));
+                    downloads.remove(fileReference);
+                    return;
+                }
+                if (rpcResult.result() == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
                     timeoutCount++;
                     if (timeoutCount >= maxTimeoutsBeforeClose) {
                         log.log(Level.INFO, "RPC request for " + fileReference + " timed out " + timeoutCount +
@@ -160,13 +179,13 @@ public class FileReferenceDownloader {
 
                     log.log(Level.FINE, () -> "Will download " + fileReference + " with timeout " + downloadTimeout + " from " + spec.host());
                     downloads.add(fileReferenceDownload);
-                    var result = startDownloadRpc(fileReferenceDownload, 1, connection, downloadTimeout);
-                    if (result == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
+                    var rpcResult = startDownloadRpc(fileReferenceDownload, 1, connection, downloadTimeout);
+                    if (rpcResult.result() == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
                         connection.closeConnection();
                     }
                     // Need to explicitly remove from downloads if downloading has not started.
                     // If downloading *has* started FileReceiver will take care of that when download has completed or failed
-                    if (result != DownloadResult.SUCCESS)
+                    if (rpcResult.result() != DownloadResult.SUCCESS)
                         downloads.remove(fileReference);
                 });
         }
@@ -176,7 +195,7 @@ public class FileReferenceDownloader {
         downloads.remove(fileReference);
     }
 
-    private DownloadResult startDownloadRpc(FileReferenceDownload fileReferenceDownload, int retryCount, Connection connection, Duration timeout) {
+    private RpcResult startDownloadRpc(FileReferenceDownload fileReferenceDownload, int retryCount, Connection connection, Duration timeout) {
         Request request = createRequest(fileReferenceDownload);
         connection.invokeSync(request, timeout);
 
@@ -189,19 +208,24 @@ public class FileReferenceDownloader {
 
             if (errorCode == 0) {
                 log.log(Level.FINE, () -> "Found " + fileReference + " available at " + address);
-                return DownloadResult.SUCCESS;
+                return RpcResult.of(DownloadResult.SUCCESS);
             } else {
                 var error = FileApiErrorCodes.get(errorCode);
                 var errorDescription = error == null ? "Unknown error" : error.description();
                 log.log(logLevel, "Downloading " + fileReference + " from " + address + " failed (" + errorDescription + ")");
-                return DownloadResult.FAILURE;
+                return RpcResult.of(DownloadResult.FAILURE);
             }
+        } else if (isAuthorizationError(request.errorCode())) {
+            log.log(logLevel, "Downloading " + fileReference + " from " + address +
+                    " (client " + fileReferenceDownload.client() + ") denied:" +
+                    " error code " + request.errorCode() + " (" + request.errorMessage() + ")");
+            return new RpcResult(DownloadResult.PERMISSION_DENIED, request.errorMessage());
         } else {
             log.log(logLevel, "Downloading " + fileReference + " from " + address +
                     " (client " + fileReferenceDownload.client() + ") failed:" +
                     " error code " + request.errorCode() + " (" + request.errorMessage() + ")." +
                     " (retry " + retryCount + ", rpc timeout " + timeout + ")");
-            return request.errorCode() == ErrorCode.TIMEOUT ? DownloadResult.TIMEOUT : DownloadResult.FAILURE;
+            return RpcResult.of(request.errorCode() == ErrorCode.TIMEOUT ? DownloadResult.TIMEOUT : DownloadResult.FAILURE);
         }
     }
 

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -55,6 +55,16 @@ public class FileReferenceDownloader {
         return errorCode == jrtErrorUnauthorized || errorCode == jrtErrorAuthorizationFailed;
     }
 
+    // A denial can be a transient side effect of the config server not yet having registered file reference
+    // ownership for a just-activated application generation, rather than a durable authorization problem.
+    // Retry through this grace period before treating the denial as permanent.
+    // Undocumented on purpose, might change or be removed at any time
+    private static final Duration defaultPermissionDeniedGracePeriod;
+    static {
+        var graceSeconds = System.getenv("VESPA_FILE_DOWNLOAD_PERMISSION_DENIED_GRACE_PERIOD_SECONDS");
+        defaultPermissionDeniedGracePeriod = Duration.ofSeconds(graceSeconds == null ? 10 : Long.parseLong(graceSeconds));
+    }
+
     private final ExecutorService downloadExecutor =
             Executors.newFixedThreadPool(Math.max(8, Runtime.getRuntime().availableProcessors()),
                                          new DaemonThreadFactory("filereference downloader"));
@@ -66,6 +76,7 @@ public class FileReferenceDownloader {
     private final File downloadDirectory;
     private final AtomicBoolean shutDown = new AtomicBoolean(false);
     private final int maxTimeoutsBeforeClose;
+    private final Duration permissionDeniedGracePeriod;
 
     FileReferenceDownloader(ConnectionPool connectionPool,
                             Downloads downloads,
@@ -84,12 +95,25 @@ public class FileReferenceDownloader {
                             Duration backoffInitialTime,
                             File downloadDirectory,
                             int maxTimeoutsBeforeClose) {
+        this(connectionPool, downloads, timeout, backoffInitialTime, downloadDirectory, maxTimeoutsBeforeClose,
+             defaultPermissionDeniedGracePeriod);
+    }
+
+    // Package-private, for tests: allows overriding the permission-denied grace period.
+    FileReferenceDownloader(ConnectionPool connectionPool,
+                            Downloads downloads,
+                            Duration timeout,
+                            Duration backoffInitialTime,
+                            File downloadDirectory,
+                            int maxTimeoutsBeforeClose,
+                            Duration permissionDeniedGracePeriod) {
         this.connectionPool = connectionPool;
         this.downloads = downloads;
         this.downloadTimeout = timeout;
         this.backoffInitialTime = backoffInitialTime;
         this.downloadDirectory = downloadDirectory;
         this.maxTimeoutsBeforeClose = maxTimeoutsBeforeClose;
+        this.permissionDeniedGracePeriod = permissionDeniedGracePeriod;
         // Undocumented on purpose, might change or be removed at any time
         var timeoutString = Optional.ofNullable(System.getenv("VESPA_FILE_DOWNLOAD_RPC_TIMEOUT"));
         this.rpcTimeout = timeoutString.map(t -> Duration.ofSeconds(Integer.parseInt(t)));
@@ -100,6 +124,7 @@ public class FileReferenceDownloader {
         FileReference fileReference = fileReferenceDownload.fileReference();
         int retryCount = 0;
         int timeoutCount = 0;
+        Instant permissionDeniedSince = null;
         Connection connection = connectionPool.getCurrent();
         do {
             if (retryCount > 0)
@@ -116,12 +141,17 @@ public class FileReferenceDownloader {
                 var rpcResult = startDownloadRpc(fileReferenceDownload, retryCount, connection, timeout);
                 if (rpcResult.result() == DownloadResult.SUCCESS) return;
                 if (rpcResult.result() == DownloadResult.PERMISSION_DENIED) {
-                    fileReferenceDownload.future().completeExceptionally(
-                            new FileReferenceDownloadPermissionDeniedException(fileReference, rpcResult.message()));
-                    downloads.remove(fileReference);
-                    return;
-                }
-                if (rpcResult.result() == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
+                    // File reference ownership may not yet be registered on the config server right after an
+                    // application generation is activated - retry for a grace period before giving up, so that
+                    // a transient race doesn't get treated the same as a durable authorization denial.
+                    if (permissionDeniedSince == null) permissionDeniedSince = Instant.now();
+                    if (!Duration.between(permissionDeniedSince, Instant.now()).minus(permissionDeniedGracePeriod).isNegative()) {
+                        fileReferenceDownload.future().completeExceptionally(
+                                new FileReferenceDownloadPermissionDeniedException(fileReference, rpcResult.message()));
+                        downloads.remove(fileReference);
+                        return;
+                    }
+                } else if (rpcResult.result() == DownloadResult.TIMEOUT && maxTimeoutsBeforeClose > 0) {
                     timeoutCount++;
                     if (timeoutCount >= maxTimeoutsBeforeClose) {
                         log.log(Level.INFO, "RPC request for " + fileReference + " timed out " + timeoutCount +

--- a/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
+++ b/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
@@ -38,6 +38,7 @@ import static com.yahoo.vespa.filedistribution.FileReferenceData.Type;
 import static com.yahoo.vespa.filedistribution.FileReferenceData.Type.compressed;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -196,6 +197,28 @@ public class FileDownloaderTest {
         assertDownloadStatus(fileReference, 1.0);
 
         assertEquals(timesToFail, responseHandler.failedTimes);
+    }
+
+    @Test
+    public void getFileWhenPermissionDenied() {
+        // Use a much longer timeout than the test should ever take: if the denial were treated as a
+        // retryable failure instead of failing fast, this test would time out waiting for getFile() instead
+        // of throwing promptly.
+        fileDownloader = createDownloader(connection, Duration.ofSeconds(30));
+
+        MockConnection.PermissionDeniedResponseHandler responseHandler = new MockConnection.PermissionDeniedResponseHandler();
+        connection.setResponseHandler(responseHandler);
+
+        FileReference fileReference = new FileReference("deniedFileReference");
+        FileReferenceDownloadPermissionDeniedException exception = assertThrows(
+                FileReferenceDownloadPermissionDeniedException.class,
+                () -> getFile(fileReference));
+        assertTrue(exception.getMessage(), exception.getMessage().contains("Peer is not allowed to access file reference"));
+
+        // Denial must exit the retry loop on the very first RPC round trip, not after retrying for the
+        // full download timeout.
+        assertEquals(1, responseHandler.requestCount);
+        assertFalse(fileDownloader.isDownloading(fileReference));
     }
 
     @Test
@@ -494,6 +517,20 @@ public class FileDownloaderTest {
                         request.returnValues().add(new Int32Value(0));
                         request.returnValues().add(new StringValue("OK"));
                     }
+                }
+            }
+        }
+
+        private static class PermissionDeniedResponseHandler implements MockConnection.ResponseHandler {
+
+            int requestCount = 0;
+
+            @Override
+            public void request(Request request) {
+                if (request.methodName().equals("filedistribution.serveFile")) {
+                    requestCount++;
+                    request.setError(FileReferenceDownloader.jrtErrorUnauthorized,
+                                      "Peer is not allowed to access file reference " + request.parameters().get(0).asString());
                 }
             }
         }

--- a/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
+++ b/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
@@ -201,10 +201,10 @@ public class FileDownloaderTest {
 
     @Test
     public void getFileWhenPermissionDenied() {
-        // Use a much longer timeout than the test should ever take: if the denial were treated as a
-        // retryable failure instead of failing fast, this test would time out waiting for getFile() instead
-        // of throwing promptly.
-        fileDownloader = createDownloader(connection, Duration.ofSeconds(30));
+        // Zero grace period: a denial must be treated as permanent on the very first RPC round trip,
+        // not retried at all.
+        fileDownloader = new FileDownloader(connection, supervisor, downloadDir,
+                                            Duration.ofSeconds(30), sleepBetweenRetries, 0, Duration.ZERO);
 
         MockConnection.PermissionDeniedResponseHandler responseHandler = new MockConnection.PermissionDeniedResponseHandler();
         connection.setResponseHandler(responseHandler);
@@ -215,10 +215,59 @@ public class FileDownloaderTest {
                 () -> getFile(fileReference));
         assertTrue(exception.getMessage(), exception.getMessage().contains("Peer is not allowed to access file reference"));
 
-        // Denial must exit the retry loop on the very first RPC round trip, not after retrying for the
-        // full download timeout.
+        // With no grace period, denial must exit the retry loop on the very first RPC round trip, not after
+        // retrying for the full download timeout.
         assertEquals(1, responseHandler.requestCount);
         assertFalse(fileDownloader.isDownloading(fileReference));
+    }
+
+    @Test
+    public void getFileWhenPermissionDeniedOutlastsGracePeriod() {
+        // Short grace period so the test runs fast, but long enough to observe more than one retry.
+        fileDownloader = new FileDownloader(connection, supervisor, downloadDir,
+                                            Duration.ofSeconds(30), sleepBetweenRetries, 0, Duration.ofMillis(100));
+
+        MockConnection.PermissionDeniedResponseHandler responseHandler = new MockConnection.PermissionDeniedResponseHandler();
+        connection.setResponseHandler(responseHandler);
+
+        FileReference fileReference = new FileReference("deniedFileReference");
+        FileReferenceDownloadPermissionDeniedException exception = assertThrows(
+                FileReferenceDownloadPermissionDeniedException.class,
+                () -> getFile(fileReference));
+        assertTrue(exception.getMessage(), exception.getMessage().contains("Peer is not allowed to access file reference"));
+
+        // A denial that persists for the whole grace period must still end up permanent, but only after
+        // being retried rather than failing on the very first attempt.
+        assertTrue("Expected more than one request, got " + responseHandler.requestCount, responseHandler.requestCount > 1);
+        assertFalse(fileDownloader.isDownloading(fileReference));
+    }
+
+    @Test
+    public void getFileWhenPermissionDeniedIsTransient() throws IOException {
+        // A denial that clears up before the grace period elapses must not fail the download -
+        // this is the eventual-consistency race the grace period exists to ride out.
+        fileDownloader = new FileDownloader(connection, supervisor, downloadDir,
+                                            Duration.ofSeconds(2), sleepBetweenRetries, 0, Duration.ofSeconds(1));
+
+        int timesToDeny = 3;
+        MockConnection.PermissionDeniedThenFoundResponseHandler responseHandler =
+                new MockConnection.PermissionDeniedThenFoundResponseHandler(timesToDeny);
+        connection.setResponseHandler(responseHandler);
+
+        FileReference fileReference = new FileReference("temporarilyDeniedFileReference");
+        // The RPC retries past the transient denials and the download "starts", but since no file content
+        // has been pushed yet, getFile() still times out waiting for it - it must NOT throw
+        // FileReferenceDownloadPermissionDeniedException, which is what the grace period prevents.
+        assertFalse(getFile(fileReference).isPresent());
+        assertTrue("Expected more than one request, got " + responseHandler.requestCount,
+                   responseHandler.requestCount > timesToDeny);
+
+        // Receives fileReference, should return and make it available to caller - proving the earlier
+        // denials did not permanently fail the download.
+        String filename = "abc.jar";
+        receiveFile(fileReference, filename, FileReferenceData.Type.file, "some content");
+        Optional<File> downloadedFile = getFile(fileReference);
+        assertTrue(downloadedFile.isPresent());
     }
 
     @Test
@@ -531,6 +580,30 @@ public class FileDownloaderTest {
                     requestCount++;
                     request.setError(FileReferenceDownloader.jrtErrorUnauthorized,
                                       "Peer is not allowed to access file reference " + request.parameters().get(0).asString());
+                }
+            }
+        }
+
+        private static class PermissionDeniedThenFoundResponseHandler implements MockConnection.ResponseHandler {
+
+            private final int timesToDeny;
+            int requestCount = 0;
+
+            PermissionDeniedThenFoundResponseHandler(int timesToDeny) {
+                this.timesToDeny = timesToDeny;
+            }
+
+            @Override
+            public void request(Request request) {
+                if (request.methodName().equals("filedistribution.serveFile")) {
+                    requestCount++;
+                    if (requestCount <= timesToDeny) {
+                        request.setError(FileReferenceDownloader.jrtErrorUnauthorized,
+                                          "Peer is not allowed to access file reference " + request.parameters().get(0).asString());
+                    } else {
+                        request.returnValues().add(new Int32Value(0));
+                        request.returnValues().add(new StringValue("OK"));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Reverts vespa-engine/vespa#37600

Commit #2 adds a grace period for permission-denied downloads and fixes bundle loader state on partial install failure
