### PR TITLE
Fix aggregation result type for multi-pass grouping merge targets

### DIFF
--- a/searchcore/src/tests/grouping/grouping_test.cpp
+++ b/searchcore/src/tests/grouping/grouping_test.cpp
@@ -7,6 +7,8 @@
 #include <vespa/searchcore/grouping/groupingsession.h>
 #include <vespa/searchcore/proton/matching/sessionmanager.h>
 #include <vespa/searchlib/aggregation/grouping.h>
+#include <vespa/searchlib/aggregation/maxaggregationresult.h>
+#include <vespa/searchlib/aggregation/minaggregationresult.h>
 #include <vespa/searchlib/aggregation/sumaggregationresult.h>
 #include <vespa/searchlib/attribute/extendableattributes.h>
 #include <vespa/searchlib/common/allocatedbitvector.h>
@@ -342,6 +344,148 @@ TEST(GroupingTest, testGroupingSession) {
         session.continueExecution(context);
         ASSERT_TRUE(session.finished());
     }
+}
+
+// A multi-pass session keeps its own copy of the grouping and leaves the request object behind as
+// merge target for continueExecution(). Aggregation results at the root level are merged (not
+// copied) into that target, so it must have been prepared with a result node of the proper type.
+// Corresponds to "all(output(min(attr0)) all(group(attr1) each(output(count()))))".
+TEST(GroupingTest, testSessionWithRootLevelAggregationResult) {
+    DoomFixture f1;
+    MyWorld     world;
+    Grouping    request;
+    request.setId(0)
+        .setFirstLevel(0)
+        .setLastLevel(0)
+        .setRoot(Group().addResult(MinAggregationResult().setExpression(MU<AttributeNode>("attr0"))))
+        .addLevel(createGL(MU<AttributeNode>("attr1"), MU<AttributeNode>("attr2")));
+
+    auto            r = std::make_shared<Grouping>(request);
+    GroupingContext initContext(world.bv, f1.clock.nowRef(), f1.timeOfDoom);
+    initContext.addGrouping(r);
+    // The request has a fallback result node for min() until the session prepares it
+    const AggregationResult& rootMin = r->getRoot().getAggregationResult(0);
+    EXPECT_TRUE(rootMin.getResult() != nullptr);
+    EXPECT_EQ("search::expression::FloatResultNode", std::string(rootMin.getResult()->getClass().name()));
+
+    SessionId       id("foo");
+    GroupingSession session(id, initContext, world.attributeContext, &world.documentType);
+    ASSERT_TRUE(rootMin.getResult() != nullptr);
+    // attr0 is a single int32 attribute, so the result node must be an integer, not the fallback
+    EXPECT_EQ("search::expression::Int64ResultNode", std::string(rootMin.getResult()->getClass().name()));
+
+    RankedHit hit;
+    hit._docId = 3;
+    session.getGroupingManager().groupInRelevanceOrder(7, &hit, 1);
+    session.continueExecution(initContext);
+    ASSERT_TRUE(!session.finished());
+
+    EXPECT_EQ(3, static_cast<const MinAggregationResult&>(rootMin).getMin().getInteger()); // attr0 == docid
+}
+
+// Same bug as testSessionWithRootLevelAggregationResult, but with two root-level aggregation
+// results on the same request; both must independently get their proper (non-fallback) result
+// node type, not just the first one visited by select().
+TEST(GroupingTest, testSessionWithMultipleRootLevelAggregationResults) {
+    DoomFixture f1;
+    MyWorld     world;
+    Grouping    request;
+    request.setId(0)
+        .setFirstLevel(0)
+        .setLastLevel(0)
+        .setRoot(Group()
+                     .addResult(MinAggregationResult().setExpression(MU<AttributeNode>("attr0")))
+                     .addResult(MaxAggregationResult().setExpression(MU<AttributeNode>("attr1"))))
+        .addLevel(createGL(MU<AttributeNode>("attr1"), MU<AttributeNode>("attr2")));
+
+    auto            r = std::make_shared<Grouping>(request);
+    GroupingContext initContext(world.bv, f1.clock.nowRef(), f1.timeOfDoom);
+    initContext.addGrouping(r);
+    const AggregationResult& rootMin = r->getRoot().getAggregationResult(0);
+    const AggregationResult& rootMax = r->getRoot().getAggregationResult(1);
+    ASSERT_TRUE(rootMin.getResult() != nullptr);
+    ASSERT_TRUE(rootMax.getResult() != nullptr);
+    EXPECT_EQ("search::expression::FloatResultNode", std::string(rootMin.getResult()->getClass().name()));
+    EXPECT_EQ("search::expression::FloatResultNode", std::string(rootMax.getResult()->getClass().name()));
+
+    SessionId       id("foo");
+    GroupingSession session(id, initContext, world.attributeContext, &world.documentType);
+    // attr0 and attr1 are both single int32 attributes, so both results must be integers
+    EXPECT_EQ("search::expression::Int64ResultNode", std::string(rootMin.getResult()->getClass().name()));
+    EXPECT_EQ("search::expression::Int64ResultNode", std::string(rootMax.getResult()->getClass().name()));
+
+    RankedHit hit;
+    hit._docId = 3;
+    session.getGroupingManager().groupInRelevanceOrder(7, &hit, 1);
+    session.continueExecution(initContext);
+    ASSERT_TRUE(!session.finished());
+
+    EXPECT_EQ(3, static_cast<const MinAggregationResult&>(rootMin).getMin().getInteger()); // attr0 == docid
+    EXPECT_EQ(6, static_cast<const MaxAggregationResult&>(rootMax).getMax().getInteger()); // attr1 == docid*2
+}
+
+// Same setup as testSessionWithRootLevelAggregationResult, but continued across all passes of a
+// multi-level grouping (mirrors the pass structure of testGroupingSession). The root-level
+// aggregation result is only merged into during the first pass (later passes are "frozen" at the
+// root level), so it must keep the value and type it got there for the remainder of the session.
+TEST(GroupingTest, testSessionWithRootLevelAggregationResultAcrossPasses) {
+    DoomFixture f1;
+    MyWorld     world;
+    Grouping    request;
+    request.setId(0)
+        .setFirstLevel(0)
+        .setLastLevel(0)
+        .setRoot(Group().addResult(MinAggregationResult().setExpression(MU<AttributeNode>("attr0"))))
+        .addLevel(createGL(MU<AttributeNode>("attr1"), MU<AttributeNode>("attr2")))
+        .addLevel(createGL(MU<AttributeNode>("attr2"), MU<AttributeNode>("attr3")));
+
+    auto            r = std::make_shared<Grouping>(request);
+    GroupingContext initContext(world.bv, f1.clock.nowRef(), f1.timeOfDoom);
+    initContext.addGrouping(r);
+    const AggregationResult& rootMin = r->getRoot().getAggregationResult(0);
+
+    SessionId       id("foo");
+    GroupingSession session(id, initContext, world.attributeContext, &world.documentType);
+    EXPECT_EQ("search::expression::Int64ResultNode", std::string(rootMin.getResult()->getClass().name()));
+
+    RankedHit hit;
+    hit._docId = 3;
+    session.getGroupingManager().groupInRelevanceOrder(7, &hit, 1);
+
+    // First pass: root level (0) is merged, since firstLevel == 0 here.
+    session.continueExecution(initContext);
+    ASSERT_TRUE(!session.finished());
+    EXPECT_EQ("search::expression::Int64ResultNode", std::string(rootMin.getResult()->getClass().name()));
+    EXPECT_EQ(3, static_cast<const MinAggregationResult&>(rootMin).getMin().getInteger()); // attr0 == docid
+
+    // Second pass: a fresh request object, root level is now frozen (firstLevel == 1) so it is
+    // not touched again; the result already delivered in the first pass must remain intact.
+    {
+        GroupingContext context(world.bv, f1.clock.nowRef(), f1.timeOfDoom);
+        auto            r2 = std::make_shared<Grouping>(request);
+        r2->setFirstLevel(1);
+        r2->setLastLevel(1);
+        context.addGrouping(r2);
+
+        session.continueExecution(context);
+        ASSERT_TRUE(!session.finished());
+    }
+    EXPECT_EQ("search::expression::Int64ResultNode", std::string(rootMin.getResult()->getClass().name()));
+    EXPECT_EQ(3, static_cast<const MinAggregationResult&>(rootMin).getMin().getInteger());
+
+    // Third (last) pass: session should be marked as finished, first-pass result still intact.
+    {
+        GroupingContext context(world.bv, f1.clock.nowRef(), f1.timeOfDoom);
+        auto            r3 = std::make_shared<Grouping>(request);
+        r3->setFirstLevel(2);
+        r3->setLastLevel(2);
+        context.addGrouping(r3);
+
+        session.continueExecution(context);
+        ASSERT_TRUE(session.finished());
+    }
+    EXPECT_EQ("search::expression::Int64ResultNode", std::string(rootMin.getResult()->getClass().name()));
+    EXPECT_EQ(3, static_cast<const MinAggregationResult&>(rootMin).getMin().getInteger());
 }
 
 TEST(GroupingTest, testEmptySessionId) {

--- a/searchcore/src/vespa/searchcore/grouping/groupingsession.cpp
+++ b/searchcore/src/vespa/searchcore/grouping/groupingsession.cpp
@@ -10,9 +10,8 @@ LOG_SETUP(".groupingsession");
 
 namespace search::grouping {
 
-using search::aggregation::Group;
+using search::aggregation::AggregationResult;
 using search::aggregation::Grouping;
-using search::aggregation::GroupingLevel;
 using search::attribute::IAttributeContext;
 
 GroupingSession::GroupingSession(const SessionId& sessionId, GroupingContext& groupingContext,
@@ -28,18 +27,37 @@ GroupingSession::~GroupingSession() = default;
 
 void GroupingSession::init(GroupingContext& groupingContext, const IAttributeContext& attrCtx,
                            const document::DocumentType* documentType) {
-    GroupingList& sessionList(groupingContext.getGroupingList());
-    for (auto g : sessionList) {
-        // Make internal copy of those we want to keep for another pass
+    GroupingList& requestList(groupingContext.getGroupingList());
+    for (auto g : requestList) {
+        // Groupings that need more than this pass to finish get a session copy: it is the one
+        // that actually gets grouped/aggregated into (via _mgrContext/_groupingManager below) and
+        // is cached in _groupingMap for use by later passes. The original stays behind, untouched,
+        // as the element still in requestList (and hence in the request itself); that original is
+        // what continueExecution() later merges the session copy's results into.
         if (!_sessionId.empty() && g->getLastLevel() < g->levels().size()) {
-            auto gp = std::make_shared<Grouping>(*g);
-            gp->setLastLevel(gp->levels().size());
-            _groupingMap[gp->getId()] = gp;
-            g = std::move(gp);
+            auto sessionCopy = std::make_shared<Grouping>(*g);
+            sessionCopy->setLastLevel(sessionCopy->levels().size());
+            _groupingMap[sessionCopy->getId()] = sessionCopy;
+            g = std::move(sessionCopy);
         }
         _mgrContext->addGrouping(std::move(g));
     }
     _groupingManager->init(attrCtx, documentType);
+    prepareMergeTargets(requestList);
+}
+
+void GroupingSession::prepareMergeTargets(const GroupingList& requestList) {
+    // The groupings we made a session copy of above are left behind in the request, where
+    // continueExecution() will use them as merge target. They are not part of _mgrContext, so the
+    // init() above did not touch them and their aggregation results are still default-constructed.
+    // Prepare them here: they share their expression trees with the session copies, which init()
+    // just configured, so the result nodes get the type the expression actually produces.
+    AggregationResult::Configure aggrConf;
+    for (const auto& g : requestList) {
+        if (_groupingMap.contains(g->getId())) {
+            g->select(aggrConf, aggrConf);
+        }
+    }
 }
 
 void GroupingSession::prepareThreadContextCreation(size_t num_threads) {

--- a/searchcore/src/vespa/searchcore/grouping/groupingsession.h
+++ b/searchcore/src/vespa/searchcore/grouping/groupingsession.h
@@ -106,6 +106,9 @@ private:
     GroupingMap                      _groupingMap;
     vespalib::steady_time            _timeOfDoom;
 
+    /** Prepare the aggregation results of the groupings we will use as merge target. */
+    void prepareMergeTargets(const GroupingList& requestList);
+
 public:
     using UP = std::unique_ptr<GroupingSession>;
 

--- a/searchlib/src/vespa/searchlib/aggregation/aggregationresult.h
+++ b/searchlib/src/vespa/searchlib/aggregation/aggregationresult.h
@@ -38,6 +38,8 @@ public:
     using ResultNode = expression::ResultNode;
     DECLARE_NBO_SERIALIZE;
     DECLARE_ABSTRACT_AGGREGATIONRESULT(AggregationResult);
+    // Note: copy is shallow wrt. _expressionTree (see below); search::grouping::GroupingSession
+    // relies on that sharing to fix up merge-target result types after a copy is re-configured.
     AggregationResult(const AggregationResult&);
     AggregationResult& operator=(const AggregationResult&);
     AggregationResult(AggregationResult&&) = default;
@@ -106,6 +108,10 @@ private:
         (void)rank;
         onAggregate(result);
     }
+    // Shared (not deep-copied) by the default copy constructor above: a copy and its
+    // original keep resolving to the same ExpressionTree instance, so configuring one
+    // (e.g. via Configure) also fixes up the result type the other's getExpression()
+    // reports, even though each AggregationResult's own result node stays independent.
     std::shared_ptr<expression::ExpressionTree> _expressionTree;
     uint32_t                                    _tag;
 };


### PR DESCRIPTION
When a grouping session is created for a multi-pass request, the session keeps an internal copy of each grouping for later passes and leaves the original behind in the request to serve as continueExecution()'s merge target. That original is never touched by GroupingManager::init(), so any root-level AggregationResult on it kept its default-constructed (fallback) result node instead of the type its expression actually produces (e.g. Int64ResultNode for an int32 attribute instead of the fallback FloatResultNode). Merging a differently-typed result into it would then be wrong.

Fix by running AggregationResult::Configure over the leftover request groupings right after init(), in GroupingSession::prepareMergeTargets(). This works because AggregationResult shares its ExpressionTree with the session's internal copy (via a shared_ptr set up at copy-construction), so by the time init() has configured the session copy's expression, the leftover request's aggregation result can select the correct result node type from that same expression.

Added a regression test covering a root-level min() aggregation.

@toregge FYI
