### PR TITLE
Add internal OpenTelemetry spans to the container query path

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ThreadedRequestHandler.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ThreadedRequestHandler.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.jdisc;
 
+import ai.vespa.telemetry.api.trace.OtelTracing;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.Request;
@@ -13,7 +14,12 @@ import com.yahoo.jdisc.handler.OverloadException;
 import com.yahoo.jdisc.handler.ReadableContentChannel;
 import com.yahoo.jdisc.handler.ResponseDispatch;
 import com.yahoo.jdisc.handler.ResponseHandler;
+import com.yahoo.jdisc.http.server.jetty.RequestUtils;
 import com.yahoo.container.core.HandlerMetricContextUtil;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
 
 import java.time.Duration;
 import java.util.Map;
@@ -181,7 +187,8 @@ public abstract class ThreadedRequestHandler extends AbstractRequestHandler {
         @Override
         public void run() {
             try (ResourceReference reference = requestReference) {
-                processRequest();
+                OtelTracing.instrument(parentContext(), "handler." + ThreadedRequestHandler.this.getClass().getSimpleName(),
+                        this::processRequest);
             }
         }
 
@@ -189,6 +196,7 @@ public abstract class ThreadedRequestHandler extends AbstractRequestHandler {
             try {
                 ThreadedRequestHandler.this.handleRequest(request, content, this);
             } catch (Exception e) {
+                Span.current().recordException(e).setStatus(StatusCode.ERROR);
                 log.log(Level.WARNING, "Uncaught exception in " + ThreadedRequestHandler.this.getClass().getName() +
                                        ".", e);
             }
@@ -198,6 +206,12 @@ public abstract class ThreadedRequestHandler extends AbstractRequestHandler {
             // so respond with status 500 if we get here and no response has been generated.
             if ( ! allowAsyncResponse)
                 respondWithErrorIfNotResponded();
+        }
+
+        /** The SERVER-span Context bridged into the jdisc request by container-disc (L1), or root() when absent. */
+        private Context parentContext() {
+            return request.context().get(RequestUtils.JDISC_REQUEST_OTEL_CONTEXT) instanceof Context c
+                    ? c : Context.root();
         }
 
         @Override
@@ -253,19 +267,19 @@ public abstract class ThreadedRequestHandler extends AbstractRequestHandler {
 
     private static class NullRequestMetric implements Metric {
         @Override
-        public void set(String key, Number val, Context ctx) {
+        public void set(String key, Number val, Metric.Context ctx) {
         }
 
         @Override
-        public void add(String key, Number val, Context ctx) {
+        public void add(String key, Number val, Metric.Context ctx) {
         }
 
         @Override
-        public Context createContext(Map<String, ?> properties) {
+        public Metric.Context createContext(Map<String, ?> properties) {
             return NullFeedContext.INSTANCE;
         }
 
-        private static class NullFeedContext implements Context {
+        private static class NullFeedContext implements Metric.Context {
             private static final NullFeedContext INSTANCE = new NullFeedContext();
         }
 

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
@@ -3,6 +3,7 @@ package com.yahoo.jdisc.http.server.jetty;
 
 import com.yahoo.jdisc.http.HttpRequest;
 import com.yahoo.jdisc.service.CurrentContainer;
+import io.opentelemetry.context.Context;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.Request;
 
@@ -40,7 +41,13 @@ class HttpRequestFactory {
             jdiscHttpReq.context().put(RequestUtils.JDICS_REQUEST_PORT, Request.getLocalPort(jettyRequest));
             var sslSessionData = (EndPoint.SslSessionData) jettyRequest.getAttribute(EndPoint.SslSessionData.ATTRIBUTE);
             if (sslSessionData != null) jdiscHttpReq.context().put(RequestUtils.JDISC_REQUEST_SSLSESSION, sslSessionData.sslSession());
+
+            // Bridge the SERVER span's OpenTelemetry Context (created by JettyServerSpanHandler) into the jdisc
+            // request context, which crosses to the handler worker thread so it can parent child spans.
+            if (jettyRequest.getAttribute(JettyServerSpanHandler.OTEL_CONTEXT_REQUEST_ATTRIBUTE) instanceof Context otelContext)
+                jdiscHttpReq.context().put(RequestUtils.JDISC_REQUEST_OTEL_CONTEXT, otelContext);
             jettyRequest.setAttribute(HttpRequest.class.getName(), jdiscHttpReq);
+
             copyHeaders(jettyRequest, jdiscHttpReq);
             return jdiscHttpReq;
         } catch (IllegalArgumentException e) {

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyServerSpanHandler.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyServerSpanHandler.java
@@ -3,6 +3,7 @@ package com.yahoo.jdisc.http.server.jetty;
 
 import ai.vespa.telemetry.api.Telemetry;
 import ai.vespa.telemetry.api.trace.ScopedTracer;
+import ai.vespa.telemetry.api.trace.OtelTracing;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
@@ -24,9 +25,10 @@ import java.util.logging.Logger;
  * Jetty integration that creates an OpenTelemetry {@link SpanKind#SERVER server span} per HTTP request.
  *
  * <p>The span is started when request handling begins ({@link #onBeforeHandling}) and ended when the
- * request and response are fully processed ({@link #onComplete}). The owning {@link Context} (the
- * incoming W3C trace context with this server span set) is stored as a Jetty request attribute under
- * {@link #OTEL_CONTEXT_REQUEST_ATTRIBUTE}, so downstream code can create child spans and propagate it.</p>
+ * request and response are fully processed ({@link #onComplete}). The owning {@link Context} — the incoming
+ * W3C trace context with this server span set, plus the {@link Telemetry} instance when enabled — is stored
+ * as a Jetty request attribute under {@link #OTEL_CONTEXT_REQUEST_ATTRIBUTE}, so downstream code can recover
+ * the telemetry, create child spans, and propagate the context further.</p>
  *
  * <p>{@link #onBeforeHandling} and {@link #onComplete} are not guaranteed to run on the same thread
  * (async requests), so the span is carried explicitly in the request attribute rather than via a
@@ -39,11 +41,11 @@ import java.util.logging.Logger;
  */
 class JettyServerSpanHandler extends EventsHandler {
 
-    /** Request attribute holding the {@link Context} (incoming context + server span) for this request. */
+    /** Request attribute holding the {@link Context} (incoming context, server span, and the {@link Telemetry}
+     *  instance when enabled) for this request. */
     static final String OTEL_CONTEXT_REQUEST_ATTRIBUTE = "jdisc.request.otel.context";
 
     private static final Logger log = Logger.getLogger(JettyServerSpanHandler.class.getName());
-    private static final String INSTRUMENTATION_SCOPE_NAME = "com.yahoo.jdisc.http.server.jetty";
 
     // OpenTelemetry HTTP-server semantic-convention attribute keys. Hardcoded here (rather than depending
     // on the alpha opentelemetry-semconv artifact) so this stays on the API-only classpath.
@@ -70,10 +72,12 @@ class JettyServerSpanHandler extends EventsHandler {
 
     private final ScopedTracer tracer;
     private final TextMapPropagator propagator;
+    private final Telemetry telemetry;
 
     JettyServerSpanHandler(Telemetry telemetry, Handler handler) {
         super(handler);
-        this.tracer = telemetry.tracer(INSTRUMENTATION_SCOPE_NAME);
+        this.telemetry = telemetry;
+        this.tracer = telemetry.tracer(OtelTracing.DEFAULT_SCOPE);
         this.propagator = telemetry.textMapPropagator();
     }
 
@@ -83,7 +87,8 @@ class JettyServerSpanHandler extends EventsHandler {
      * <p>Context propagation: the incoming W3C trace-context headers are read via the {@link #propagator}
      * to recover the caller's (remote parent) {@link Context}; the new span is created as a child of it, so a
      * distributed trace started upstream continues through this server. The owning context — the extracted
-     * parent with this span set on it ({@code parentContext.with(span)}) — is then stored in the Jetty request
+     * parent with this span set on it, plus the {@link Telemetry} instance
+     * ({@code Telemetry.store(parentContext.with(span), telemetry)}) — is then stored in the Jetty request
      * attribute {@link #OTEL_CONTEXT_REQUEST_ATTRIBUTE}, NOT in a thread-local {@link io.opentelemetry.context.Scope},
      * because {@link #onComplete} may run on a different thread for async requests. Downstream code can read that
      * attribute to create child spans and propagate the context further.</p>
@@ -93,11 +98,16 @@ class JettyServerSpanHandler extends EventsHandler {
     @Override
     protected void onBeforeHandling(Request request) {
         try {
-            Context parentContext = propagator.extract(Context.current(), request, HEADER_GETTER);
+            // Extract from root() rather than current(): nothing is attached on the Jetty thread so they are
+            // equal today, but root() is immune to a scope leaked from a prior request on this reused thread.
+            // Vespa runs no external OTel agent, so inheriting the thread's ambient context has no value here.
+            Context parentContext = propagator.extract(Context.root(), request, HEADER_GETTER);
             Span span = tracer.startServerSpan(spanName(request), parentContext);
-            // Store the context before setting attributes so onComplete can always end the span,
-            // even if an attribute getter below throws.
-            request.setAttribute(OTEL_CONTEXT_REQUEST_ATTRIBUTE, parentContext.with(span));
+            // Store the context before setting attributes so onComplete can always end the span even if a
+            // getter below throws. Telemetry is stored into the context too, so downstream span sites in
+            // exported packages (which cannot be dependency-injected) recover it from the ambient context.
+            request.setAttribute(OTEL_CONTEXT_REQUEST_ATTRIBUTE,
+                    Telemetry.store(parentContext.with(span), telemetry));
             setRequestAttributes(span, request);
         } catch (Exception e) {
             log.log(Level.WARNING, "Failed to start server span", e);

--- a/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/RequestUtils.java
+++ b/container-disc/src/main/java/com/yahoo/jdisc/http/server/jetty/RequestUtils.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 public class RequestUtils {
     public static final String JDISC_REQUEST_X509CERT = "jdisc.request.X509Certificate";
     public static final String JDISC_REQUEST_SSLSESSION = "jdisc.request.SSLSession";
+    public static final String JDISC_REQUEST_OTEL_CONTEXT = "jdisc.request.otel.context";
     public static final String JDISC_REQUEST_CHAIN = "jdisc.request.chain";
     public static final String JDISC_RESPONSE_CHAIN = "jdisc.response.chain";
 

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/ThreadedRequestHandlerTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/ThreadedRequestHandlerTest.java
@@ -1,0 +1,257 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.container.jdisc;
+
+import ai.vespa.telemetry.api.NoopTelemetry;
+import ai.vespa.telemetry.api.Telemetry;
+import ai.vespa.telemetry.api.trace.ScopedTracer;
+import ai.vespa.telemetry.api.trace.OtelTracing;
+import com.yahoo.jdisc.Request;
+import com.yahoo.jdisc.Response;
+import com.yahoo.jdisc.handler.BufferedContentChannel;
+import com.yahoo.jdisc.handler.ResponseDispatch;
+import com.yahoo.jdisc.handler.ResponseHandler;
+import com.yahoo.jdisc.http.HttpRequest;
+import com.yahoo.jdisc.http.server.jetty.RequestUtils;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the per-handler INTERNAL span that {@link ThreadedRequestHandler#processRequest} creates: it is a
+ * child of the SERVER context bridged into the jdisc request, is made current for the handler body, and is
+ * non-recording when no telemetry rode along.
+ *
+ * @author onur
+ */
+class ThreadedRequestHandlerTest {
+
+    @Test
+    void creates_a_child_handler_span_made_current_for_the_handler_body() throws InterruptedException {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        Telemetry telemetry = recording(tracerProvider);
+        Span serverSpan = telemetry.tracer(OtelTracing.DEFAULT_SCOPE).startSpan("server", SpanKind.SERVER, Context.root());
+        Context bridged = Telemetry.store(Context.root().with(serverSpan), telemetry);
+
+        // A real worker thread, not Runnable::run: with a same-thread executor, processRequest runs inside
+        // request.connect() before the driver writes/closes the request body, so consumeRequestContent()
+        // deadlocks draining a body that never arrives. A real executor lets connect() return first.
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CapturingHandler handler = new CapturingHandler(executor);
+        try (RequestHandlerTestDriver driver = new RequestHandlerTestDriver(handler)) {
+            Request request = driver.createRequest("http://localhost/foo", HttpRequest.Method.GET);
+            request.context().put(RequestUtils.JDISC_REQUEST_OTEL_CONTEXT, bridged);
+            driver.sendRequest(request, "");
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS), "the handler task must complete");
+        }
+        serverSpan.end();
+
+        SpanData handlerSpan = spanNamed(exporter, "handler.CapturingHandler");
+        assertEquals(SpanKind.INTERNAL, handlerSpan.getKind());
+        assertEquals(OtelTracing.DEFAULT_SCOPE, handlerSpan.getInstrumentationScopeInfo().getName());
+        assertEquals(serverSpan.getSpanContext().getSpanId(), handlerSpan.getParentSpanId(),
+                     "the handler span must be a child of the bridged SERVER span");
+        assertEquals(handlerSpan.getSpanId(), handler.current.get().getSpanContext().getSpanId(),
+                     "the handler span must be current during handleRequest");
+
+        tracerProvider.close();
+    }
+
+    @Test
+    void handler_span_is_non_recording_when_no_telemetry_is_carried() throws InterruptedException {
+        ExecutorService executor = Executors.newSingleThreadExecutor();   // real worker (see the child-span test)
+        CapturingHandler handler = new CapturingHandler(executor);
+        try (RequestHandlerTestDriver driver = new RequestHandlerTestDriver(handler)) {
+            driver.sendRequest("http://localhost/foo");   // request carries no OTel context
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS), "the handler task must complete");
+        }
+
+        Span current = handler.current.get();
+        assertNotNull(current, "handleRequest must still run");
+        assertFalse(current.getSpanContext().isValid(), "no carried telemetry => invalid, non-recording span");
+        assertFalse(current.isRecording());
+    }
+
+    @Test
+    void handler_that_throws_records_the_exception_and_still_responds_500() throws InterruptedException {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        Telemetry telemetry = recording(tracerProvider);
+        Span serverSpan = telemetry.tracer(OtelTracing.DEFAULT_SCOPE).startSpan("server", SpanKind.SERVER, Context.root());
+        Context bridged = Telemetry.store(Context.root().with(serverSpan), telemetry);
+
+        // A real worker thread (not Runnable::run): with a same-thread executor, processRequest would run
+        // inside request.connect() before the driver writes/closes the request body, so consumeRequestContent()
+        // would deadlock draining a body that never arrives. A real executor lets connect() return first.
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ThrowingHandler handler = new ThrowingHandler(executor);
+        try (RequestHandlerTestDriver driver = new RequestHandlerTestDriver(handler)) {
+            Request request = driver.createRequest("http://localhost/foo", HttpRequest.Method.GET);
+            request.context().put(RequestUtils.JDISC_REQUEST_OTEL_CONTEXT, bridged);
+            var response = driver.sendRequest(request, "").awaitResponse();   // wait for the auto-generated 500
+            assertEquals(500, response.getStatus(), "a throwing handler must still produce a 500 response");
+            response.readAll();
+        }
+        executor.shutdown();
+        serverSpan.end();
+
+        SpanData handlerSpan = spanNamed(exporter, "handler.ThrowingHandler");
+        assertEquals(StatusCode.ERROR, handlerSpan.getStatus().getStatusCode());
+        assertTrue(handlerSpan.hasEnded(), "the handler span must be ended even when the handler throws");
+        assertEquals(1, handlerSpan.getEvents().size(), "the thrown exception must be recorded on the span");
+        assertEquals("exception", handlerSpan.getEvents().get(0).getName());
+
+        tracerProvider.close();
+    }
+
+    @Test
+    void async_handler_span_ends_when_handleRequest_returns_before_the_async_response() throws InterruptedException {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        Telemetry telemetry = recording(tracerProvider);
+        Span serverSpan = telemetry.tracer(OtelTracing.DEFAULT_SCOPE).startSpan("server", SpanKind.SERVER, Context.root());
+        Context bridged = Telemetry.store(Context.root().with(serverSpan), telemetry);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();   // real worker (see the throwing-handler test)
+        AsyncHandler handler = new AsyncHandler(executor);
+        try (RequestHandlerTestDriver driver = new RequestHandlerTestDriver(handler)) {
+            Request request = driver.createRequest("http://localhost/foo", HttpRequest.Method.GET);
+            request.context().put(RequestUtils.JDISC_REQUEST_OTEL_CONTEXT, bridged);
+            var response = driver.sendRequest(request, "");
+            executor.shutdown();
+            boolean finished = executor.awaitTermination(10, TimeUnit.SECONDS);   // handleRequest returned; span ended
+
+            // Capture the outcome, then dispatch the deferred response BEFORE asserting, so a failing
+            // assertion can never leave the driver without a response (which would block close()).
+            Response synchronousResponse = response.getResponse();
+            Span currentDuringHandle = handler.current.get();
+            handler.respond();
+            response.readAll();
+
+            assertTrue(finished, "the handler task must complete");
+            assertNull(synchronousResponse, "an async handler must not respond synchronously");
+            SpanData handlerSpan = spanNamed(exporter, "handler.AsyncHandler");
+            assertTrue(handlerSpan.hasEnded(), "the span must end when handleRequest returns, before the async response");
+            assertEquals(StatusCode.UNSET, handlerSpan.getStatus().getStatusCode());
+            assertEquals(handlerSpan.getSpanId(), currentDuringHandle.getSpanContext().getSpanId(),
+                         "the handler span must have been current during handleRequest");
+        }
+        serverSpan.end();
+
+        tracerProvider.close();
+    }
+
+    @Test
+    void handler_span_parents_correctly_on_a_real_worker_thread() throws InterruptedException {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        Telemetry telemetry = recording(tracerProvider);
+        Span serverSpan = telemetry.tracer(OtelTracing.DEFAULT_SCOPE).startSpan("server", SpanKind.SERVER, Context.root());
+        Context bridged = Telemetry.store(Context.root().with(serverSpan), telemetry);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CapturingHandler handler = new CapturingHandler(executor);   // real worker thread, not the test thread
+        try (RequestHandlerTestDriver driver = new RequestHandlerTestDriver(handler)) {
+            Request request = driver.createRequest("http://localhost/foo", HttpRequest.Method.GET);
+            request.context().put(RequestUtils.JDISC_REQUEST_OTEL_CONTEXT, bridged);
+            driver.sendRequest(request, "");
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS), "the handler task must complete");
+        }
+        serverSpan.end();
+
+        SpanData handlerSpan = spanNamed(exporter, "handler.CapturingHandler");
+        assertEquals(serverSpan.getSpanContext().getSpanId(), handlerSpan.getParentSpanId(),
+                     "the handler span must be a child of the bridged SERVER span");
+        assertEquals(handlerSpan.getSpanId(), handler.current.get().getSpanContext().getSpanId(),
+                     "the span made current on the real worker thread must be the handler span");
+
+        tracerProvider.close();
+    }
+
+    private static Telemetry recording(SdkTracerProvider tracerProvider) {
+        return new Telemetry() {
+            @Override public ScopedTracer tracer(String scope) { return new ScopedTracer(tracerProvider.get(scope)); }
+            @Override public TextMapPropagator textMapPropagator() { return NoopTelemetry.INSTANCE.textMapPropagator(); }
+        };
+    }
+
+    private static SpanData spanNamed(InMemorySpanExporter exporter, String name) {
+        return exporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no span named '" + name + "' in " + exporter.getFinishedSpanItems()));
+    }
+
+    /** Captures the current span during handleRequest and returns an empty 200. */
+    private static final class CapturingHandler extends ThreadedRequestHandler {
+        final AtomicReference<Span> current = new AtomicReference<>();
+
+        CapturingHandler(Executor executor) { super(executor); }
+
+        @Override
+        protected void handleRequest(Request request, BufferedContentChannel requestContent, ResponseHandler responseHandler) {
+            current.set(Span.current());
+            ResponseDispatch.newInstance(new Response(Response.Status.OK)).dispatch(responseHandler);
+        }
+    }
+
+    /** Throws from handleRequest to exercise the error path. */
+    private static final class ThrowingHandler extends ThreadedRequestHandler {
+        ThrowingHandler(Executor executor) { super(executor); }
+
+        @Override
+        protected void handleRequest(Request request, BufferedContentChannel requestContent, ResponseHandler responseHandler) {
+            throw new RuntimeException("boom");
+        }
+    }
+
+    /** Allows an async response: captures the current span and the response handler, then responds later. */
+    private static final class AsyncHandler extends ThreadedRequestHandler {
+        final AtomicReference<Span> current = new AtomicReference<>();
+        private volatile ResponseHandler responseHandler;
+
+        AsyncHandler(Executor executor) { super(executor, null, true); }
+
+        @Override
+        protected void handleRequest(Request request, BufferedContentChannel requestContent, ResponseHandler responseHandler) {
+            current.set(Span.current());
+            this.responseHandler = responseHandler;   // respond later, not in this call
+        }
+
+        void respond() {
+            ResponseHandler rh = responseHandler;
+            if (rh != null)
+                ResponseDispatch.newInstance(new Response(Response.Status.OK)).dispatch(rh);
+        }
+    }
+}

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactoryTest.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactoryTest.java
@@ -8,6 +8,8 @@ import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.handler.RequestHandler;
 import com.yahoo.jdisc.http.HttpRequest;
 import com.yahoo.jdisc.service.CurrentContainer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import org.eclipse.jetty.server.Request;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +20,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -147,6 +151,28 @@ public class HttpRequestFactoryTest {
                         .header("X-Foo", List.of())
                         .build());
         assertTrue(request.headers().isEmpty(), () -> "Found headers: " + request.headers());
+    }
+
+    @Test
+    void bridges_otel_context_into_jdisc_request_context() {
+        ContextKey<Object> marker = ContextKey.named("test-marker");
+        Context otelContext = Context.root().with(marker, new Object());
+        Request jettyRequest = JettyMockRequestBuilder.newBuilder()
+                .uri("https", "example.com", LOCAL_PORT, "/search", "query=value")
+                .remote("127.0.0.1", "localhost", 1234)
+                .localPort(LOCAL_PORT)
+                .attribute(JettyServerSpanHandler.OTEL_CONTEXT_REQUEST_ATTRIBUTE, otelContext)
+                .build();
+        HttpRequest request = HttpRequestFactory.newJDiscRequest(new MockContainer(), jettyRequest);
+        assertSame(otelContext, request.context().get(RequestUtils.JDISC_REQUEST_OTEL_CONTEXT));
+    }
+
+    @Test
+    void no_otel_context_entry_when_jetty_attribute_absent() {
+        HttpRequest request = HttpRequestFactory.newJDiscRequest(
+                new MockContainer(),
+                createMockRequest("https", "example.com", "/search", "query=value"));
+        assertFalse(request.context().containsKey(RequestUtils.JDISC_REQUEST_OTEL_CONTEXT));
     }
 
     private Request createMockRequest(String scheme, String host, String path, String query) {

--- a/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/JettyServerSpanHandlerTest.java
+++ b/container-disc/src/test/java/com/yahoo/jdisc/http/server/jetty/JettyServerSpanHandlerTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http.server.jetty;
 
+import ai.vespa.telemetry.api.NoopTelemetry;
 import ai.vespa.telemetry.api.Telemetry;
 import ai.vespa.telemetry.api.trace.ScopedTracer;
 import com.google.inject.Module;
@@ -12,9 +13,11 @@ import com.yahoo.jdisc.handler.ResponseHandler;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -26,12 +29,15 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.yahoo.jdisc.Response.Status.INTERNAL_SERVER_ERROR;
 import static com.yahoo.jdisc.Response.Status.OK;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -115,7 +121,45 @@ class JettyServerSpanHandlerTest {
         assertTrue(driver.close());
     }
 
+    @Test
+    void bridgedContextCarriesTelemetryWhenEnabled() throws IOException {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        Telemetry telemetry = recordingTelemetry(exporter);
+        AtomicReference<Context> captured = new AtomicReference<>();
+        JettyTestDriver driver = JettyTestDriver.newInstance(contextCapturingHandler(captured), moduleFor(telemetry));
+
+        driver.client().newGet("/search/").execute().expectStatusCode(is(OK));
+
+        Context ctx = captured.get();
+        assertNotNull(ctx, "the SERVER context must reach the handler thread via the jdisc request context");
+        assertTrue(Span.fromContext(ctx).getSpanContext().isValid(), "a recording server span must be set on it");
+        assertSame(telemetry, Telemetry.from(ctx), "the enabled Telemetry must ride along in the context");
+
+        assertTrue(driver.close());
+    }
+
+    @Test
+    void bridgedContextCarriesNoTelemetryWhenDisabled() throws IOException {
+        // Default NoopTelemetry binding (disabled). The context is still bridged (Decision 3A), but store()
+        // short-circuited, so no telemetry rides along and the server span is invalid/non-recording.
+        AtomicReference<Context> captured = new AtomicReference<>();
+        JettyTestDriver driver = JettyTestDriver.newInstance(contextCapturingHandler(captured));
+
+        driver.client().newGet("/search/").execute().expectStatusCode(is(OK));
+
+        Context ctx = captured.get();
+        assertNotNull(ctx, "the context is bridged unconditionally (Decision 3A)");
+        assertFalse(Span.fromContext(ctx).getSpanContext().isValid(), "the disabled server span is invalid");
+        assertSame(NoopTelemetry.INSTANCE, Telemetry.from(ctx), "no telemetry rides along when disabled");
+
+        assertTrue(driver.close());
+    }
+
     private static Module otelModule(InMemorySpanExporter exporter) {
+        return moduleFor(recordingTelemetry(exporter));
+    }
+
+    private static Telemetry recordingTelemetry(InMemorySpanExporter exporter) {
         OpenTelemetry sdk = OpenTelemetrySdk.builder()
                 .setTracerProvider(SdkTracerProvider.builder()
                         .addSpanProcessor(SimpleSpanProcessor.create(exporter))
@@ -124,10 +168,13 @@ class JettyServerSpanHandlerTest {
                 .build();
         // Minimal recording Telemetry over the in-memory SDK (OtelTelemetry.create builds its own SDK, so it
         // cannot be pointed at an InMemorySpanExporter; the seam is trivial to implement inline for the test).
-        Telemetry telemetry = new Telemetry() {
+        return new Telemetry() {
             @Override public ScopedTracer tracer(String scope) { return new ScopedTracer(sdk.getTracer(scope)); }
             @Override public TextMapPropagator textMapPropagator() { return sdk.getPropagators().getTextMapPropagator(); }
         };
+    }
+
+    private static Module moduleFor(Telemetry telemetry) {
         return binder -> binder.bind(Telemetry.class).toInstance(telemetry);
     }
 
@@ -140,6 +187,16 @@ class JettyServerSpanHandlerTest {
         }
         assertEquals(1, spans.size(), "expected exactly one server span");
         return spans.get(0);
+    }
+
+    private static AbstractRequestHandler contextCapturingHandler(AtomicReference<Context> captured) {
+        return new AbstractRequestHandler() {
+            @Override
+            public ContentChannel handleRequest(Request request, ResponseHandler handler) {
+                if (request.context().get(RequestUtils.JDISC_REQUEST_OTEL_CONTEXT) instanceof Context ctx) captured.set(ctx);
+                return handler.handleResponse(new Response(OK));
+            }
+        };
     }
 
     private static class ServerErrorRequestHandler extends AbstractRequestHandler {

--- a/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/Telemetry.java
+++ b/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/Telemetry.java
@@ -2,7 +2,11 @@
 package ai.vespa.telemetry.api;
 
 import ai.vespa.telemetry.api.trace.ScopedTracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+
+import java.util.Objects;
 
 /**
  * Entry point for Vespa-internal telemetry. Inject this into any container component.
@@ -15,6 +19,9 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
  * (meter(String) — adding an interface method is binary-compatible for callers;
  * only the platform implements this interface).</p>
  *
+ * <p>{@link #store}/{@link #from} carry this instance inside an OpenTelemetry {@link Context}, for
+ * instrumentation sites that cannot be dependency-injected — notably searchers and executions.</p>
+ *
  * @author onur
  */
 public interface Telemetry {
@@ -25,4 +32,37 @@ public interface Telemetry {
 
     /** The configured propagator (W3C trace context); no-op propagator when disabled. */
     TextMapPropagator textMapPropagator();
+
+    /**
+     * Returns a context carrying {@code telemetry}, or {@code ctx} unchanged when there is nothing to carry.
+     * A null or no-op telemetry is tolerated on purpose: telemetry may legitimately be unconfigured, whereas a
+     * missing context is a programming error.
+     *
+     * @throws NullPointerException if {@code ctx} is null
+     */
+    static Context store(Context ctx, Telemetry telemetry) {
+        Objects.requireNonNull(ctx, "ctx");
+        return (telemetry == null || telemetry == NoopTelemetry.INSTANCE) ? ctx : ctx.with(Key.INSTANCE, telemetry);
+    }
+
+    /**
+     * The telemetry carried in {@code ctx}, or the no-op instance when absent. Never null.
+     *
+     * @throws NullPointerException if {@code ctx} is null
+     */
+    static Telemetry from(Context ctx) {
+        Objects.requireNonNull(ctx, "ctx");
+        Telemetry telemetry = ctx.get(Key.INSTANCE);
+        return telemetry != null ? telemetry : NoopTelemetry.INSTANCE;
+    }
+
+    /**
+     * Holds the carrier key privately: a bare interface field would be {@code public static final}, exposing it.
+     * {@link ContextKey} is compared by reference, so this must remain a single shared instance; the enclosing
+     * interface reaches it as a nestmate.
+     */
+    final class Key {
+        private static final ContextKey<Telemetry> INSTANCE = ContextKey.named("ai.vespa.telemetry");
+        private Key() { }
+    }
 }

--- a/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/trace/OtelTracing.java
+++ b/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/trace/OtelTracing.java
@@ -1,0 +1,110 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.telemetry.api.trace;
+
+import ai.vespa.telemetry.api.Telemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+
+
+/**
+ * OpenTelemetry tracing facade over the {@link Telemetry} carried in an OpenTelemetry {@link Context}
+ * (see {@link Telemetry#store}/{@link Telemetry#from}). Span sites call this instead of unpacking
+ * telemetry &rarr; tracer &rarr; span by hand. Non-recording — and nothing exported — when the carried
+ * telemetry is absent or disabled, so sites instrument unconditionally.
+ *
+ * <p>Named for OpenTelemetry deliberately: Vespa already has an unrelated {@code Trace} — the per-query
+ * diagnostic trace reachable through {@code Query.trace(..)} — and call sites here sit within a few lines of
+ * it. Nothing in this class has anything to do with that.</p>
+ *
+ * @author onur
+ */
+public final class OtelTracing {
+
+    /** Single instrumentation scope for Vespa-internal spans; pass an explicit scope only when you truly need one. */
+    public static final String DEFAULT_SCOPE = "ai.vespa";
+
+    private OtelTracing() { }
+
+    /**
+     * Starts a span whose parent span AND {@link Telemetry} are both taken from {@code parent}, under the
+     * {@link #DEFAULT_SCOPE}. For boundary layers where the context is not yet current (e.g. a handler entry);
+     * the caller owns {@code makeCurrent()} / {@code end()}.
+     */
+    public static Span startSpan(Context parent, String name, SpanKind kind) {
+        return startSpan(parent, DEFAULT_SCOPE, name, kind);
+    }
+
+    /** As {@link #startSpan(Context, String, SpanKind)} but under an explicit instrumentation scope. */
+    public static Span startSpan(Context parent, String scope, String name, SpanKind kind) {
+        return Telemetry.from(parent).tracer(scope).startSpan(name, kind, parent);
+    }
+
+    /**
+     * Instruments {@code body}: RUNS it inside an {@link SpanKind#INTERNAL INTERNAL} span under the
+     * {@link #DEFAULT_SCOPE}, whose parent span AND {@link Telemetry} are both taken from {@code parent}. Starts
+     * the span, makes it current for the duration of {@code body}, records the exception and sets ERROR status if
+     * {@code body} throws (then rethrows), and always ends the span. Best-effort — non-recording, and nothing
+     * exported, when the carried telemetry is absent or disabled, so callers instrument unconditionally.
+     */
+    public static void instrument(Context parent, String name, Runnable body) {
+        Telemetry.from(parent).tracer(DEFAULT_SCOPE).instrument(name, SpanKind.INTERNAL, parent, body);
+    }
+
+    /** Ambient form of {@link #instrument(Context, String, Runnable)}: the parent span and {@link Telemetry} are
+     *  taken from {@link Context#current()}. Use downstream of the handler entry, where the context is already
+     *  current; lets call sites instrument without naming {@link Context} (some Vespa classes shadow that name). */
+    public static void instrument(String name, Runnable body) {
+        instrument(Context.current(), name, body);
+    }
+
+    /**
+     * As {@link #instrument(Context, String, Runnable)}, for a body that RETURNS a value, which is passed back
+     * through. Takes a {@link ThrowingSupplier}, so a body declaring {@code throws} can be instrumented; a body
+     * that throws no checked exception infers {@code E = RuntimeException} and the call site needs no
+     * {@code throws}.
+     */
+    public static <T, E extends Exception> T instrument(Context parent, String name, ThrowingSupplier<T, E> body) throws E {
+        return Telemetry.from(parent).tracer(DEFAULT_SCOPE).instrument(name, SpanKind.INTERNAL, parent, body);
+    }
+
+    /** Ambient form of {@link #instrument(Context, String, ThrowingSupplier)}. */
+    public static <T, E extends Exception> T instrument(String name, ThrowingSupplier<T, E> body) throws E {
+        return instrument(Context.current(), name, body);
+    }
+
+    /**
+     * Returns {@code task} bound to the CURRENT context, so the thread that later runs it does so under the same
+     * span and {@link Telemetry} as the thread that submitted it. Use at a fork — a point where request work is
+     * handed to another thread — since the OpenTelemetry context lives in a plain, non-inheritable ThreadLocal and
+     * would otherwise be absent there, leaving spans on the receiving thread non-recording and unexported.
+     *
+     * <p>The context is captured HERE, at call time on the forking thread, not when the task later runs. The scope
+     * is closed when the task returns, so a pooled thread never leaks context into an unrelated later task.</p>
+     *
+     * <p>Unlike {@link #instrument}, this RUNS NOTHING — it returns a wrapper for the caller to submit.</p>
+     *
+     * <p>This is propagation ACROSS THREADS within one process. Propagation across processes is a different
+     * mechanism — {@link Telemetry#textMapPropagator()} serialises the context into carrier headers.</p>
+     */
+    public static Runnable withCurrentContext(Runnable task) {
+        return Context.current().wrap(task);
+    }
+
+    /**
+     * A tracer under the {@link #DEFAULT_SCOPE}, backed by the telemetry in the CURRENT context. Use only where
+     * the context is already current (downstream of the handler entry); returns a no-op tracer otherwise.
+     */
+    public static ScopedTracer tracer() {
+        return Telemetry.from(Context.current()).tracer(DEFAULT_SCOPE);
+    }
+
+    public static ScopedTracer tracer(Context context) {
+        return Telemetry.from(context).tracer(DEFAULT_SCOPE);
+    }
+
+    /** As {@link #tracer()} but under an explicit instrumentation scope. */
+    public static ScopedTracer tracer(String scope) {
+        return Telemetry.from(Context.current()).tracer(scope);
+    }
+}

--- a/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/trace/ScopedTracer.java
+++ b/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/trace/ScopedTracer.java
@@ -9,7 +9,8 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
-import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Span-creation helpers over one instrumentation scope.
@@ -22,12 +23,17 @@ import java.util.function.Supplier;
  */
 public final class ScopedTracer {
 
+    private static final Logger log = Logger.getLogger(ScopedTracer.class.getName());
+
     private final Tracer tracer;
 
     public ScopedTracer(Tracer tracer) { this.tracer = tracer; }
 
-    /** Runs body inside a span on the current thread: start, make current, record failure, end. */
-    public <T> T inSpan(String name, SpanKind kind, Context parent, Supplier<T> body) {
+    /** Instruments a body that RETURNS a value: runs it inside a span on the current thread - start, make
+     *  current, record failure, end - and passes the value back through. Takes a {@link ThrowingSupplier} so a
+     *  body declaring {@code throws} can be instrumented without altering its exception behaviour; a
+     *  non-throwing body infers {@code E = RuntimeException}. */
+    public <T, E extends Exception> T instrument(String name, SpanKind kind, Context parent, ThrowingSupplier<T, E> body) throws E {
         Span span = startSpan(name, kind, parent);
         try (Scope ignored = span.makeCurrent()) {
             return body.get();
@@ -40,13 +46,23 @@ public final class ScopedTracer {
         }
     }
 
-    public void inSpan(String name, SpanKind kind, Context parent, Runnable body) {
-        inSpan(name, kind, parent, () -> { body.run(); return null; });
+    /** As above, for a body that produces no value. */
+    public void instrument(String name, SpanKind kind, Context parent, Runnable body) {
+        instrument(name, kind, parent, () -> { body.run(); return null; });
     }
 
-    /** For spans ended on a DIFFERENT thread (RPC replies etc.): caller owns end(); Span is thread-safe. */
+    /** For spans ended on a DIFFERENT thread (RPC replies etc.): caller owns end(); Span is thread-safe.
+     *  Never throws: on any failure to create the span (e.g. a sampler or SpanProcessor.onStart that throws),
+     *  logs and returns a non-recording invalid span, so instrumentation can never break the caller. This is
+     *  the single creation choke point — {@link #instrument} and the {@link OtelTracing} facade both route
+     *  through it. */
     public Span startSpan(String name, SpanKind kind, Context parent) {
-        return tracer.spanBuilder(name).setSpanKind(kind).setParent(parent).startSpan();
+        try {
+            return tracer.spanBuilder(name).setSpanKind(kind).setParent(parent).startSpan();
+        } catch (Exception e) {
+            log.log(Level.WARNING, "Failed to start span '" + name + "'", e);
+            return Span.getInvalid();
+        }
     }
 
     /** Convenience for the common server-side case: a {@link SpanKind#SERVER} span under {@code parent}.
@@ -54,7 +70,7 @@ public final class ScopedTracer {
     public Span startServerSpan(String name, Context parent) { return startSpan(name, SpanKind.SERVER, parent); }
 
     /** The raw {@link SpanBuilder} for this scope: full control before starting (attributes at creation,
-     *  links, multiple parents, explicit start timestamp). Prefer {@link #startSpan}/{@link #inSpan} for the
+     *  links, multiple parents, explicit start timestamp). Prefer {@link #startSpan}/{@link #instrument} for the
      *  common cases; use this when they are not expressive enough. */
     public SpanBuilder spanBuilder(String spanName) { return tracer.spanBuilder(spanName); }
 

--- a/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/trace/ThrowingSupplier.java
+++ b/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/trace/ThrowingSupplier.java
@@ -1,0 +1,24 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.telemetry.api.trace;
+
+/**
+ * A {@link java.util.function.Supplier} that may throw a checked exception.
+ *
+ * <p>Instrumenting a method which declares {@code throws} is impossible with {@code Supplier}, whose
+ * {@code get()} cannot carry one — {@code SearchInvoker.search} declares {@code throws IOException}, for
+ * instance. This interface exists so a span can wrap such a body without the instrumentation changing the
+ * exception behaviour of the code it measures.</p>
+ *
+ * <p>The value-returning {@code instrument} methods take this INSTEAD OF {@code Supplier}, not in addition to it: with both
+ * present javac reports "reference to inSpan is ambiguous", for non-throwing and throwing lambdas alike.
+ * Replacing costs callers nothing — a body that throws no checked exception infers {@code E =
+ * RuntimeException}, so an ordinary call site needs neither a {@code throws} clause nor a {@code catch}.</p>
+ *
+ * @author onur
+ */
+@FunctionalInterface
+public interface ThrowingSupplier<T, E extends Exception> {
+
+    T get() throws E;
+
+}

--- a/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/trace/TraceAttributes.java
+++ b/container-opentelemetry/src/main/java/ai/vespa/telemetry/api/trace/TraceAttributes.java
@@ -1,0 +1,117 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.telemetry.api.trace;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+/**
+ * The attribute vocabulary of Vespa-internal spans: every key is declared here once, so a name is never
+ * spelled twice and the whole emitted vocabulary can be reviewed in one place — which is what makes
+ * cardinality and privacy reviewable at all.
+ *
+ * <p>Keys are pre-allocated. {@link io.opentelemetry.api.trace.Span#setAttribute} has String-keyed
+ * overloads, but each call would build a fresh {@link AttributeKey}.</p>
+ *
+ * <p>NEVER declare a key that carries user content — query text, YQL, document ids or hit contents.</p>
+ *
+ * @author onur
+ */
+public final class TraceAttributes {
+
+    private TraceAttributes() { }
+
+    /** Id of the search chain being executed, e.g. "default". */
+    public static final AttributeKey<String> SEARCH_CHAIN = AttributeKey.stringKey("vespa.search.chain");
+
+    /** Rank profile the query resolves to; "default" when the query sets none. */
+    public static final AttributeKey<String> QUERY_RANK_PROFILE = AttributeKey.stringKey("vespa.query.rank_profile");
+
+    /** Component id of the searcher. */
+    public static final AttributeKey<String> SEARCHER_ID = AttributeKey.stringKey("vespa.searcher.id");
+
+    /** Implementation class of the searcher, which separates third-party searchers sharing an id pattern. */
+    public static final AttributeKey<String> SEARCHER_CLASS = AttributeKey.stringKey("vespa.searcher.class");
+
+    /** Summary class being filled. */
+    public static final AttributeKey<String> FILL_SUMMARY_CLASS = AttributeKey.stringKey("vespa.fill.summary_class");
+
+    /** Number of concrete hits the fill covers. */
+    public static final AttributeKey<Long> FILL_HITS = AttributeKey.longKey("vespa.fill.hits");
+
+    /** Hits that came back with no docsum after the first wave of docsum requests. Non-zero means the content
+     *  layer returned empty summaries, which is what a redistribution in progress looks like from here. */
+    public static final AttributeKey<Long> FILL_SKIPPED = AttributeKey.longKey("vespa.fill.skipped");
+
+    /** Whether the retry wave was sent. FALSE means it was considered and DECLINED by the retry limit, so those
+     *  docsums are lost for this query; ABSENT means no hit was ever missing and the question never arose. */
+    public static final AttributeKey<Boolean> FILL_RETRIED = AttributeKey.booleanKey("vespa.fill.retried");
+
+    /** How wide the retry fanned out. Vespa does not know which node now holds a moved document, so it asks
+     *  every other known node - this can be as large as the cluster. */
+    public static final AttributeKey<Long> FILL_RETRY_NODES = AttributeKey.longKey("vespa.fill.retry_nodes");
+
+    /** Hits still missing a docsum after the retry. */
+    public static final AttributeKey<Long> FILL_UNFILLED = AttributeKey.longKey("vespa.fill.unfilled");
+
+    /** Whether one docsum request belongs to the retry wave rather than the first. */
+    public static final AttributeKey<Boolean> FILL_RETRY = AttributeKey.booleanKey("vespa.fill.retry");
+
+    /** How many content-cluster backends one fill asked. */
+    public static final AttributeKey<Long> FILL_BACKENDS = AttributeKey.longKey("vespa.fill.backends");
+
+    /** How many content nodes one dispatch of a fill fanned out to. Determined by which nodes own the surviving
+     *  hits, NOT by the cluster size - unlike the search side, where every node in the group is asked. */
+    public static final AttributeKey<Long> FILL_NODES = AttributeKey.longKey("vespa.fill.nodes");
+
+    /** Hits that actually got a docsum. Compare against {@link #FILL_HITS} to see a partial fill. */
+    public static final AttributeKey<Long> FILL_HITS_FILLED = AttributeKey.longKey("vespa.fill.hits_filled");
+
+    /** How many docsums one content node was asked for. */
+    public static final AttributeKey<Long> FILL_HITS_REQUESTED = AttributeKey.longKey("vespa.fill.hits_requested");
+
+    /** The single schema a dispatch is searching. One query can produce several concurrent dispatches — one per
+     *  schema, one per grouping pass — so without this their spans are indistinguishable. */
+    public static final AttributeKey<String> SCHEMA = AttributeKey.stringKey("vespa.schema");
+
+    /** Vespa error code of a failed operation, e.g. 12 for a timeout. */
+    public static final AttributeKey<Long> ERROR_CODE = AttributeKey.longKey("vespa.error_code");
+
+    /** The SHORT error message — a fixed literal per error code in every {@code ErrorMessage} factory
+     *  ("Timed out", "Backend communication error", …).
+     *
+     *  <p>NEVER the DETAILED message: that is the caller-supplied half, and
+     *  {@code VespaBackend:144} passes the request URI into it, which carries the query text.</p> */
+    public static final AttributeKey<String> ERROR_MESSAGE = AttributeKey.stringKey("vespa.error_message");
+
+    /** Name of the content cluster a dispatch is talking to. */
+    public static final AttributeKey<String> CONTENT_CLUSTER = AttributeKey.stringKey("vespa.content.cluster");
+
+    /** Distribution key of the content node — the identifier operators actually work with. */
+    public static final AttributeKey<Long> CONTENT_NODE_KEY = AttributeKey.longKey("vespa.content.node_key");
+
+    /** Host the content node runs on. */
+    public static final AttributeKey<String> CONTENT_NODE_HOST = AttributeKey.stringKey("vespa.content.node_host");
+
+    /** Which replica group of the cluster was queried. */
+    public static final AttributeKey<Long> CONTENT_GROUP = AttributeKey.longKey("vespa.content.group");
+
+    /** OpenTelemetry semantic convention: the RPC system in use. */
+    public static final AttributeKey<String> RPC_SYSTEM = AttributeKey.stringKey("rpc.system");
+
+    /** OpenTelemetry semantic convention: the RPC method invoked. Named with a KEY suffix only because
+     *  {@code RpcSearchInvoker} already has a private constant {@code RPC_METHOD} holding the method's VALUE,
+     *  and renaming existing code for the convenience of instrumentation is the wrong way round. */
+    public static final AttributeKey<String> RPC_METHOD_KEY = AttributeKey.stringKey("rpc.method");
+
+    /** Percentage of the corpus the result actually covers; below 100 means the query was degraded. */
+    public static final AttributeKey<Long> COVERAGE_PERCENTAGE = AttributeKey.longKey("vespa.coverage.percentage");
+
+    /** Nodes that answered. */
+    public static final AttributeKey<Long> COVERAGE_NODES = AttributeKey.longKey("vespa.coverage.nodes");
+
+    /** Nodes that were asked, whether or not they answered. */
+    public static final AttributeKey<Long> COVERAGE_NODES_TRIED = AttributeKey.longKey("vespa.coverage.nodes_tried");
+
+    /** Whether the result is degraded, by any cause — timeout, adaptive timeout, match phase or ANN timeout. */
+    public static final AttributeKey<Boolean> COVERAGE_DEGRADED = AttributeKey.booleanKey("vespa.coverage.degraded");
+
+}

--- a/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/NoopTelemetryTest.java
+++ b/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/NoopTelemetryTest.java
@@ -41,7 +41,7 @@ class NoopTelemetryTest {
     @Test
     void inSpan_still_runs_the_body_and_returns_its_value() {
         String result = NoopTelemetry.INSTANCE.tracer("scope")
-                .inSpan("x", SpanKind.INTERNAL, Context.root(), () -> "body-value");
+                .instrument("x", SpanKind.INTERNAL, Context.root(), () -> "body-value");
 
         assertEquals("body-value", result);
     }
@@ -52,7 +52,7 @@ class NoopTelemetryTest {
 
         IllegalStateException thrown = assertThrows(IllegalStateException.class,
                 () -> NoopTelemetry.INSTANCE.tracer("scope")
-                        .inSpan("x", SpanKind.INTERNAL, Context.root(), () -> { throw boom; }));
+                        .instrument("x", SpanKind.INTERNAL, Context.root(), () -> { throw boom; }));
 
         assertSame(boom, thrown);
     }

--- a/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/TelemetryTest.java
+++ b/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/TelemetryTest.java
@@ -1,0 +1,112 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.telemetry.api;
+
+import ai.vespa.telemetry.api.trace.ScopedTracer;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Exercises {@link Telemetry#store}/{@link Telemetry#from} — carrying the telemetry through an OpenTelemetry
+ * {@link Context}.
+ *
+ * @author onur
+ */
+class TelemetryTest {
+
+    /** A Telemetry that is not the no-op, so that store() does not short-circuit. */
+    private static final Telemetry TELEMETRY = new Telemetry() {
+        @Override public ScopedTracer tracer(String scope) { return NoopTelemetry.INSTANCE.tracer(scope); }
+        @Override public TextMapPropagator textMapPropagator() { return NoopTelemetry.INSTANCE.textMapPropagator(); }
+    };
+
+    @Test
+    void stored_telemetry_is_returned() {
+        Context context = Telemetry.store(Context.root(), TELEMETRY);
+
+        assertSame(TELEMETRY, Telemetry.from(context));
+    }
+
+    @Test
+    void an_empty_context_yields_the_noop_rather_than_null() {
+        Telemetry telemetry = Telemetry.from(Context.root());
+
+        assertNotNull(telemetry);
+        assertSame(NoopTelemetry.INSTANCE, telemetry);
+    }
+
+    @Test
+    void storing_the_noop_leaves_the_context_untouched() {
+        Context root = Context.root();
+
+        assertSame(root, Telemetry.store(root, NoopTelemetry.INSTANCE));
+    }
+
+    @Test
+    void storing_null_leaves_the_context_untouched() {
+        Context root = Context.root();
+
+        assertSame(root, Telemetry.store(root, null));
+    }
+
+    @Test
+    void store_does_not_mutate_the_context_it_was_given() {
+        Context root = Context.root();
+
+        Telemetry.store(root, TELEMETRY);
+
+        assertSame(NoopTelemetry.INSTANCE, Telemetry.from(root),
+                   "Context is immutable: store() must return a new context, never modify the original");
+    }
+
+    /**
+     * The load-bearing property: L1 hands us a context that already carries the SERVER span and the
+     * parent extracted from the incoming W3C headers. Storing telemetry must ADD to that context, never
+     * rebuild it — otherwise every trace silently loses its parent.
+     */
+    @Test
+    void store_preserves_everything_already_in_the_context() {
+        Span span = Span.wrap(SpanContext.create("0af7651916cd43dd8448eb211c80319c",
+                                                 "b7ad6b7169203331",
+                                                 TraceFlags.getSampled(),
+                                                 TraceState.getDefault()));
+        Context withSpan = Context.root().with(span);
+
+        Context withBoth = Telemetry.store(withSpan, TELEMETRY);
+
+        assertSame(TELEMETRY, Telemetry.from(withBoth));
+        assertSame(span, Span.fromContext(withBoth),
+                   "storing telemetry must not drop what the context already carried");
+    }
+
+    @Test
+    void from_rejects_a_null_context() {
+        assertThrows(NullPointerException.class, () -> Telemetry.from(null));
+    }
+
+    @Test
+    void store_rejects_a_null_context() {
+        assertThrows(NullPointerException.class, () -> Telemetry.store(null, TELEMETRY));
+    }
+
+    @Test
+    void telemetry_is_reachable_through_the_current_context() {
+        Context context = Telemetry.store(Context.root(), TELEMETRY);
+
+        try (Scope ignored = context.makeCurrent()) {
+            assertSame(TELEMETRY, Telemetry.from(Context.current()));
+        }
+
+        assertSame(NoopTelemetry.INSTANCE, Telemetry.from(Context.current()),
+                   "closing the scope must restore a context without telemetry");
+    }
+}

--- a/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/trace/OtelTracingTest.java
+++ b/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/trace/OtelTracingTest.java
@@ -1,0 +1,312 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.telemetry.api.trace;
+
+import ai.vespa.telemetry.api.NoopTelemetry;
+import ai.vespa.telemetry.api.Telemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the {@link OtelTracing} facade: spans get the default (or explicit) scope, parent under the
+ * context they are given, and become non-recording when the carried telemetry is absent.
+ *
+ * @author onur
+ */
+class OtelTracingTest {
+
+    private InMemorySpanExporter exporter;
+    private SdkTracerProvider tracerProvider;
+    private Telemetry telemetry;
+
+    @BeforeEach
+    void setUp() {
+        exporter = InMemorySpanExporter.create();
+        tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        telemetry = new Telemetry() {
+            @Override public ScopedTracer tracer(String scope) { return new ScopedTracer(tracerProvider.get(scope)); }
+            @Override public TextMapPropagator textMapPropagator() { return NoopTelemetry.INSTANCE.textMapPropagator(); }
+        };
+    }
+
+    @AfterEach
+    void tearDown() {
+        tracerProvider.close();
+    }
+
+    @Test
+    void startSpan_uses_the_default_scope() {
+        Context parent = Telemetry.store(Context.root(), telemetry);
+
+        OtelTracing.startSpan(parent, "handler X", SpanKind.INTERNAL).end();
+
+        SpanData data = onlySpan();
+        assertEquals("handler X", data.getName());
+        assertEquals(SpanKind.INTERNAL, data.getKind());
+        assertEquals(OtelTracing.DEFAULT_SCOPE, data.getInstrumentationScopeInfo().getName());
+    }
+
+    @Test
+    void startSpan_honours_an_explicit_scope() {
+        Context parent = Telemetry.store(Context.root(), telemetry);
+
+        OtelTracing.startSpan(parent, "custom.scope", "op", SpanKind.INTERNAL).end();
+
+        assertEquals("custom.scope", onlySpan().getInstrumentationScopeInfo().getName());
+    }
+
+    @Test
+    void startSpan_parents_under_the_span_carried_in_the_context() {
+        Span serverParent = telemetry.tracer(OtelTracing.DEFAULT_SCOPE).startSpan("server", SpanKind.SERVER, Context.root());
+        Context parent = Telemetry.store(Context.root().with(serverParent), telemetry);
+
+        OtelTracing.startSpan(parent, "handler X", SpanKind.INTERNAL).end();
+        serverParent.end();
+
+        assertEquals(serverParent.getSpanContext().getSpanId(), spanNamed("handler X").getParentSpanId());
+    }
+
+    @Test
+    void startSpan_without_telemetry_is_non_recording_and_exports_nothing() {
+        Span span = OtelTracing.startSpan(Context.root(), "handler X", SpanKind.INTERNAL);
+
+        assertFalse(span.isRecording());
+        span.end();
+        assertTrue(exporter.getFinishedSpanItems().isEmpty(), "no carried telemetry => nothing exported");
+    }
+
+    @Test
+    void ambient_tracer_reads_telemetry_from_the_current_context() {
+        Context ctx = Telemetry.store(Context.root(), telemetry);
+
+        try (Scope ignored = ctx.makeCurrent()) {
+            OtelTracing.tracer().startSpan("ambient", SpanKind.INTERNAL, Context.current()).end();
+        }
+
+        assertEquals(OtelTracing.DEFAULT_SCOPE, onlySpan().getInstrumentationScopeInfo().getName());
+    }
+
+    @Test
+    void ambient_tracer_without_a_current_context_is_noop() {
+        Span span = OtelTracing.tracer().startSpan("orphan", SpanKind.INTERNAL, Context.current());
+
+        assertFalse(span.isRecording());
+        span.end();
+        assertTrue(exporter.getFinishedSpanItems().isEmpty());
+    }
+
+    @Test
+    void inSpan_runs_the_body_in_an_internal_default_scope_span_parented_under_the_carried_span() {
+        Span serverParent = telemetry.tracer(OtelTracing.DEFAULT_SCOPE).startSpan("server", SpanKind.SERVER, Context.root());
+        Context parent = Telemetry.store(Context.root().with(serverParent), telemetry);
+        AtomicReference<Span> current = new AtomicReference<>();
+
+        OtelTracing.instrument(parent, "handler X", () -> current.set(Span.current()));
+        serverParent.end();
+
+        SpanData data = spanNamed("handler X");
+        assertEquals(SpanKind.INTERNAL, data.getKind());
+        assertEquals(OtelTracing.DEFAULT_SCOPE, data.getInstrumentationScopeInfo().getName());
+        assertEquals(serverParent.getSpanContext().getSpanId(), data.getParentSpanId());
+        assertEquals(data.getSpanId(), current.get().getSpanContext().getSpanId(),
+                     "the span must be current during the body");
+        assertTrue(data.hasEnded());
+    }
+
+    @Test
+    void inSpan_without_telemetry_still_runs_the_body_and_exports_nothing() {
+        AtomicReference<Boolean> ran = new AtomicReference<>(false);
+
+        OtelTracing.instrument(Context.root(), "handler X", () -> ran.set(true));
+
+        assertTrue(ran.get(), "the body must run even with no telemetry");
+        assertTrue(exporter.getFinishedSpanItems().isEmpty(), "no carried telemetry => nothing exported");
+    }
+
+    @Test
+    void inSpan_supplier_returns_the_body_value_and_ends_a_recording_span() {
+        Context parent = Telemetry.store(Context.root(), telemetry);
+
+        String result = OtelTracing.instrument(parent, "chain default", () -> "body-value");
+
+        assertEquals("body-value", result);
+        SpanData data = onlySpan();
+        assertEquals("chain default", data.getName());
+        assertEquals(SpanKind.INTERNAL, data.getKind());
+        assertEquals(OtelTracing.DEFAULT_SCOPE, data.getInstrumentationScopeInfo().getName());
+        assertTrue(data.hasEnded());
+    }
+
+    @Test
+    void inSpan_supplier_without_telemetry_still_returns_the_body_value() {
+        String result = OtelTracing.instrument(Context.root(), "chain X", () -> "body-value");
+
+        assertEquals("body-value", result);
+        assertTrue(exporter.getFinishedSpanItems().isEmpty(), "no carried telemetry => nothing exported");
+    }
+
+    @Test
+    void ambient_inSpan_reads_the_current_context_and_returns_the_body_value() {
+        Context ctx = Telemetry.store(Context.root(), telemetry);
+
+        String result;
+        try (Scope ignored = ctx.makeCurrent()) {
+            result = OtelTracing.instrument("chain X", () -> "body-value");
+        }
+
+        assertEquals("body-value", result);
+        SpanData data = onlySpan();
+        assertEquals("chain X", data.getName());
+        assertEquals(SpanKind.INTERNAL, data.getKind());
+        assertEquals(OtelTracing.DEFAULT_SCOPE, data.getInstrumentationScopeInfo().getName());
+    }
+
+    @Test
+    void inSpan_propagates_a_checked_exception_and_marks_the_span_error() {
+        Context parent = Telemetry.store(Context.root(), telemetry);
+
+        IOException thrown = assertThrows(IOException.class,
+                                          () -> OtelTracing.instrument(parent, "dispatch.search", () -> { throw new IOException("boom"); }));
+
+        assertEquals("boom", thrown.getMessage());
+        SpanData data = onlySpan();
+        assertEquals(StatusCode.ERROR, data.getStatus().getStatusCode());
+        assertEquals(1, data.getEvents().size(), "the checked exception must be recorded on the span");
+        assertTrue(data.hasEnded());
+    }
+
+    @Test
+    void a_body_throwing_nothing_needs_no_throws_clause_at_the_call_site() {
+        // This test is really a COMPILE-time assertion: E infers to RuntimeException, so replacing the
+        // Supplier overload with ThrowingSupplier left every existing call site unchanged.
+        Context parent = Telemetry.store(Context.root(), telemetry);
+
+        assertEquals("value", OtelTracing.instrument(parent, "chain X", () -> "value"));
+    }
+
+    @Test
+    void withCurrentContext_restores_the_forking_threads_context_on_the_receiving_thread() throws Exception {
+        Context ctx = Telemetry.store(Context.root(), telemetry);
+        Span outer = OtelTracing.startSpan(ctx, "outer", SpanKind.INTERNAL);
+        AtomicReference<String> seenSpanId = new AtomicReference<>();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            try (Scope ignored = ctx.with(outer).makeCurrent()) {
+                executor.submit(OtelTracing.withCurrentContext(() -> seenSpanId.set(Span.current().getSpanContext().getSpanId()))).get();
+            }
+        } finally {
+            shutdown(executor);
+        }
+        outer.end();
+
+        assertEquals(outer.getSpanContext().getSpanId(), seenSpanId.get(),
+                     "the task must run under the span that was current when it was submitted");
+    }
+
+    @Test
+    void a_task_submitted_directly_sees_no_context_on_the_receiving_thread() throws Exception {
+        Context ctx = Telemetry.store(Context.root(), telemetry);
+        Span outer = OtelTracing.startSpan(ctx, "outer", SpanKind.INTERNAL);
+        AtomicReference<Context> seen = new AtomicReference<>();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            try (Scope ignored = ctx.with(outer).makeCurrent()) {
+                executor.submit(() -> seen.set(Context.current())).get();
+            }
+        } finally {
+            shutdown(executor);
+        }
+        outer.end();
+
+        // The control for the test above: the OpenTelemetry context is a plain, non-inheritable ThreadLocal,
+        // so without withCurrentContext() nothing crosses the thread boundary. This is the condition L4 exists to fix.
+        assertFalse(Span.fromContext(seen.get()).getSpanContext().isValid(),
+                    "a task submitted directly must see no span, otherwise this test proves nothing about withCurrentContext()");
+    }
+
+    @Test
+    void a_span_created_inside_a_context_propagating_task_parents_to_the_forking_span() throws Exception {
+        Context ctx = Telemetry.store(Context.root(), telemetry);
+        Span outer = OtelTracing.startSpan(ctx, "outer", SpanKind.INTERNAL);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            try (Scope ignored = ctx.with(outer).makeCurrent()) {
+                executor.submit(OtelTracing.withCurrentContext(() -> OtelTracing.instrument("forked", () -> { }))).get();
+            }
+        } finally {
+            shutdown(executor);
+        }
+        outer.end();
+
+        SpanData forked = spanNamed("forked");
+        assertEquals(outer.getSpanContext().getSpanId(), forked.getParentSpanId(),
+                     "a span created on the receiving thread must be a child of the forking span");
+        assertEquals(outer.getSpanContext().getTraceId(), forked.getTraceId(), "and stay in the same trace");
+    }
+
+    @Test
+    void a_context_propagating_task_does_not_leak_context_into_the_next_task_on_that_thread() throws Exception {
+        Context ctx = Telemetry.store(Context.root(), telemetry);
+        Span outer = OtelTracing.startSpan(ctx, "outer", SpanKind.INTERNAL);
+        AtomicReference<Context> afterwards = new AtomicReference<>();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();   // single thread: the same one runs both
+        try {
+            try (Scope ignored = ctx.with(outer).makeCurrent()) {
+                executor.submit(OtelTracing.withCurrentContext(() -> { })).get();
+            }
+            executor.submit(() -> afterwards.set(Context.current())).get();
+        } finally {
+            shutdown(executor);
+        }
+        outer.end();
+
+        assertFalse(Span.fromContext(afterwards.get()).getSpanContext().isValid(),
+                    "withCurrentContext() must close its scope, leaving the pooled thread clean for an unrelated later task");
+    }
+
+    private static void shutdown(ExecutorService executor) throws InterruptedException {
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS), "executor did not terminate");
+    }
+
+    private SpanData onlySpan() {
+        List<SpanData> spans = exporter.getFinishedSpanItems();
+        assertEquals(1, spans.size(), "expected exactly one span, got " + spans);
+        return spans.get(0);
+    }
+
+    private SpanData spanNamed(String name) {
+        return exporter.getFinishedSpanItems().stream()
+                .filter(s -> s.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no span named " + name));
+    }
+}

--- a/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/trace/ScopedTracerTest.java
+++ b/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/trace/ScopedTracerTest.java
@@ -5,6 +5,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -47,8 +48,8 @@ class ScopedTracerTest {
     }
 
     @Test
-    void inSpan_returns_body_value_and_ends_span_without_error_status() {
-        String result = tracer.inSpan("success", SpanKind.INTERNAL, Context.root(), () -> "body-value");
+    void instrument_returns_body_value_and_ends_span_without_error_status() {
+        String result = tracer.instrument("success", SpanKind.INTERNAL, Context.root(), () -> "body-value");
 
         assertEquals("body-value", result);
         SpanData span = onlySpan();
@@ -60,19 +61,19 @@ class ScopedTracerTest {
     }
 
     @Test
-    void inSpan_makes_the_span_current_for_the_body() {
+    void instrument_makes_the_span_current_for_the_body() {
         AtomicReference<Span> seen = new AtomicReference<>();
-        tracer.inSpan("current", SpanKind.INTERNAL, Context.root(), () -> seen.set(Span.current()));
+        tracer.instrument("current", SpanKind.INTERNAL, Context.root(), () -> seen.set(Span.current()));
 
         assertEquals(onlySpan().getSpanId(), seen.get().getSpanContext().getSpanId());
     }
 
     @Test
-    void inSpan_records_exception_sets_error_status_ends_span_and_propagates() {
+    void instrument_records_exception_sets_error_status_ends_span_and_propagates() {
         IllegalStateException boom = new IllegalStateException("boom");
 
         IllegalStateException thrown = assertThrows(IllegalStateException.class,
-                () -> tracer.inSpan("failing", SpanKind.INTERNAL, Context.root(), () -> { throw boom; }));
+                () -> tracer.instrument("failing", SpanKind.INTERNAL, Context.root(), () -> { throw boom; }));
 
         assertSame(boom, thrown);
         SpanData span = onlySpan();
@@ -84,9 +85,9 @@ class ScopedTracerTest {
     }
 
     @Test
-    void inSpan_runnable_overload_runs_body_and_ends_span() {
+    void instrument_runnable_form_runs_body_and_ends_span() {
         AtomicReference<String> ran = new AtomicReference<>();
-        tracer.inSpan("runnable", SpanKind.INTERNAL, Context.root(), (Runnable) () -> ran.set("ran"));
+        tracer.instrument("runnable", SpanKind.INTERNAL, Context.root(), () -> ran.set("ran"));
 
         assertEquals("ran", ran.get());
         SpanData span = onlySpan();
@@ -148,6 +149,29 @@ class ScopedTracerTest {
     @Test
     void otelTracer_returns_the_underlying_tracer() {
         assertSame(tracer.otelTracer(), tracer.otelTracer());
+    }
+
+    @Test
+    void startSpan_never_throws_and_returns_a_non_recording_span_when_creation_fails() {
+        ScopedTracer failing = new ScopedTracer(name -> { throw new RuntimeException("boom"); });
+
+        Span span = failing.startSpan("x", SpanKind.INTERNAL, Context.root());
+
+        assertFalse(span.getSpanContext().isValid(), "a failed span creation must yield an invalid span");
+        assertFalse(span.isRecording());
+        span.end();   // must be a safe no-op
+    }
+
+    @Test
+    void instrument_still_runs_the_body_when_span_creation_fails() {
+        ScopedTracer failing = new ScopedTracer(name -> { throw new RuntimeException("boom"); });
+        AtomicReference<String> ran = new AtomicReference<>();
+
+        String result = failing.instrument("x", SpanKind.INTERNAL, Context.root(),
+                                       () -> { ran.set("ran"); return "body-value"; });
+
+        assertEquals("ran", ran.get(), "instrumentation failure must not skip the body");
+        assertEquals("body-value", result);
     }
 
     private SpanData onlySpan() {

--- a/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/trace/TraceAttributesTest.java
+++ b/container-opentelemetry/src/test/java/ai/vespa/telemetry/api/trace/TraceAttributesTest.java
@@ -1,0 +1,61 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.telemetry.api.trace;
+
+import io.opentelemetry.api.common.AttributeType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Pins the emitted attribute names. This is deliberate: once traces are queried, an attribute name is as much
+ * an interface as a method signature, and renaming one silently breaks dashboards without breaking a build.
+ *
+ * <p>This class is pure vocabulary. Attributes are set with OpenTelemetry's own {@code Span.setAttribute}
+ * at the span sites; there is no Vespa wrapper for it.</p>
+ *
+ * @author onur
+ */
+class TraceAttributesTest {
+
+    @Test
+    void attribute_names_and_types_are_pinned() {
+        assertEquals("vespa.search.chain", TraceAttributes.SEARCH_CHAIN.getKey());
+        assertEquals("vespa.query.rank_profile", TraceAttributes.QUERY_RANK_PROFILE.getKey());
+        assertEquals("vespa.searcher.id", TraceAttributes.SEARCHER_ID.getKey());
+        assertEquals("vespa.searcher.class", TraceAttributes.SEARCHER_CLASS.getKey());
+        assertEquals("vespa.fill.summary_class", TraceAttributes.FILL_SUMMARY_CLASS.getKey());
+        assertEquals("vespa.fill.hits", TraceAttributes.FILL_HITS.getKey());
+        assertEquals("vespa.fill.skipped", TraceAttributes.FILL_SKIPPED.getKey());
+        assertEquals("vespa.fill.retried", TraceAttributes.FILL_RETRIED.getKey());
+        assertEquals("vespa.fill.retry_nodes", TraceAttributes.FILL_RETRY_NODES.getKey());
+        assertEquals("vespa.fill.unfilled", TraceAttributes.FILL_UNFILLED.getKey());
+        assertEquals("vespa.fill.retry", TraceAttributes.FILL_RETRY.getKey());
+        assertEquals("vespa.fill.backends", TraceAttributes.FILL_BACKENDS.getKey());
+        assertEquals("vespa.fill.nodes", TraceAttributes.FILL_NODES.getKey());
+        assertEquals("vespa.fill.hits_filled", TraceAttributes.FILL_HITS_FILLED.getKey());
+        assertEquals("vespa.fill.hits_requested", TraceAttributes.FILL_HITS_REQUESTED.getKey());
+        assertEquals("vespa.schema", TraceAttributes.SCHEMA.getKey());
+        assertEquals("vespa.error_code", TraceAttributes.ERROR_CODE.getKey());
+        assertEquals("vespa.error_message", TraceAttributes.ERROR_MESSAGE.getKey());
+        assertEquals("vespa.content.cluster", TraceAttributes.CONTENT_CLUSTER.getKey());
+        assertEquals("vespa.content.node_key", TraceAttributes.CONTENT_NODE_KEY.getKey());
+        assertEquals("vespa.content.node_host", TraceAttributes.CONTENT_NODE_HOST.getKey());
+        assertEquals("vespa.content.group", TraceAttributes.CONTENT_GROUP.getKey());
+        assertEquals("vespa.coverage.percentage", TraceAttributes.COVERAGE_PERCENTAGE.getKey());
+        assertEquals("vespa.coverage.nodes", TraceAttributes.COVERAGE_NODES.getKey());
+        assertEquals("vespa.coverage.nodes_tried", TraceAttributes.COVERAGE_NODES_TRIED.getKey());
+        assertEquals("vespa.coverage.degraded", TraceAttributes.COVERAGE_DEGRADED.getKey());
+
+        // OpenTelemetry semantic-convention names: deliberately NOT under vespa.*
+        assertEquals("rpc.system", TraceAttributes.RPC_SYSTEM.getKey());
+        assertEquals("rpc.method", TraceAttributes.RPC_METHOD_KEY.getKey());
+
+        assertEquals(AttributeType.STRING, TraceAttributes.SEARCH_CHAIN.getType());
+        assertEquals(AttributeType.LONG, TraceAttributes.FILL_HITS.getType());
+        assertEquals(AttributeType.LONG, TraceAttributes.ERROR_CODE.getType());
+        assertEquals(AttributeType.LONG, TraceAttributes.CONTENT_NODE_KEY.getType());
+        assertEquals(AttributeType.BOOLEAN, TraceAttributes.COVERAGE_DEGRADED.getType());
+        assertEquals(AttributeType.BOOLEAN, TraceAttributes.FILL_RETRY.getType());
+        assertEquals(AttributeType.LONG, TraceAttributes.FILL_RETRY_NODES.getType());
+    }
+}

--- a/container-search-and-docproc/pom.xml
+++ b/container-search-and-docproc/pom.xml
@@ -234,6 +234,21 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- OpenTelemetry, also declared in container-search and NOT duplication: the bundle-plugin reads only
+         THIS module's provided dependencies when generating Import-Package, so removing these two silently
+         ships a bundle with no OTel imports and fails at the first span. Do not remove as redundant. -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>container-opentelemetry</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- TEST scope -->
     <dependency>
       <groupId>junit</groupId>

--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -83,6 +83,27 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- OpenTelemetry API only (Span, SpanKind, Context); provided at runtime by the container-opentelemetry bundle. -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Telemetry seam (Telemetry/ScopedTracer); must stay provided, as compile scope would break config-model-fat. -->
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>container-opentelemetry</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- InMemorySpanExporter + SdkTracerProvider for asserting on emitted spans in tests (also pulls in the SDK);
+         version managed by the opentelemetry-bom. -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>

--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.cluster;
 
+import ai.vespa.telemetry.api.trace.OtelTracing;
+import ai.vespa.telemetry.api.trace.TraceAttributes;
 import com.yahoo.collections.TinyIdentitySet;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.component.ComponentId;
@@ -28,6 +30,7 @@ import com.yahoo.search.schema.Cluster;
 import com.yahoo.search.schema.Schema;
 import com.yahoo.search.schema.SchemaInfo;
 import com.yahoo.search.searchchain.Execution;
+import io.opentelemetry.api.trace.Span;
 import com.yahoo.vespa.streamingvisitors.StreamingBackend;
 import com.yahoo.yolean.Exceptions;
 
@@ -49,6 +52,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
+
 
 /**
  * A searcher which forwards to a cluster of monitored native Vespa backends.
@@ -182,22 +186,36 @@ public class ClusterSearcher extends Searcher {
                     .collect(Collectors.toCollection(TinyIdentitySet::new))
                 : schema2Searcher.values().stream().collect(Collectors.toCollection(TinyIdentitySet::new));
 
-        if ( ! servers.isEmpty() ) {
-            for (var server : servers) {
-                if (query.getTimeLeft() > 0) {
-                    server.fill(result, summaryClass);
-                } else {
-                    if (result.hits().getErrorHit() == null) {
-                        result.hits().addError(ErrorMessage.createTimeout("No time left to get summaries, query timeout was " +
-                                                                          query.getTimeout() + " ms"));
+        // The top of the fill side of the dispatch layer, and the counterpart of dispatch.search: this is the
+        // level at which "a fill happened against this content cluster" is true, and it is the span the
+        // per-invoker and per-node fill spans hang under. The error branches are covered deliberately - a fill
+        // that produced nothing but a timeout still took time, and is the case worth seeing in a trace.
+        OtelTracing.instrument("cluster.fill", () -> {
+            // Set before any work, so a fill that finds no backend in service is still attributable to a
+            // cluster and a summary class rather than being an anonymous failed span. No vespa.schema here:
+            // the restrict can hold several, and dispatch.fill below carries the precise one per partition.
+            Span.current()
+                .setAttribute(TraceAttributes.CONTENT_CLUSTER,    searchClusterName)
+                .setAttribute(TraceAttributes.FILL_SUMMARY_CLASS, summaryClass)
+                .setAttribute(TraceAttributes.FILL_BACKENDS,      servers.size());
+
+            if ( ! servers.isEmpty() ) {
+                for (var server : servers) {
+                    if (query.getTimeLeft() > 0) {
+                        server.fill(result, summaryClass);
+                    } else {
+                        if (result.hits().getErrorHit() == null) {
+                            result.hits().addError(ErrorMessage.createTimeout("No time left to get summaries, query timeout was " +
+                                                                              query.getTimeout() + " ms"));
+                        }
                     }
                 }
+            } else {
+                if (result.hits().getErrorHit() == null) {
+                    result.hits().addError(ErrorMessage.createNoBackendsInService("Could not fill result"));
+                }
             }
-        } else {
-            if (result.hits().getErrorHit() == null) {
-                result.hits().addError(ErrorMessage.createNoBackendsInService("Could not fill result"));
-            }
-        }
+        });
     }
 
     private void validateQueryTimeout(Query query) {
@@ -351,7 +369,10 @@ public class ClusterSearcher extends Searcher {
             for (var entry : schemaQueries.entrySet()) {
                 FutureTask<Result> task = new FutureTask<>(() -> perSchemaSearch(entry.getKey(), entry.getValue()));
                 try {
-                    executor.execute(task);
+                    // Carry the trace context onto the pool thread: the dispatch and per-node spans created
+                    // below perSchemaSearch would otherwise see no context and never be exported. The rejection
+                    // path below runs on this thread, where the context is already current, and needs nothing.
+                    executor.execute(OtelTracing.withCurrentContext(task));
                     pending.add(task);
                 } catch (RejectedExecutionException rej) {
                     task.run();

--- a/container-search/src/main/java/com/yahoo/search/Searcher.java
+++ b/container-search/src/main/java/com/yahoo/search/Searcher.java
@@ -1,13 +1,17 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search;
 
+import ai.vespa.telemetry.api.trace.OtelTracing;
+import ai.vespa.telemetry.api.trace.TraceAttributes;
 import com.yahoo.component.ComponentId;
 import com.yahoo.prelude.fastsearch.PartialSummaryHandler;
 import com.yahoo.processing.Processor;
 import com.yahoo.processing.Response;
 import com.yahoo.search.searchchain.Execution;
+import io.opentelemetry.api.trace.Span;
 
 import java.util.logging.Logger;
+
 
 /**
  * Superclass of all {@link com.yahoo.component.Component Components} which produces Results in response to
@@ -132,7 +136,16 @@ public abstract class Searcher extends Processor {
     /** Use the search method in Searcher processors. This forwards to it. */
     @Override
     public final Response process(com.yahoo.processing.Request request, com.yahoo.processing.execution.Execution execution) {
-        return search((Query)request, (Execution)execution);
+        return OtelTracing.instrument("searcher.search", () -> {
+            // The span name is fixed, so these attributes are the ONLY thing telling one searcher's span from the
+            // next one's: a chain nests them, and every one of them is named "searcher.search".
+            // stringValue() is the precomputed canonical form; getIdString() would render via ComponentId.toString(),
+            // which spells a namespace as " in ns" rather than "@ns".
+            Span.current()
+                .setAttribute(TraceAttributes.SEARCHER_ID,    getId().stringValue())
+                .setAttribute(TraceAttributes.SEARCHER_CLASS, getClass().getName());
+            return search((Query)request, (Execution)execution);
+        });
     }
 
     /**
@@ -172,7 +185,22 @@ public abstract class Searcher extends Processor {
             int fillStartTraceAt = 6;
             if (result.getQuery().getTrace().getLevel() >= fillStartTraceAt)
                 result.getQuery().trace("Hits need fill(" + summaryClass + "); hasFilled=" + hasFilled + " in " + this.getClass(), fillStartTraceAt);
-            fill(result, summaryClass, execution);
+
+            String sc = summaryClass;   // summaryClass is reassigned above, so capture a final copy for the lambda
+            OtelTracing.instrument("searcher.ensureFilled", () -> {
+                Span span = Span.current();
+                // The fill call walks the whole chain - fill() below dispatches to the next searcher unless this
+                // one overrides it - so these spans nest one per searcher, all under the same fixed name. As on
+                // the search span, the searcher identity is what tells them apart.
+                span.setAttribute(TraceAttributes.SEARCHER_ID,        getId().stringValue())
+                    .setAttribute(TraceAttributes.SEARCHER_CLASS,     getClass().getName())
+                    .setAttribute(TraceAttributes.FILL_SUMMARY_CLASS, sc);
+                // Guarded because it is the one attribute whose value is not a field read: getConcreteSize
+                // walks the whole hit tree when the result has subgroups, as grouping results do.
+                if (span.isRecording())
+                    span.setAttribute(TraceAttributes.FILL_HITS, result.hits().getConcreteSize());
+                fill(result, sc, execution);
+            });
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/FillInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/FillInvoker.java
@@ -1,7 +1,13 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch;
 
+import ai.vespa.telemetry.api.trace.OtelTracing;
+import ai.vespa.telemetry.api.trace.TraceAttributes;
 import com.yahoo.search.Result;
+import com.yahoo.search.result.ErrorMessage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+
 
 /**
  * FillInvoker encapsulates an allocated connection for running a document summary retrieval.
@@ -13,8 +19,26 @@ public abstract class FillInvoker extends CloseableInvoker {
 
     /** Retrieves document summaries for the unfilled hits in the given {@link Result} */
     public void fill(Result result, String summaryClass) {
-        sendFillRequest(result, summaryClass);
-        getFillResults(result, summaryClass);
+        OtelTracing.instrument("dispatch.fill", () -> {
+            sendFillRequest(result, summaryClass);
+            getFillResults(result, summaryClass);
+
+            // Fill failures are RETURNED, not thrown: every failure path in RpcProtobufFillInvoker adds an
+            // ErrorMessage to the result and returns normally, so inSpan's own catch never sees them and the
+            // span would be reported as successful. This result is the partition Result built fresh in
+            // VespaBackend.partitionHits, so an error on it can only have come from this fill.
+            //
+            // Only the SHORT message is used. The detailed half is caller-supplied and can carry the request
+            // URI, and with it the query text, which must never reach a span.
+            //
+            // Deliberately NOT setFinalStatus(): unlike SearchInvoker.search, this method never reported one,
+            // and adding tracing must not change what the teardown callback records.
+            ErrorMessage error = result.hits().getError();
+            if (error != null)
+                Span.current().setStatus(StatusCode.ERROR)
+                              .setAttribute(TraceAttributes.ERROR_CODE, error.getCode())
+                              .setAttribute(TraceAttributes.ERROR_MESSAGE, error.getMessage());
+        });
     }
 
     protected abstract void getFillResults(Result result, String summaryClass);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/SearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/SearchInvoker.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch;
 
+import ai.vespa.telemetry.api.trace.OtelTracing;
+import ai.vespa.telemetry.api.trace.TraceAttributes;
 import com.yahoo.prelude.cluster.ClusterSearcher;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -8,9 +10,13 @@ import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.result.Coverage;
 import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.searchchain.Execution;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.Set;
+
 
 /**
  * SearchInvoker encapsulates an allocated connection for running a single search query.
@@ -33,11 +39,40 @@ public abstract class SearchInvoker extends CloseableInvoker {
      * for correct result windowing.
      */
     public Result search(Query query, double contentShare) throws IOException {
-        sendSearchRequest(query, contentShare, null);
-        InvokerResult result = getSearchResult();
-        setFinalStatus(result.getResult().hits().getError() == null);
-        result.complete();
-        return result.getResult();
+        return OtelTracing.instrument("dispatch.search", () -> {
+            // Set before any work, so a dispatch that fails on send is still attributable to its schema.
+            Span.current().setAttribute(TraceAttributes.SCHEMA, schemaOf(query));
+
+            sendSearchRequest(query, contentShare, null);
+            InvokerResult result = getSearchResult();
+
+            // Dispatch failures are RETURNED, not thrown — errorResult below, and every early return in
+            // RpcSearchInvoker, builds a Result carrying an ErrorMessage. inSpan's own catch therefore never
+            // sees them, and the span would be reported as successful unless we record the outcome here.
+            ErrorMessage error = result.getResult().hits().getError();
+            setFinalStatus(error == null);
+            if (error != null)
+                Span.current().setStatus(StatusCode.ERROR)
+                              .setAttribute(TraceAttributes.ERROR_CODE, error.getCode())
+                              .setAttribute(TraceAttributes.ERROR_MESSAGE, error.getMessage());
+
+            // false: null when there is no coverage, so we set nothing rather than report a misleading zero.
+            Coverage coverage = result.getResult().getCoverage(false);
+            if (coverage != null)
+                Span.current().setAttribute(TraceAttributes.COVERAGE_PERCENTAGE,  coverage.getResultPercentage())
+                              .setAttribute(TraceAttributes.COVERAGE_NODES,       coverage.getNodes())
+                              .setAttribute(TraceAttributes.COVERAGE_NODES_TRIED, coverage.getNodesTried())
+                              .setAttribute(TraceAttributes.COVERAGE_DEGRADED,    coverage.isDegraded());
+
+            result.complete();
+            return result.getResult();
+        });
+    }
+
+    /** The one schema this dispatch searches; perSchemaSearch guarantees exactly one entry on this path. */
+    private static String schemaOf(Query query) {
+        Set<String> restrict = query.getModel().getRestrict();
+        return restrict != null && restrict.size() == 1 ? restrict.iterator().next() : null;
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
@@ -2,6 +2,8 @@
 package com.yahoo.search.dispatch.rpc;
 
 import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
+import ai.vespa.telemetry.api.trace.TraceAttributes;
+import ai.vespa.telemetry.api.trace.OtelTracing;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.yahoo.collections.ListMap;
 import com.yahoo.compress.Compressor;
@@ -23,6 +25,10 @@ import com.yahoo.search.result.Hit;
 import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.BinaryFormat;
 import com.yahoo.slime.BinaryView;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 
 /**
  * {@link FillInvoker} implementation using Protobuf over JRT
@@ -95,6 +102,14 @@ public class RpcProtobufFillInvoker extends FillInvoker {
             return;
         }
         ListMap<Integer, FastHit> hitsByNode = hitsByNode(result);
+
+        // Span.current() is dispatch.fill, created by FillInvoker.fill one frame up. Set from here rather than
+        // from the base class because FillInvoker has no fields at all - none of these values exist there.
+        // numHitsToFill was just counted by hitsByNode() above.
+        Span.current().setAttribute(TraceAttributes.SCHEMA,     soleSchemaOf(result.getQuery()))
+                      .setAttribute(TraceAttributes.FILL_NODES, hitsByNode.size())
+                      .setAttribute(TraceAttributes.FILL_HITS,  numHitsToFill);
+
         int queueSize = Math.max(hitsByNode.size(), resourcePool.knownNodeIds().size());
         responses = new LinkedBlockingQueue<>(queueSize);
         sendFillRequestByNode(result, summaryClass, hitsByNode);
@@ -146,6 +161,9 @@ public class RpcProtobufFillInvoker extends FillInvoker {
         } catch (TimeoutException e) {
             result.hits().addError(ErrorMessage.createTimeout("Summary data is incomplete: " + e.getMessage()));
         }
+        // After the catch, so a fill that timed out still reports how much it did manage to fetch - which is
+        // the number that says whether a slow fill was partial or total.
+        Span.current().setAttribute(TraceAttributes.FILL_HITS_FILLED, numOkFilledHits);
     }
 
     @Override
@@ -175,6 +193,8 @@ public class RpcProtobufFillInvoker extends FillInvoker {
                                     double clientTimeout) {
         Client.NodeConnection node = resourcePool.getConnection(nodeId);
         if (node == null) {
+            // No span: nothing goes out on the wire here, and node.fill is a CLIENT span, which by
+            // OpenTelemetry's definition represents an outbound request that was actually made.
             String error = "Could not fill hits from unknown node " + nodeId;
             receive(Client.ResponseOrError.fromError(error), hits);
             result.hits().addError(ErrorMessage.createEmptyDocsums(error));
@@ -183,8 +203,33 @@ public class RpcProtobufFillInvoker extends FillInvoker {
         }
         Query query = result.getQuery();
         Compressor.Compression compressionResult = compressor.compress(query, payload);
+
+        Span span = OtelTracing.startSpan(Context.current(), "node.fill", SpanKind.CLIENT);
+        // Every value is a parameter or a constant, so no isRecording() guard is warranted. There is no
+        // cluster, host or group here: the fill path carries only an integer node id, with no Node object -
+        // the enclosing cluster.fill span names the cluster.
+        span.setAttribute(TraceAttributes.CONTENT_NODE_KEY,    nodeId)
+            .setAttribute(TraceAttributes.RPC_SYSTEM,          "vespa_jrt")
+            .setAttribute(TraceAttributes.RPC_METHOD_KEY,      RPC_METHOD)
+            .setAttribute(TraceAttributes.FILL_HITS_REQUESTED, hits.size())
+            .setAttribute(TraceAttributes.FILL_RETRY,          hits.get(0).getDistributionKey() != nodeId);
+        
+        // End BEFORE enqueueing, as RpcSearchInvoker.receive does, so the same statement holds on both paths:
+        // the caller thread can never observe a response whose span is still recording. It also keeps the span
+        // ending even if receive() throws - responses is a BOUNDED queue and uses add(), which throws when full.
         node.request(RPC_METHOD, compressionResult.type(), payload.length, compressionResult.data(),
-                roe -> receive(roe, hits), clientTimeout);
+                roe -> { endSpan(span, roe); receive(roe, hits); }, clientTimeout);
+    }
+
+    /**
+     * Ends one node.fill span with the outcome the transport reported. Runs on a JRT transport thread, which is
+     * why it touches nothing but the span: {@code receive} below it only enqueues, and all decoding happens
+     * later on the caller thread.
+     */
+    private static void endSpan(Span span, Client.ResponseOrError<ProtobufResponse> response) {
+        if ( ! span.isRecording()) return;
+        response.error().ifPresent(error -> span.setStatus(StatusCode.ERROR, error));
+        span.end();
     }
 
     private ResponseAndHits getNextResponse(long timeLeftMs) throws InterruptedException {
@@ -298,6 +343,18 @@ public class RpcProtobufFillInvoker extends FillInvoker {
         return List.of();
     }
 
+    /**
+     * The one schema this fill is restricted to, or null when it spans several or none.
+     *
+     * <p>Read from the query rather than from the {@code documentDb} field, even though the invoker holds one:
+     * {@code VespaBackend.getDocumentDatabase:123-130} falls back to the FIRST configured database when the
+     * restrict does not hold exactly one schema, so that field would report a confidently wrong name.</p>
+     */
+    private static String soleSchemaOf(Query query) {
+        Set<String> restrict = query.getModel().getRestrict();
+        return restrict != null && restrict.size() == 1 ? restrict.iterator().next() : null;
+    }
+
     private void throwTimeout() throws TimeoutException {
         throw new TimeoutException("Timed out waiting for summary data. " + outstandingResponses + " responses outstanding.");
     }
@@ -346,12 +403,23 @@ public class RpcProtobufFillInvoker extends FillInvoker {
                     outstandingResponses--;
                 }
                 skippedHits.removeIf(hit -> !partialSummaryHandler.needFill(hit));
+
+                // Span.current() here IS dispatch.fill: FillInvoker.fill -> getFillResults -> processResponses
+                // -> maybeRetry is synchronous on one thread, so the span needs no plumbing to reach.
+                Span.current().setAttribute(TraceAttributes.FILL_SKIPPED,     numSkipped)
+                              .setAttribute(TraceAttributes.FILL_RETRIED,     true)
+                              .setAttribute(TraceAttributes.FILL_RETRY_NODES, retryMap.size())
+                              .setAttribute(TraceAttributes.FILL_UNFILLED,    skippedHits.size());
             }
         } else {
             result.getQuery().trace(false, 1, "Summary fetching got " + numSkipped + " empty docsums (of " + numHitsToFill + " hits), no retry");
             if (shouldLogNoRetry()) {
                 log.log(Level.WARNING, "Docsum fetch failed for " + numSkipped + " hits (" + numOkFilledHits + " ok hits), no retry");
             }
+            // Declined by the retry limit: these docsums are lost for this query. Recorded as retried=false
+            // rather than left absent, so "considered and declined" is distinguishable from "never needed".
+            Span.current().setAttribute(TraceAttributes.FILL_SKIPPED, numSkipped)
+                          .setAttribute(TraceAttributes.FILL_RETRIED, false);
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch.rpc;
 
+import ai.vespa.telemetry.api.trace.TraceAttributes;
+import ai.vespa.telemetry.api.trace.OtelTracing;
 import com.yahoo.compress.Compressor;
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.prelude.fastsearch.VespaBackend;
@@ -10,6 +12,11 @@ import com.yahoo.search.dispatch.SearchInvoker;
 import com.yahoo.search.dispatch.rpc.Client.ProtobufResponse;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.result.ErrorMessage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+
 
 import java.io.IOException;
 import java.util.Optional;
@@ -36,6 +43,10 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
 
     private Query query;
 
+    /** This invoker is already per-query-per-node, so it is the carrier: no lookup structure is needed.
+     *  Created on the worker thread, ended on whichever thread learns the outcome — Span is thread-safe. */
+    private Span span = Span.getInvalid();
+
     RpcSearchInvoker(VespaBackend searcher, CompressPayload compressor, Node node, RpcConnectionPool resourcePool, int maxHits, QrSearchersConfig qrSearchersConfig) {
         super(Optional.of(node));
         this.searcher = searcher;
@@ -50,6 +61,15 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
     @Override
     protected Object sendSearchRequest(Query query, double contentShare, Object incomingContext) {
         this.query = query;
+        span = OtelTracing.startSpan(Context.current(), "node.search", SpanKind.CLIENT);
+        // Set on the span FIELD, not Span.current(): this span is deliberately never made current. Every value
+        // here is a field read or a constant, so no isRecording() guard is warranted.
+        span.setAttribute(TraceAttributes.CONTENT_CLUSTER,   searcher.getName())
+            .setAttribute(TraceAttributes.CONTENT_NODE_KEY,  node.key())
+            .setAttribute(TraceAttributes.CONTENT_NODE_HOST, node.hostname())
+            .setAttribute(TraceAttributes.CONTENT_GROUP,     node.group())
+            .setAttribute(TraceAttributes.RPC_SYSTEM,        "vespa_jrt")
+            .setAttribute(TraceAttributes.RPC_METHOD_KEY,    RPC_METHOD);
 
         Client.NodeConnection nodeConnection = resourcePool.getConnection(node.key());
         if (nodeConnection == null) {
@@ -109,10 +129,35 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
 
     @Override
     protected void release() {
-        // nothing to release
+        // Ends the span on the two paths above that create it and then return WITHOUT sending anything: an
+        // unknown node connection, and a timeout detected before sending. Those never reach the transport, so
+        // receive() is never called for them and nothing else would end their span.
+        //
+        // It is NOT what covers a node that goes silent. JRT guarantees the response waiter is called exactly
+        // once for every request it accepts - InvocationClient.run() fires on the scheduled timeout and calls
+        // handleRequestDone - so a silent node still reaches receive(), with a TIMEOUT error. This method is
+        // then a no-op for it, since the span has already ended.
+        //
+        // Ends late - release() runs from close(), after the search has returned - which is accepted: on the
+        // paths it actually covers, no request was ever sent, so there is no round trip being mis-measured.
+        endSpan("ended without a response from node " + node.key() + " on " + node.hostname());
+    }
+
+    /**
+     * Ends the span once, whichever path gets here first. Idempotent by construction: {@code isRecording()}
+     * is false once a span has ended (SdkSpan:586-590) and a second {@code end()} is a logged no-op
+     * (SdkSpan:559-564). That matters because release() also runs for invokers that DID answer —
+     * InterleavedSearchInvoker.ejectInvoker calls it on every invoker it consumes — and must not restamp
+     * a finished span with an error.
+     */
+    private void endSpan(String error) {
+        if ( ! span.isRecording()) return;
+        if (error != null) span.setStatus(StatusCode.ERROR, error);
+        span.end();
     }
 
     public void receive(Client.ResponseOrError<ProtobufResponse> response) {
+        endSpan(response.error().orElse(null));   // may run on a JRT transport thread
         responses.add(response);
         responseAvailable();
     }

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -3,6 +3,8 @@ package com.yahoo.search.handler;
 
 import ai.vespa.metrics.ContainerMetrics;
 import ai.vespa.cloud.ZoneInfo;
+import ai.vespa.telemetry.api.trace.OtelTracing;
+import ai.vespa.telemetry.api.trace.TraceAttributes;
 import com.yahoo.collections.Tuple2;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.component.Vtag;
@@ -47,6 +49,7 @@ import com.yahoo.search.statistics.ElapsedTime;
 import com.yahoo.slime.Inspector;
 import com.yahoo.yolean.Exceptions;
 import com.yahoo.yolean.trace.TraceNode;
+import io.opentelemetry.api.trace.Span;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -369,7 +372,12 @@ public class SearchHandler extends LoggingRequestHandler {
             // check and set (instead of set directly) to avoid overwriting stuff from prepareForBreakdownAnalysis()
             execution.context().setDetailedDiagnostics(true);
         }
-        Result result = execution.search(query);
+        Result result = OtelTracing.instrument("chain.search", () -> {
+            Span.current()
+                .setAttribute(TraceAttributes.SEARCH_CHAIN,       searchChain.getId().stringValue())
+                .setAttribute(TraceAttributes.QUERY_RANK_PROFILE, query.getRanking().getProfile());
+            return execution.search(query);
+        });
         if (result.getQuery() == null)
             result.setQuery(query);
 

--- a/container-search/src/main/java/com/yahoo/search/searchchain/AsyncExecution.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/AsyncExecution.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.searchchain;
 
+import ai.vespa.telemetry.api.trace.OtelTracing;
 import com.yahoo.component.chain.Chain;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -132,7 +133,7 @@ public class AsyncExecution {
     private static <T> Future<T> getFuture(Executor executor, Callable<T> callable) {
         FutureTask<T> future = new FutureTask<>(callable);
         try {
-            executor.execute(future);
+            executor.execute(OtelTracing.withCurrentContext(future));
         } catch (RejectedExecutionException e) {
             future.run();
         }
@@ -149,7 +150,7 @@ public class AsyncExecution {
     private FutureResult getFutureResult(Executor executor, Callable<Result> callable, Query query) {
         FutureResult future = new FutureResult(callable, execution, query);
         try {
-            executor.execute(future);
+            executor.execute(OtelTracing.withCurrentContext(future));
         } catch (RejectedExecutionException e) {
             future.run();
         }

--- a/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTracingTest.java
@@ -1,0 +1,290 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.prelude.cluster;
+
+import ai.vespa.telemetry.api.trace.OtelTracing;
+import ai.vespa.telemetry.api.trace.TraceAttributes;
+import com.yahoo.prelude.fastsearch.ClusterParams;
+import com.yahoo.prelude.fastsearch.FastHit;
+import com.yahoo.prelude.fastsearch.VespaBackend;
+import com.yahoo.search.dispatch.FillInvoker;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.schema.Cluster;
+import com.yahoo.search.schema.Schema;
+import com.yahoo.search.schema.SchemaInfo;
+import com.yahoo.search.searchchain.Execution;
+import com.yahoo.search.test.SpanRecorder;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies L4 fork context propagation at {@link ClusterSearcher#searchMultipleDocumentTypes}: when a query
+ * resolves to more than one schema, each schema is searched on a pool thread, and work below that fork must
+ * still see the trace context.
+ *
+ * <p>Nothing between the fork and the backend creates a span today, so this test stands in for the L5 dispatch
+ * and per-node spans that will be created there: the fake backend creates one, exactly where a real
+ * {@code dispatch.search} span would be.</p>
+ *
+ * <p>Also verifies the L6 {@code cluster.fill} span at {@link ClusterSearcher#fill(Result, String, Execution)}.
+ * That is the top of the fill side of the dispatch layer: one span per fill against one content cluster, under
+ * which the per-invoker {@code dispatch.fill} and per-node {@code node.fill} spans hang.</p>
+ *
+ * @author onur
+ */
+class ClusterSearcherTracingTest {
+
+    @Test
+    void the_multi_schema_fork_carries_the_trace_context_to_the_pool_thread() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("forking");
+
+        SpanCreatingBackend backend = new SpanCreatingBackend();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        // Two backends => doSearch takes the multi-schema branch (ClusterSearcher:226) and forks per schema
+        ClusterSearcher searcher = new ClusterSearcher(schemaInfo("s1", "s2"),
+                                                       Map.of("s1", backend, "s2", backend),
+                                                       executor);
+        try {
+            recorder.record(() -> searcher.search(new Query("?query=test"),
+                                                  new Execution(Execution.Context.createContextStub())));
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS), "executor did not terminate");
+        }
+
+        assertFalse(backend.threads.contains(Thread.currentThread().getName()),
+                    "the per-schema searches must really run on the pool thread, or this test proves nothing");
+
+        for (String schema : List.of("s1", "s2")) {
+            SpanData backendSpan = recorder.spanNamed("backend " + schema);
+            assertEquals(recorder.parentSpan().getSpanContext().getTraceId(), backendSpan.getTraceId(),
+                         "a span created below the fork must stay in the forking thread's trace");
+            assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), backendSpan.getParentSpanId(),
+                         "and be a child of the span that was current when the task was submitted");
+        }
+
+        recorder.close();
+    }
+
+    @Test
+    void a_fill_produces_one_cluster_fill_span() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("fill default");   // as the L3 span in ensureFilled
+
+        FillSpanBackend backend = new FillSpanBackend();
+        ClusterSearcher searcher = new ClusterSearcher(schemaInfo("s1"), Map.of("s1", backend), null);
+
+        recorder.record(() -> searcher.fill(new Result(new Query("?query=test")), "default",
+                                            new Execution(Execution.Context.createContextStub())));
+
+        SpanData span = recorder.spanNamed("cluster.fill");
+        assertEquals("ai.vespa", span.getInstrumentationScopeInfo().getName());
+        assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), span.getParentSpanId(),
+                     "cluster.fill must hang under the L3 fill span that drove the fill");
+
+        recorder.close();
+    }
+
+    @Test
+    void work_done_by_the_backend_hangs_under_the_cluster_fill_span() throws Exception {
+        // The property the rest of L6 depends on: cluster.fill is CURRENT while the backends fill, so
+        // dispatch.fill and node.fill become its children with no context plumbing of their own.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("fill default");
+
+        FillSpanBackend backend = new FillSpanBackend();
+        ClusterSearcher searcher = new ClusterSearcher(schemaInfo("s1"), Map.of("s1", backend), null);
+
+        recorder.record(() -> searcher.fill(new Result(new Query("?query=test")), "default",
+                                            new Execution(Execution.Context.createContextStub())));
+
+        assertEquals(1, backend.fills.get(), "the backend must actually have been asked to fill");
+        assertEquals(recorder.spanNamed("cluster.fill").getSpanId(),
+                     recorder.spanNamed("backend fill").getParentSpanId());
+
+        recorder.close();
+    }
+
+    @Test
+    void the_span_covers_the_no_backend_branch_too() throws Exception {
+        // A fill that can serve nothing still took time and still produced an error, which is exactly the
+        // case worth seeing in a trace - so the span must cover the error branch, not just the happy one.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("fill default");
+
+        ClusterSearcher searcher = new ClusterSearcher(schemaInfo(), Map.of(), null);
+        Result result = new Result(new Query("?query=test"));
+
+        recorder.record(() -> searcher.fill(result, "default", new Execution(Execution.Context.createContextStub())));
+
+        assertNotNull(result.hits().getErrorHit(), "no backends in service must still be reported as an error");
+        assertEquals(1, recorder.countSpans("cluster.fill"));
+
+        recorder.close();
+    }
+
+    @Test
+    void nothing_is_recorded_when_telemetry_is_absent() throws Exception {
+        // Without a Telemetry in the current context the tracer is the no-op one, so the span is never created
+        // rather than created and dropped. Run OUTSIDE recorder.record() to get that state.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("fill default");
+
+        ClusterSearcher searcher = new ClusterSearcher(schemaInfo("s1"), Map.of("s1", new FillSpanBackend()), null);
+        searcher.fill(new Result(new Query("?query=test")), "default",
+                      new Execution(Execution.Context.createContextStub()));
+
+        assertEquals(0, recorder.countSpans("cluster.fill"));
+
+        recorder.close();
+    }
+
+    @Test
+    void dispatch_fill_spans_hang_under_the_cluster_fill_span() throws Exception {
+        // The real nesting, through the real code path: ClusterSearcher.fill -> VespaBackend.fill ->
+        // partitionHits -> doPartialFill -> FillInvoker.fill. Chunk 1 only proved that SOME work done by the
+        // backend nests under cluster.fill; this proves it for the actual L6 span.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher.ensureFilled");
+
+        Result result = new Result(new Query("?query=test"));
+        Query tag = new Query("?query=test");
+        for (int i = 0; i < 2; i++) {           // same query identity => one partition => one invoker
+            FastHit hit = new FastHit();
+            hit.setQuery(tag);
+            hit.setFillable();
+            result.hits().add(hit);
+        }
+        InvokerRunningBackend backend = new InvokerRunningBackend();
+        ClusterSearcher searcher = new ClusterSearcher(schemaInfo("s1"), Map.of("s1", backend), null);
+
+        recorder.record(() -> searcher.fill(result, "default", new Execution(Execution.Context.createContextStub())));
+
+        assertEquals(1, recorder.countSpans("dispatch.fill"));
+        assertEquals(recorder.spanNamed("cluster.fill").getSpanId(),
+                     recorder.spanNamed("dispatch.fill").getParentSpanId());
+
+        recorder.close();
+    }
+
+    @Test
+    void the_cluster_fill_span_names_the_cluster_the_summary_class_and_the_backend_count() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher.ensureFilled");
+
+        ClusterSearcher searcher = new ClusterSearcher(schemaInfo("s1"), Map.of("s1", new FillSpanBackend()), null);
+
+        recorder.record(() -> searcher.fill(new Result(new Query("?query=test")), "default",
+                                            new Execution(Execution.Context.createContextStub())));
+
+        var attrs = recorder.spanNamed("cluster.fill").getAttributes();
+        assertEquals("testScenario", attrs.get(TraceAttributes.CONTENT_CLUSTER), "the cluster name the test constructor sets");
+        assertEquals("default", attrs.get(TraceAttributes.FILL_SUMMARY_CLASS));
+        assertEquals(1L, attrs.get(TraceAttributes.FILL_BACKENDS).longValue());
+
+        recorder.close();
+    }
+
+    @Test
+    void the_cluster_fill_span_is_attributable_even_when_no_backend_can_serve_it() throws Exception {
+        // The attributes are set before any work, so the failure case is not an anonymous span.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher.ensureFilled");
+
+        ClusterSearcher searcher = new ClusterSearcher(schemaInfo(), Map.of(), null);
+
+        recorder.record(() -> searcher.fill(new Result(new Query("?query=test")), "default",
+                                            new Execution(Execution.Context.createContextStub())));
+
+        var attrs = recorder.spanNamed("cluster.fill").getAttributes();
+        assertEquals("testScenario", attrs.get(TraceAttributes.CONTENT_CLUSTER));
+        assertEquals(0L, attrs.get(TraceAttributes.FILL_BACKENDS).longValue());
+
+        recorder.close();
+    }
+
+    private static SchemaInfo schemaInfo(String... names) {
+        Cluster.Builder cluster = new Cluster.Builder("testScenario");   // matches the test constructor's cluster name
+        for (String name : names) cluster.addSchema(name);
+        return new SchemaInfo(Stream.of(names).map(name -> new Schema.Builder(name).build()).toList(),
+                              List.of(cluster.build()));
+    }
+
+    /** A backend whose doPartialFill runs a real {@link FillInvoker}, so the L6 dispatch.fill span is created. */
+    private static final class InvokerRunningBackend extends VespaBackend {
+
+        InvokerRunningBackend() { super(new ClusterParams("container.0")); }
+
+        @Override protected Result doSearch2(String schema, Query query) {
+            throw new UnsupportedOperationException("this backend only fills");
+        }
+
+        @Override protected void doPartialFill(Result result, String summaryClass) {
+            new FillInvoker() {
+                @Override protected void sendFillRequest(Result r, String sc) { }
+                @Override protected void getFillResults(Result r, String sc) { }
+                @Override protected void release() { }
+            }.fill(result, summaryClass);
+        }
+    }
+
+    /**
+     * Stands in for a real backend: records which thread it ran on and creates a span where L5 would create
+     * {@code dispatch.search}. {@code search} is overridden rather than {@code doSearch2} because
+     * {@code perSchemaSearch:259} calls the public method.
+     */
+    private static final class SpanCreatingBackend extends VespaBackend {
+
+        final Set<String> threads = ConcurrentHashMap.newKeySet();
+
+        SpanCreatingBackend() { super(new ClusterParams("container.0")); }
+
+        @Override
+        public Result search(String schema, Query query) {
+            threads.add(Thread.currentThread().getName());
+            OtelTracing.instrument("backend " + schema, () -> { });
+            return new Result(query);
+        }
+
+        @Override protected Result doSearch2(String schema, Query query) {
+            throw new UnsupportedOperationException("search() is overridden");
+        }
+
+        @Override protected void doPartialFill(Result result, String summaryClass) { }
+    }
+
+    /**
+     * Stands in for a real backend on the FILL path: creates a span where L6 will create {@code dispatch.fill}.
+     * {@code fill} is overridden rather than {@code doPartialFill} so the test needs no fillable-hit fixture -
+     * {@code VespaBackend.fill:205} would partition the hits first and reach nothing on an empty result.
+     */
+    private static final class FillSpanBackend extends VespaBackend {
+
+        final AtomicInteger fills = new AtomicInteger();
+
+        FillSpanBackend() { super(new ClusterParams("container.0")); }
+
+        @Override
+        public void fill(Result result, String summaryClass) {
+            fills.incrementAndGet();
+            OtelTracing.instrument("backend fill", () -> { });
+        }
+
+        @Override protected Result doSearch2(String schema, Query query) {
+            throw new UnsupportedOperationException("this backend only fills");
+        }
+
+        @Override protected void doPartialFill(Result result, String summaryClass) {
+            throw new UnsupportedOperationException("fill() is overridden");
+        }
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/SearcherTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/search/SearcherTracingTest.java
@@ -1,0 +1,226 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search;
+
+import ai.vespa.telemetry.api.trace.TraceAttributes;
+import com.yahoo.component.ComponentId;
+import com.yahoo.component.chain.Chain;
+import com.yahoo.search.result.Hit;
+import com.yahoo.search.searchchain.Execution;
+import com.yahoo.search.test.SpanRecorder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the two L3 per-SEARCHER spans: {@code searcher.search} from {@link Searcher#process} and
+ * {@code searcher.ensureFilled} from {@link Searcher#ensureFilled}.
+ *
+ * <p>Both names are FIXED. A chain nests one span per searcher for each operation, so the searcher identity lives
+ * entirely in the {@code vespa.searcher.id} and {@code vespa.searcher.class} attributes - without them the nested
+ * spans would be indistinguishable. Several tests below therefore look spans up by attribute rather than by name,
+ * which is the property the fixed naming depends on.</p>
+ *
+ * @author onur
+ */
+class SearcherTracingTest {
+
+    @Test
+    void searcher_spans_nest_as_the_chain_recurses() {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("chain");
+
+        Chain<Searcher> chain = new Chain<>(new ComponentId("test"),
+                new PassThroughSearcher("A"), new PassThroughSearcher("B"), new SourceSearcher("C"));
+        Execution execution = new Execution(chain, Execution.Context.createContextStub());
+
+        recorder.record(() -> {
+            execution.search(new Query("?query=test"));
+        });
+
+        assertEquals(3, recorder.countSpans("searcher.search"), "one span per searcher, all with the same name");
+        SpanData a = searcherSpan(recorder, "A");
+        SpanData b = searcherSpan(recorder, "B");
+        SpanData c = searcherSpan(recorder, "C");
+        assertEquals(SpanKind.INTERNAL, a.getKind());
+        assertEquals("ai.vespa", a.getInstrumentationScopeInfo().getName());
+        assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), a.getParentSpanId(), "outermost searcher nests under the chain span");
+        assertEquals(a.getSpanId(), b.getParentSpanId(), "searcher B nests under searcher A");
+        assertEquals(b.getSpanId(), c.getParentSpanId(), "searcher C nests under searcher B");
+
+        recorder.close();
+    }
+
+    @Test
+    void searcher_spans_carry_the_component_id_and_implementation_class_as_attributes() {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("chain");
+
+        Chain<Searcher> chain = new Chain<>(new ComponentId("test"), new SourceSearcher("A"));
+        Execution execution = new Execution(chain, Execution.Context.createContextStub());
+
+        recorder.record(() -> {
+            execution.search(new Query("?query=test"));
+        });
+
+        SpanData a = recorder.spanNamed("searcher.search");
+        assertEquals("A", a.getAttributes().get(TraceAttributes.SEARCHER_ID));
+        assertEquals(SourceSearcher.class.getName(), a.getAttributes().get(TraceAttributes.SEARCHER_CLASS),
+                     "the implementation class, not the component id, so third-party searchers are distinguishable");
+
+        recorder.close();
+    }
+
+    @Test
+    void a_throwing_searcher_records_the_exception_on_its_span() {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("chain");
+
+        Chain<Searcher> chain = new Chain<>(new ComponentId("test"), new ThrowingSearcher("X"));
+        Execution execution = new Execution(chain, Execution.Context.createContextStub());
+
+        recorder.record(() -> {
+            assertThrows(RuntimeException.class, () -> execution.search(new Query("?query=test")));
+        });
+
+        SpanData x = recorder.spanNamed("searcher.search");
+        assertEquals(StatusCode.ERROR, x.getStatus().getStatusCode());
+        assertEquals(1, x.getEvents().size(), "the thrown exception must be recorded on the searcher span");
+        assertEquals("exception", x.getEvents().get(0).getName());
+
+        recorder.close();
+    }
+
+    @Test
+    void fill_span_is_created_when_hits_need_filling() {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("chain");
+
+        Result result = new Result(new Query("?query=test"));
+        Hit hit = new Hit("id");
+        hit.setFillable();   // fillable but not filled => getFilled() is non-null but empty => needs fill
+        result.hits().add(hit);
+        FillingSearcher searcher = new FillingSearcher("filler");
+        Execution execution = new Execution(new Chain<>(new ComponentId("c"), searcher), Execution.Context.createContextStub());
+
+        recorder.record(() -> {
+            searcher.ensureFilled(result, "default", execution);
+        });
+
+        SpanData fill = recorder.spanNamed("searcher.ensureFilled");
+        assertEquals(SpanKind.INTERNAL, fill.getKind());
+        assertEquals("ai.vespa", fill.getInstrumentationScopeInfo().getName());
+        assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), fill.getParentSpanId(), "the fill span nests under the current span");
+        assertEquals(1, recorder.countSpans("searcher.ensureFilled"), "exactly one fill span");
+
+        recorder.close();
+    }
+
+    @Test
+    void fill_span_carries_the_summary_class_and_the_number_of_hits_being_filled() {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("chain");
+
+        Result result = new Result(new Query("?query=test"));
+        for (String id : new String[] { "id1", "id2" }) {   // two, so the count cannot be confused with a constant 1
+            Hit hit = new Hit(id);
+            hit.setFillable();
+            result.hits().add(hit);
+        }
+        FillingSearcher searcher = new FillingSearcher("filler");
+        Execution execution = new Execution(new Chain<>(new ComponentId("c"), searcher), Execution.Context.createContextStub());
+
+        recorder.record(() -> {
+            searcher.ensureFilled(result, "default", execution);
+        });
+
+        SpanData fill = recorder.spanNamed("searcher.ensureFilled");
+        assertEquals("default", fill.getAttributes().get(TraceAttributes.FILL_SUMMARY_CLASS));
+        assertEquals(2L, fill.getAttributes().get(TraceAttributes.FILL_HITS).longValue(),
+                     "the count is read before fill runs, so it reports the hits the fill covers");
+
+        recorder.close();
+    }
+
+    @Test
+    void no_fill_span_when_hits_are_already_filled() {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("chain");
+
+        Result result = new Result(new Query("?query=test"));
+        Hit hit = new Hit("id");
+        hit.setFillable();
+        hit.setFilled("default");   // already filled for the requested class => short-circuit, no fill span
+        result.hits().add(hit);
+        FillingSearcher searcher = new FillingSearcher("filler");
+        Execution execution = new Execution(new Chain<>(new ComponentId("c"), searcher), Execution.Context.createContextStub());
+
+        recorder.record(() -> {
+            searcher.ensureFilled(result, "default", execution);
+        });
+
+        assertEquals(0, recorder.countSpans("searcher.ensureFilled"), "already-filled hits must not create a fill span");
+
+        recorder.close();
+    }
+
+
+    @Test
+    void fill_spans_carry_the_searcher_identity_so_the_nested_ones_can_be_told_apart() {
+        // The name is fixed, so without these attributes a chain of fills produces N identical spans. This is
+        // the whole reason the identity attributes were added to the fill span.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("chain");
+
+        Result result = new Result(new Query("?query=test"));
+        Hit hit = new Hit("id");
+        hit.setFillable();
+        result.hits().add(hit);
+        FillingSearcher searcher = new FillingSearcher("filler");
+        Execution execution = new Execution(new Chain<>(new ComponentId("c"), searcher), Execution.Context.createContextStub());
+
+        recorder.record(() -> {
+            searcher.ensureFilled(result, "default", execution);
+        });
+
+        SpanData fill = recorder.spanNamed("searcher.ensureFilled");
+        assertEquals("filler", fill.getAttributes().get(TraceAttributes.SEARCHER_ID));
+        assertEquals(FillingSearcher.class.getName(), fill.getAttributes().get(TraceAttributes.SEARCHER_CLASS));
+
+        recorder.close();
+    }
+
+    /** The one {@code searcher.search} span belonging to the searcher with this component id. */
+    private static SpanData searcherSpan(SpanRecorder recorder, String id) {
+        List<SpanData> matching = recorder.spans().stream()
+                .filter(s -> s.getName().equals("searcher.search"))
+                .filter(s -> id.equals(s.getAttributes().get(TraceAttributes.SEARCHER_ID)))
+                .toList();
+        assertEquals(1, matching.size(), "expected exactly one searcher.search span with id '" + id + "', got " + recorder.spans());
+        return matching.get(0);
+    }
+
+    /** Invokes the rest of the chain, so its span nests over the downstream searcher spans. */
+    private static final class PassThroughSearcher extends Searcher {
+        PassThroughSearcher(String id) { super(new ComponentId(id)); }
+        @Override public Result search(Query query, Execution execution) { return execution.search(query); }
+    }
+
+    /** Terminal searcher: returns a result without calling down the chain. */
+    private static final class SourceSearcher extends Searcher {
+        SourceSearcher(String id) { super(new ComponentId(id)); }
+        @Override public Result search(Query query, Execution execution) { return new Result(query); }
+    }
+
+    private static final class ThrowingSearcher extends Searcher {
+        ThrowingSearcher(String id) { super(new ComponentId(id)); }
+        @Override public Result search(Query query, Execution execution) { throw new RuntimeException("boom"); }
+    }
+
+    /** Terminal searcher whose fill() fills the hits directly (so ensureFilled reaches the fill branch). */
+    private static final class FillingSearcher extends Searcher {
+        FillingSearcher(String id) { super(new ComponentId(id)); }
+        @Override public Result search(Query query, Execution execution) { return new Result(query); }
+        @Override public void fill(Result result, String summaryClass, Execution execution) {
+            result.hits().asList().forEach(hit -> hit.setFilled(summaryClass));
+        }
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/dispatch/DispatchFillTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/DispatchFillTracingTest.java
@@ -1,0 +1,173 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch;
+
+import ai.vespa.telemetry.api.trace.TraceAttributes;
+import com.yahoo.prelude.fastsearch.ClusterParams;
+import com.yahoo.prelude.fastsearch.FastHit;
+import com.yahoo.prelude.fastsearch.VespaBackend;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.test.SpanRecorder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the L6 {@code dispatch.fill} span created in {@link FillInvoker#fill}.
+ *
+ * <p>It is the fill-side twin of {@code dispatch.search} in {@link SearchInvoker#search}: one span per allocated
+ * fill connection, covering both phases of the two-phase invoker - {@code sendFillRequest} then
+ * {@code getFillResults}. One invoker is built and closed per PARTITION of the hits
+ * ({@code IndexedBackend.doPartialFill:108}), and {@code VespaBackend.partitionHits:176} splits by the identity of
+ * the {@link Query} each hit was tagged with, so one user-level fill can produce several of these spans.</p>
+ *
+ * @author onur
+ */
+class DispatchFillTracingTest {
+
+    @Test
+    void a_fill_produces_one_span_covering_both_phases() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RecordingFillInvoker invoker = new RecordingFillInvoker();
+
+        recorder.record(() -> invoker.fill(new Result(new Query("?query=test")), "default"));
+
+        SpanData span = recorder.spanNamed("dispatch.fill");
+        assertEquals(SpanKind.INTERNAL, span.getKind());
+        assertEquals("ai.vespa", span.getInstrumentationScopeInfo().getName());
+        assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), span.getParentSpanId(),
+                     "dispatch.fill hangs under the cluster.fill span");
+        assertEquals(List.of("send", "get"), invoker.phases, "the span must cover BOTH phases of the invoker");
+
+        recorder.close();
+    }
+
+    @Test
+    void nothing_is_recorded_when_telemetry_is_absent() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+
+        new RecordingFillInvoker().fill(new Result(new Query("?query=test")), "default");   // outside record()
+
+        assertEquals(0, recorder.countSpans("dispatch.fill"));
+
+        recorder.close();
+    }
+
+    @Test
+    void a_returned_error_is_recorded_as_span_status_with_the_code_and_short_message() throws Exception {
+        // Fill failures never throw - they are added to the result and returned - so without this the span
+        // of a fill that fetched nothing would look successful.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        FillInvoker invoker = failingInvoker(ErrorMessage.createTimeout("Summary data is incomplete: 2 outstanding"));
+
+        recorder.record(() -> invoker.fill(new Result(new Query("?query=test")), "default"));
+
+        SpanData span = recorder.spanNamed("dispatch.fill");
+        assertEquals(StatusCode.ERROR, span.getStatus().getStatusCode());
+        assertEquals(com.yahoo.container.protect.Error.TIMEOUT.code,
+                     span.getAttributes().get(TraceAttributes.ERROR_CODE).intValue());
+        assertEquals("Timed out", span.getAttributes().get(TraceAttributes.ERROR_MESSAGE),
+                     "the SHORT message: the detailed one carries caller-supplied text and must never be used");
+
+        recorder.close();
+    }
+
+    @Test
+    void a_successful_fill_is_not_marked_as_an_error() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RecordingFillInvoker invoker = new RecordingFillInvoker();
+
+        recorder.record(() -> invoker.fill(new Result(new Query("?query=test")), "default"));
+
+        assertEquals(StatusCode.UNSET, recorder.spanNamed("dispatch.fill").getStatus().getStatusCode());
+
+        recorder.close();
+    }
+
+    @Test
+    void one_span_per_partition_of_the_hits() throws Exception {
+        // VespaBackend.fill partitions the unfilled hits by the identity of the Query each was tagged with and
+        // builds one invoker per partition, so two query clones must yield two dispatch.fill spans.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+
+        Query a = new Query("?query=a");
+        Query b = new Query("?query=b");
+        Result result = new Result(new Query("?query=outer"));
+        for (Query q : List.of(a, a, b)) {
+            FastHit hit = new FastHit();
+            hit.setQuery(q);
+            hit.setFillable();
+            result.hits().add(hit);
+        }
+        InvokerRunningBackend backend = new InvokerRunningBackend();
+
+        recorder.record(() -> backend.fill(result, "default"));
+
+        assertEquals(2, backend.invokers, "two query identities => two partitions => two invokers");
+        assertEquals(2, recorder.countSpans("dispatch.fill"));
+
+        recorder.close();
+    }
+
+    @Test
+    void the_span_is_created_even_when_the_invoker_finds_nothing_to_do() throws Exception {
+        // RpcProtobufFillInvoker.sendFillRequest:93 returns immediately when the result is already filled, and
+        // getFillResults:128 short-circuits too. The span is still created - allocating the invoker had a cost,
+        // and suppressing it is not possible from the base class, which cannot see the subclass's state.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        FillInvoker doingNothing = new FillInvoker() {
+            @Override protected void sendFillRequest(Result result, String summaryClass) { }
+            @Override protected void getFillResults(Result result, String summaryClass) { }
+            @Override protected void release() { }
+        };
+
+        recorder.record(() -> doingNothing.fill(new Result(new Query("?query=test")), "default"));
+
+        assertEquals(1, recorder.countSpans("dispatch.fill"));
+        assertTrue(recorder.spanNamed("dispatch.fill").getEndEpochNanos() >= recorder.spanNamed("dispatch.fill").getStartEpochNanos());
+
+        recorder.close();
+    }
+
+    /** Records which phases ran, so a test can prove the span covers both rather than only the first. */
+    private static final class RecordingFillInvoker extends FillInvoker {
+        final List<String> phases = new ArrayList<>();
+        @Override protected void sendFillRequest(Result result, String summaryClass) { phases.add("send"); }
+        @Override protected void getFillResults(Result result, String summaryClass) { phases.add("get"); }
+        @Override protected void release() { }
+    }
+
+    /** An invoker that fails the way the real one does: adds an error to the result and returns normally. */
+    private static FillInvoker failingInvoker(ErrorMessage error) {
+        return new FillInvoker() {
+            @Override protected void sendFillRequest(Result result, String summaryClass) { }
+            @Override protected void getFillResults(Result result, String summaryClass) { result.hits().addError(error); }
+            @Override protected void release() { }
+        };
+    }
+
+    /** A backend whose doPartialFill runs a real FillInvoker, so VespaBackend's partitioning is exercised. */
+    private static final class InvokerRunningBackend extends VespaBackend {
+
+        int invokers = 0;
+
+        InvokerRunningBackend() { super(new ClusterParams("container.0")); }
+
+        @Override protected Result doSearch2(String schema, Query query) {
+            throw new UnsupportedOperationException("this backend only fills");
+        }
+
+        @Override protected void doPartialFill(Result result, String summaryClass) {
+            invokers++;
+            new RecordingFillInvoker().fill(result, summaryClass);
+        }
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/dispatch/DispatchSearchTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/DispatchSearchTracingTest.java
@@ -1,0 +1,215 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch;
+
+import ai.vespa.telemetry.api.trace.TraceAttributes;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.result.Coverage;
+import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.test.SpanRecorder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the L5 {@code dispatch.search} span created in {@link SearchInvoker#search}.
+ *
+ * <p>The span sits on the BASE class deliberately: {@code search()} is invoked only on the ROOT of the invoker
+ * tree, whatever its shape — an {@link InterleavedSearchInvoker} for a multi-node group, a bare
+ * {@code RpcSearchInvoker} for a single-node one ({@code InvokerFactory:90-91} returns the leaf unwrapped), or a
+ * {@link SearchErrorInvoker}. Children are driven through {@code sendSearchRequest}/{@code getSearchResult}, never
+ * {@code search()}, so one call yields exactly one span in every shape.</p>
+ *
+ * <p>Note what this span is NOT: it is one span per (query, schema, grouping pass), not one per query. A query
+ * resolving to N schemas dispatches N times concurrently, and grouping re-runs the chain once per pass.</p>
+ *
+ * @author onur
+ */
+class DispatchSearchTracingTest {
+
+    @Test
+    void one_dispatch_span_per_search_parented_under_the_current_span() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher ClusterSearcher");
+        SearchInvoker invoker = succeeding();
+
+        recorder.record(() -> invoker.search(query("s1"), 1.0));
+
+        SpanData span = recorder.spanNamed("dispatch.search");
+        assertEquals(SpanKind.INTERNAL, span.getKind());
+        assertEquals("ai.vespa", span.getInstrumentationScopeInfo().getName());
+        assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), span.getParentSpanId(),
+                     "the dispatch span must be a child of the searcher span above it");
+        assertEquals(StatusCode.UNSET, span.getStatus().getStatusCode(), "a clean dispatch is not an error");
+
+        recorder.close();
+    }
+
+    @Test
+    void the_dispatch_span_carries_the_schema_it_searched() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher");
+        SearchInvoker invoker = succeeding();
+
+        recorder.record(() -> invoker.search(query("music"), 1.0));
+
+        // Concurrent per-schema dispatches are otherwise indistinguishable from each other.
+        assertEquals("music", recorder.spanNamed("dispatch.search").getAttributes().get(TraceAttributes.SCHEMA));
+        recorder.close();
+    }
+
+    @Test
+    void a_RETURNED_error_marks_the_span_error_with_its_code_and_message() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher");
+        // Dispatch failures do not throw; without an explicit status this span would look successful.
+        SearchInvoker invoker = failingWith(ErrorMessage.createTimeout("no time left"));
+
+        recorder.record(() -> invoker.search(query("s1"), 1.0));
+
+        SpanData span = recorder.spanNamed("dispatch.search");
+        assertEquals(StatusCode.ERROR, span.getStatus().getStatusCode());
+        assertEquals(12L, span.getAttributes().get(TraceAttributes.ERROR_CODE).longValue(), "Error.TIMEOUT.code");
+        // The SHORT message is a fixed literal per factory; the DETAILED one is caller-supplied and can carry
+        // the request URI, so it is deliberately absent here.
+        assertEquals("Timed out", span.getAttributes().get(TraceAttributes.ERROR_MESSAGE));
+
+        recorder.close();
+    }
+
+    @Test
+    void a_THROWN_exception_propagates_and_marks_the_span_error() {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher");
+        SearchInvoker invoker = throwing(new IOException("connection reset"));
+
+        IOException thrown = assertThrows(IOException.class,
+                                          () -> recorder.record(() -> invoker.search(query("s1"), 1.0)));
+
+        assertEquals("connection reset", thrown.getMessage(), "instrumentation must not swallow or wrap it");
+        SpanData span = recorder.spanNamed("dispatch.search");
+        assertEquals(StatusCode.ERROR, span.getStatus().getStatusCode());
+        assertEquals(1, span.getEvents().size(), "the exception must be recorded on the span");
+
+        recorder.close();
+    }
+
+    @Test
+    void the_dispatch_span_carries_the_coverage_of_the_result() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher");
+        // Coverage is set by InterleavedSearchInvoker for a group and by ProtobufSerialization for a single
+        // node, so it is available in both invoker shapes; the fake stands in for either.
+        Coverage coverage = new Coverage(90, 100, 2);
+        SearchInvoker invoker = new FakeInvoker(null, null, coverage);
+
+        recorder.record(() -> invoker.search(query("s1"), 1.0));
+
+        var attrs = recorder.spanNamed("dispatch.search").getAttributes();
+        assertEquals(90L, attrs.get(TraceAttributes.COVERAGE_PERCENTAGE).longValue());
+        assertEquals(2L, attrs.get(TraceAttributes.COVERAGE_NODES).longValue());
+        assertNotNull(attrs.get(TraceAttributes.COVERAGE_DEGRADED));
+
+        recorder.close();
+    }
+
+    @Test
+    void no_coverage_means_NO_coverage_attributes_rather_than_zeros() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher");
+        SearchInvoker invoker = succeeding();   // its Result carries no Coverage
+
+        recorder.record(() -> invoker.search(query("s1"), 1.0));
+
+        var attrs = recorder.spanNamed("dispatch.search").getAttributes();
+        assertNull(attrs.get(TraceAttributes.COVERAGE_PERCENTAGE), "absent, not a misleading zero");
+        assertNull(attrs.get(TraceAttributes.COVERAGE_NODES));
+
+        recorder.close();
+    }
+
+    @Test
+    void a_wrapping_invoker_still_yields_exactly_one_dispatch_span() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("searcher");
+        // Mimics InterleavedSearchInvoker: it drives children via sendSearchRequest/getSearchResult, NOT search(),
+        // so the children must contribute no span of their own. This pins the placement on the base class.
+        SearchInvoker root = new WrappingInvoker(List.of(succeeding(), succeeding(), succeeding()));
+
+        recorder.record(() -> root.search(query("s1"), 1.0));
+
+        assertEquals(1, recorder.countSpans("dispatch.search"),
+                     "one span per search() call, regardless of how many nodes the root fans out to");
+        recorder.close();
+    }
+
+    private static Query query(String schema) {
+        Query query = new Query("?query=test");
+        query.getModel().setRestrict(schema);
+        return query;
+    }
+
+    private static SearchInvoker succeeding() { return new FakeInvoker(null, null, null); }
+    private static SearchInvoker failingWith(ErrorMessage error) { return new FakeInvoker(error, null, null); }
+    private static SearchInvoker throwing(IOException toThrow) { return new FakeInvoker(null, toThrow, null); }
+
+    /** A leaf invoker with no RPC: it either returns a clean result, returns one carrying an error, or throws. */
+    private static final class FakeInvoker extends SearchInvoker {
+
+        private final ErrorMessage error;
+        private final IOException toThrow;
+        private final Coverage coverage;
+        private Query query;
+
+        FakeInvoker(ErrorMessage error, IOException toThrow, Coverage coverage) {
+            super(Optional.empty());
+            this.error = error;
+            this.toThrow = toThrow;
+            this.coverage = coverage;
+        }
+
+        @Override protected Object sendSearchRequest(Query query, double contentShare, Object context) throws IOException {
+            this.query = query;
+            if (toThrow != null) throw toThrow;
+            return context;
+        }
+
+        @Override protected InvokerResult getSearchResult() {
+            Result result = error == null ? new Result(query) : new Result(query, error);
+            if (coverage != null) result.setCoverage(coverage);
+            return new InvokerResult(result);
+        }
+
+        @Override protected void release() { }
+    }
+
+    /** Mimics InterleavedSearchInvoker's shape: fans out to children without calling search() on them. */
+    private static final class WrappingInvoker extends SearchInvoker {
+
+        private final List<SearchInvoker> children;
+        private Query query;
+
+        WrappingInvoker(List<SearchInvoker> children) {
+            super(Optional.empty());
+            this.children = children;
+        }
+
+        @Override protected Object sendSearchRequest(Query query, double contentShare, Object context) throws IOException {
+            this.query = query;
+            for (SearchInvoker child : children)
+                context = child.sendSearchRequest(query, contentShare, context);
+            return context;
+        }
+
+        @Override protected InvokerResult getSearchResult() throws IOException {
+            for (SearchInvoker child : children)
+                child.getSearchResult();
+            return new InvokerResult(new Result(query));
+        }
+
+        @Override protected void release() { children.forEach(SearchInvoker::close); }
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/NodeFillTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/NodeFillTracingTest.java
@@ -1,0 +1,327 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.rpc;
+
+import ai.vespa.telemetry.api.trace.TraceAttributes;
+import com.yahoo.compress.CompressionType;
+import com.yahoo.container.QrSearchersConfig;
+import com.yahoo.prelude.fastsearch.DocumentDatabase;
+import com.yahoo.prelude.fastsearch.FastHit;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.schema.DocumentSummary;
+import com.yahoo.search.schema.Schema;
+import com.yahoo.search.test.SpanRecorder;
+import com.yahoo.slime.BinaryFormat;
+import com.yahoo.slime.Cursor;
+import com.yahoo.slime.Slime;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the L6 {@code node.fill} CLIENT span created in {@link RpcProtobufFillInvoker#sendDocsumsRequest},
+ * one per docsum request that actually goes out on the wire.
+ *
+ * <p>Unlike the search path there is no per-node invoker object to hold the span on: a single
+ * {@code RpcProtobufFillInvoker} fans out to every node that owns hits, and the response receiver handed to JRT
+ * is a lambda. The span is therefore CAPTURED by that lambda. That also handles the retry round for free, since
+ * {@code maybeRetry} re-enters the same method and each invocation gets its own span - anything keyed by node id
+ * would have had its first-wave span overwritten.</p>
+ *
+ * <p>The two paths that send nothing - an unknown node, and a timeout detected before sending - deliberately
+ * create no span, because {@code node.fill} is CLIENT-kind and represents a request that was really made.</p>
+ *
+ * @author onur
+ */
+class NodeFillTracingTest {
+
+    @Test
+    void one_client_span_per_node_that_is_asked() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWithError("nope"),
+                                                            3, replyingWithError("nope")));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0, 3), "default"));
+
+        assertEquals(2, recorder.countSpans("node.fill"), "one per node holding hits");
+        SpanData span = recorder.spans().stream().filter(s -> s.getName().equals("node.fill")).findFirst().orElseThrow();
+        assertEquals(SpanKind.CLIENT, span.getKind(), "an outbound request to a remote service");
+        assertEquals("ai.vespa", span.getInstrumentationScopeInfo().getName());
+
+        recorder.close();
+    }
+
+    @Test
+    void the_node_span_hangs_under_the_dispatch_fill_span() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWithError("nope")));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0), "default"));
+
+        assertEquals(recorder.spanNamed("dispatch.fill").getSpanId(),
+                     recorder.spanNamed("node.fill").getParentSpanId());
+
+        recorder.close();
+    }
+
+    @Test
+    void a_transport_error_marks_the_span_error_with_the_message() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWithError("connection closed")));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0), "default"));
+
+        SpanData span = recorder.spanNamed("node.fill");
+        assertEquals(StatusCode.ERROR, span.getStatus().getStatusCode());
+        assertEquals("connection closed", span.getStatus().getDescription());
+
+        recorder.close();
+    }
+
+    @Test
+    void a_delivered_reply_is_not_an_error() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWith(emptyDocsumReply())));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0), "default"));
+
+        assertEquals(StatusCode.UNSET, recorder.spanNamed("node.fill").getStatus().getStatusCode());
+
+        recorder.close();
+    }
+
+    @Test
+    void an_unknown_node_produces_no_span_because_nothing_was_sent() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of());   // empty pool: getConnection returns null
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0), "default"));
+
+        assertEquals(0, recorder.countSpans("node.fill"),
+                     "node.fill is CLIENT-kind: no request went out, so there is no client span to report");
+        assertEquals(1, recorder.countSpans("dispatch.fill"), "the dispatch span still covers the attempt");
+
+        recorder.close();
+    }
+
+    @Test
+    void nothing_is_recorded_when_telemetry_is_absent() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWithError("nope")));
+
+        invoker.fill(resultWithHitsOn(0), "default");    // outside record(): no telemetry in the context
+
+        assertEquals(0, recorder.countSpans("node.fill"));
+
+        recorder.close();
+    }
+
+    @Test
+    void the_retry_wave_produces_its_own_spans_marked_as_retries() throws Exception {
+        // A node answering with an EMPTY docsum is what a redistribution looks like from the container. Vespa
+        // does not know where the document moved to, so it re-asks every OTHER known node - maybeRetry:346.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWith(emptyDocsumsFor(1)),
+                                                            1, replyingWith(emptyDocsumsFor(1))));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0), "default"));
+
+        List<SpanData> nodeSpans = recorder.spans().stream().filter(s -> s.getName().equals("node.fill")).toList();
+        assertEquals(2, nodeSpans.size(), "one span for the first wave to node 0, one for the retry to node 1");
+        assertEquals(List.of(false, true), nodeSpans.stream().map(s -> s.getAttributes().get(TraceAttributes.FILL_RETRY)).toList(),
+                     "the first wave must NOT be marked a retry and the second must be - this pins the invariant " +
+                     "the derived flag relies on: a bucket whose hits do not belong to its node is a retry");
+
+        recorder.close();
+    }
+
+    @Test
+    void the_dispatch_span_records_that_a_retry_happened_and_how_wide_it_went() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWith(emptyDocsumsFor(1)),
+                                                            1, replyingWith(emptyDocsumsFor(1))));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0), "default"));
+
+        var attrs = recorder.spanNamed("dispatch.fill").getAttributes();
+        assertEquals(1L, attrs.get(TraceAttributes.FILL_SKIPPED).longValue(), "one hit came back with no docsum");
+        assertEquals(true, attrs.get(TraceAttributes.FILL_RETRIED));
+        assertEquals(1L, attrs.get(TraceAttributes.FILL_RETRY_NODES).longValue(), "every OTHER known node: node 1 only");
+        assertEquals(1L, attrs.get(TraceAttributes.FILL_UNFILLED).longValue(), "the retry did not find it either");
+
+        recorder.close();
+    }
+
+    @Test
+    void a_retry_declined_by_the_limit_is_recorded_as_retried_false() throws Exception {
+        // retryLimit = min(docsumRetryLimit 10, 0.5 * numHitsToFill + 1). With two hits that is 2.0, and two
+        // skipped hits is not < 2.0, so Vespa gives up - those docsums are lost for this query.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWith(emptyDocsumsFor(2)),
+                                                            1, replyingWith(emptyDocsumsFor(2))));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0, 0), "default"));
+
+        var attrs = recorder.spanNamed("dispatch.fill").getAttributes();
+        assertEquals(2L, attrs.get(TraceAttributes.FILL_SKIPPED).longValue());
+        assertEquals(false, attrs.get(TraceAttributes.FILL_RETRIED), "considered and declined, which is not the same as never needed");
+        assertEquals(1, recorder.countSpans("node.fill"), "no second wave was sent");
+
+        recorder.close();
+    }
+
+    @Test
+    void a_fill_that_needs_no_retry_records_no_retry_attributes_at_all() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWithError("nope")));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0), "default"));
+
+        var attrs = recorder.spanNamed("dispatch.fill").getAttributes();
+        assertNull(attrs.get(TraceAttributes.FILL_RETRIED), "absent means the question never arose, which differs from false");
+        assertNull(attrs.get(TraceAttributes.FILL_SKIPPED));
+
+        recorder.close();
+    }
+
+    @Test
+    void the_node_span_identifies_which_node_it_went_to_and_how_much_it_asked_for() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(7, replyingWithError("nope")));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(7, 7), "default"));
+
+        var attrs = recorder.spanNamed("node.fill").getAttributes();
+        assertEquals(7L, attrs.get(TraceAttributes.CONTENT_NODE_KEY).longValue(), "the distribution key operators work with");
+        assertEquals("vespa_jrt", attrs.get(TraceAttributes.RPC_SYSTEM));
+        assertEquals("vespa.searchprotocol.getDocsums", attrs.get(TraceAttributes.RPC_METHOD_KEY));
+        assertEquals(2L, attrs.get(TraceAttributes.FILL_HITS_REQUESTED).longValue(), "both hits live on node 7");
+
+        recorder.close();
+    }
+
+    @Test
+    void the_dispatch_span_carries_the_fan_out_and_the_hit_counts() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker invoker = invokerOver(Map.of(0, replyingWithError("nope"),
+                                                            3, replyingWithError("nope")));
+
+        recorder.record(() -> invoker.fill(resultWithHitsOn(0, 0, 3), "default"));
+
+        var attrs = recorder.spanNamed("dispatch.fill").getAttributes();
+        assertEquals(2L, attrs.get(TraceAttributes.FILL_NODES).longValue(), "hits live on two of the nodes");
+        assertEquals(3L, attrs.get(TraceAttributes.FILL_HITS).longValue(), "three fillable hits in this partition");
+        assertEquals(0L, attrs.get(TraceAttributes.FILL_HITS_FILLED).longValue(), "both nodes errored, so nothing was filled");
+
+        recorder.close();
+    }
+
+    @Test
+    void the_dispatch_span_names_the_schema_only_when_the_query_restricts_to_exactly_one() throws Exception {
+        // VespaBackend.getDocumentDatabase falls back to the FIRST configured database when the restrict is
+        // ambiguous, so the schema is read from the query instead and simply left unset when it is not certain.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("cluster.fill");
+        RpcProtobufFillInvoker one = invokerOver(Map.of(0, replyingWithError("nope")));
+        RpcProtobufFillInvoker two = invokerOver(Map.of(0, replyingWithError("nope")));
+
+        recorder.record(() -> {
+            one.fill(resultFor(new Query("?query=test&restrict=music"), 0), "default");
+            two.fill(resultFor(new Query("?query=test&restrict=music,books"), 0), "default");
+        });
+
+        List<SpanData> dispatch = recorder.spans().stream().filter(s -> s.getName().equals("dispatch.fill")).toList();
+        assertEquals(2, dispatch.size());
+        assertEquals("music", dispatch.get(0).getAttributes().get(TraceAttributes.SCHEMA));
+        assertNull(dispatch.get(1).getAttributes().get(TraceAttributes.SCHEMA), "two schemas: unset beats a confidently wrong one");
+
+        recorder.close();
+    }
+
+    // ---- fixture ------------------------------------------------------------------------------------------
+
+    private static final CompressService COMPRESSOR = new CompressService();
+
+    private RpcProtobufFillInvoker invokerOver(Map<Integer, Client.NodeConnection> connections) {
+        return new RpcProtobufFillInvoker(new RpcResourcePool(new HashMap<>(connections)),
+                                          COMPRESSOR,
+                                          new DocumentDatabase(schemaWithDefaultSummary()),
+                                          "container.0",
+                                          RpcProtobufFillInvoker.DecodePolicy.EAGER,
+                                          false,
+                                          new QrSearchersConfig.Builder().build());
+    }
+
+    /** A schema declaring a "default" document summary, which is the class the tests ask to fill. */
+    private static Schema schemaWithDefaultSummary() {
+        return new Schema.Builder("test")
+                .add(new DocumentSummary.Builder("default").addField("title", "string").build())
+                .build();
+    }
+
+    /** A result whose fillable hits are spread over the given distribution keys, one hit each. */
+    private static Result resultWithHitsOn(int... distributionKeys) {
+        return resultFor(new Query("?query=test"), distributionKeys);
+    }
+
+    private static Result resultFor(Query query, int... distributionKeys) {
+        Result result = new Result(query);
+        for (int key : distributionKeys) {
+            FastHit hit = new FastHit(new byte[12], 1.0, OptionalInt.empty(), 0, key);
+            hit.setFillable();
+            result.hits().add(hit);
+        }
+        return result;
+    }
+
+    private static Client.NodeConnection replyingWithError(String error) {
+        return replying(Client.ResponseOrError.fromError(error));
+    }
+
+    private static Client.NodeConnection replyingWith(Client.ProtobufResponse response) {
+        return replying(Client.ResponseOrError.fromResponse(response));
+    }
+
+    private static Client.NodeConnection replying(Client.ResponseOrError<Client.ProtobufResponse> reply) {
+        return new Client.NodeConnection() {
+            @Override
+            public void request(String rpcMethod, CompressionType compression, int uncompressedLength,
+                                byte[] compressedPayload, Client.ResponseReceiver receiver, double timeoutSeconds) {
+                receiver.receive(reply);
+            }
+            @Override public void close() { }
+        };
+    }
+
+    /**
+     * A reply carrying a docsums ARRAY of n entries, none of which has a "docsum" field - which is how the
+     * content layer reports "I no longer hold this document". An entirely empty reply will NOT do: fill()
+     * returns early when the docsums field itself is invalid, producing no skipped hits and hence no retry.
+     */
+    private static Client.ProtobufResponse emptyDocsumsFor(int n) {
+        Slime slime = new Slime();
+        Cursor root = slime.setObject();
+        Cursor docsums = root.setArray("docsums");
+        for (int i = 0; i < n; i++) docsums.addObject();
+        byte[] payload = ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol.DocsumReply.newBuilder()
+                .setSlimeSummaries(com.google.protobuf.ByteString.copyFrom(BinaryFormat.encode(slime)))
+                .build().toByteArray();
+        return new Client.ProtobufResponse(CompressionType.NONE.getCode(), payload.length, payload);
+    }
+
+    private static Client.ProtobufResponse emptyDocsumReply() {
+        byte[] payload = ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol.DocsumReply.newBuilder()
+                                                                                             .build()
+                                                                                             .toByteArray();
+        return new Client.ProtobufResponse(CompressionType.NONE.getCode(), payload.length, payload);
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/NodeSearchTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/NodeSearchTracingTest.java
@@ -1,0 +1,194 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.rpc;
+
+import ai.vespa.telemetry.api.trace.TraceAttributes;
+import com.google.common.collect.ImmutableMap;
+import com.yahoo.compress.CompressionType;
+import com.yahoo.container.QrSearchersConfig;
+import com.yahoo.prelude.fastsearch.ClusterParams;
+import com.yahoo.prelude.fastsearch.VespaBackend;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.dispatch.searchcluster.Node;
+import com.yahoo.search.test.SpanRecorder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies the L5 {@code node.search} CLIENT span created in {@link RpcSearchInvoker}, one per content node.
+ *
+ * <p>The span is carried on the invoker instance, which is already per-query-per-node and is already the object
+ * handed to the transport layer as the {@code ResponseReceiver} — so no lookup structure is needed. It is created
+ * on the worker thread in {@code sendSearchRequest}, before the two early returns, and ended by {@code receive}
+ * when the transport reports an outcome.</p>
+ *
+ * <p>{@code release()} ends it on exactly the two paths that create the span and then return without sending
+ * anything: an unknown node connection, and a timeout detected before sending. It is NOT what covers a node that
+ * goes silent — JRT calls the response waiter exactly once for every request it accepts, firing
+ * {@code InvocationClient.run()} on the scheduled timeout, so a silent node reaches {@code receive} with a
+ * TIMEOUT error and {@code release()} then finds the span already ended. The tests below that use a connection
+ * which never replies are therefore exercising {@code release()} as a BACKSTOP, not reproducing a production
+ * scenario.</p>
+ *
+ * @author onur
+ */
+class NodeSearchTracingTest {
+
+    private final CompressService compressor = new CompressService();
+
+    @Test
+    void a_reply_produces_one_client_span_under_the_dispatch_span() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("dispatch.search");
+        RpcSearchInvoker invoker = invokerReplying(Client.ResponseOrError.fromResponse(
+                new Client.ProtobufResponse(CompressionType.NONE.getCode(), 0, new byte[0])));
+
+        recorder.record(() -> invoker.sendSearchRequest(new Query("?query=test"), 1.0, null));
+
+        SpanData span = recorder.spanNamed("node.search");
+        assertEquals(SpanKind.CLIENT, span.getKind(), "an outbound request to a remote service");
+        assertEquals("ai.vespa", span.getInstrumentationScopeInfo().getName());
+        assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), span.getParentSpanId(),
+                     "the node span must be a child of the dispatch span");
+        assertEquals(StatusCode.UNSET, span.getStatus().getStatusCode(), "a delivered reply is not an error");
+
+        recorder.close();
+    }
+
+    @Test
+    void the_span_identifies_which_node_it_went_to() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("dispatch.search");
+        RpcSearchInvoker invoker = invokerReplying(Client.ResponseOrError.fromError("whatever"));
+
+        recorder.record(() -> invoker.sendSearchRequest(new Query("?query=test"), 1.0, null));
+
+        var attrs = recorder.spanNamed("node.search").getAttributes();
+        assertEquals(7L, attrs.get(TraceAttributes.CONTENT_NODE_KEY).longValue(), "the distribution key operators work with");
+        assertEquals("seven", attrs.get(TraceAttributes.CONTENT_NODE_HOST));
+        assertEquals(1L, attrs.get(TraceAttributes.CONTENT_GROUP).longValue());
+        assertEquals("vespa_jrt", attrs.get(TraceAttributes.RPC_SYSTEM));
+        assertEquals("vespa.searchprotocol.search", attrs.get(TraceAttributes.RPC_METHOD_KEY));
+
+        recorder.close();
+    }
+
+    @Test
+    void a_span_ended_without_a_reply_is_STILL_identifiable() throws Exception {
+        // The attributes are set at send time, so a span ended by release() - an unknown node, or a pre-send
+        // timeout - is still named even though nothing ever came back from it.
+        SpanRecorder recorder = SpanRecorder.underParentSpan("dispatch.search");
+        RpcSearchInvoker invoker = invokerReplying(null);
+
+        recorder.record(() -> {
+            invoker.sendSearchRequest(new Query("?query=test"), 1.0, null);
+            invoker.release();
+        });
+
+        var attrs = recorder.spanNamed("node.search").getAttributes();
+        assertEquals(7L, attrs.get(TraceAttributes.CONTENT_NODE_KEY).longValue());
+        assertEquals("seven", attrs.get(TraceAttributes.CONTENT_NODE_HOST));
+
+        recorder.close();
+    }
+
+    @Test
+    void an_error_reply_marks_the_span_error_with_the_transport_message() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("dispatch.search");
+        RpcSearchInvoker invoker = invokerReplying(Client.ResponseOrError.fromError("connection closed"));
+
+        recorder.record(() -> invoker.sendSearchRequest(new Query("?query=test"), 1.0, null));
+
+        SpanData span = recorder.spanNamed("node.search");
+        assertEquals(StatusCode.ERROR, span.getStatus().getStatusCode());
+        assertEquals("connection closed", span.getStatus().getDescription());
+
+        recorder.close();
+    }
+
+    @Test
+    void a_span_with_no_reply_is_ended_by_release_naming_the_node() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("dispatch.search");
+        RpcSearchInvoker invoker = invokerReplying(null);   // a connection that never replies: release() is the backstop
+
+        recorder.record(() -> {
+            invoker.sendSearchRequest(new Query("?query=test"), 1.0, null);
+            invoker.release();                              // as InterleavedSearchInvoker.release would
+        });
+
+        SpanData span = recorder.spanNamed("node.search");
+        assertEquals(StatusCode.ERROR, span.getStatus().getStatusCode());
+        assertTrue(span.getStatus().getDescription().startsWith("ended without a response"), "neutral wording: covers the unknown-node and pre-send-timeout paths alike");
+        assertTrue(span.getStatus().getDescription().contains("7"), "names the distribution key");
+        assertTrue(span.getStatus().getDescription().contains("seven"), "names the host");
+
+        recorder.close();
+    }
+
+    @Test
+    void release_after_a_reply_does_not_restamp_the_finished_span() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("dispatch.search");
+        RpcSearchInvoker invoker = invokerReplying(Client.ResponseOrError.fromResponse(
+                new Client.ProtobufResponse(CompressionType.NONE.getCode(), 0, new byte[0])));
+
+        recorder.record(() -> {
+            invoker.sendSearchRequest(new Query("?query=test"), 1.0, null);
+            // release() also runs for invokers that DID answer: InterleavedSearchInvoker.ejectInvoker calls it
+            // on every invoker it consumes. It must not turn a successful span into an error.
+            invoker.release();
+        });
+
+        SpanData span = recorder.spanNamed("node.search");
+        assertEquals(StatusCode.UNSET, span.getStatus().getStatusCode(),
+                     "the first ending wins; release() must find it already ended and do nothing");
+
+        recorder.close();
+    }
+
+    @Test
+    void an_unknown_node_still_yields_exactly_one_span_ended_by_release() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("dispatch.search");
+        // An empty pool: getConnection returns null, so sendSearchRequest takes the unknown-node early return.
+        RpcSearchInvoker invoker = new RpcSearchInvoker(mockSearcher(), compressor, node(),
+                                                        new RpcResourcePool(ImmutableMap.of()), 1000,
+                                                        new QrSearchersConfig.Builder().build());
+
+        recorder.record(() -> {
+            invoker.sendSearchRequest(new Query("?query=test"), 1.0, null);
+            invoker.release();
+        });
+
+        assertEquals(1, recorder.countSpans("node.search"), "one span per node, however the attempt ended");
+        assertEquals(StatusCode.ERROR, recorder.spanNamed("node.search").getStatus().getStatusCode());
+
+        recorder.close();
+    }
+
+    private static Node node() { return new Node("test", 7, "seven", 1, true); }
+
+    /** An invoker whose connection hands {@code reply} straight back, or nothing at all when it is null. */
+    private RpcSearchInvoker invokerReplying(Client.ResponseOrError<Client.ProtobufResponse> reply) {
+        Client.NodeConnection connection = new Client.NodeConnection() {
+            @Override
+            public void request(String rpcMethod, CompressionType compression, int uncompressedLength,
+                                byte[] compressedPayload, Client.ResponseReceiver responseReceiver, double timeoutSeconds) {
+                if (reply != null) responseReceiver.receive(reply);
+            }
+            @Override public void close() { }
+        };
+        return new RpcSearchInvoker(mockSearcher(), compressor, node(),
+                                    new RpcResourcePool(ImmutableMap.of(node().key(), connection)), 1000,
+                                    new QrSearchersConfig.Builder().build());
+    }
+
+    private VespaBackend mockSearcher() {
+        return new VespaBackend(new ClusterParams("container.0")) {
+            @Override protected Result doSearch2(String schema, Query query) { fail("Unexpected call"); return null; }
+            @Override protected void doPartialFill(Result result, String summaryClass) { fail("Unexpected call"); }
+        };
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/handler/SearchHandlerTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/SearchHandlerTracingTest.java
@@ -1,0 +1,65 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.handler;
+
+import ai.vespa.telemetry.api.trace.TraceAttributes;
+import com.yahoo.component.chain.Chain;
+import com.yahoo.search.Query;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.test.SpanRecorder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the L3 CHAIN span created in {@link SearchHandler#searchAndFill}: with a recording-telemetry context
+ * current (as L2 makes it on the worker thread), it wraps the search-chain execution in an INTERNAL, default-scope
+ * span named from the chain, as a child of the current span, emitted exactly once per query.
+ *
+ * <p>{@code searchAndFill} is called directly (synchronously) rather than through the async request driver, so the
+ * assertion does not depend on worker-pool / query-timeout / response-rendering timing.</p>
+ *
+ * @author onur
+ */
+class SearchHandlerTracingTest {
+
+    @Test
+    void chain_span_wraps_the_search_as_a_child_of_the_current_span() {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("parent");
+
+        try (SearchHandlerTester tester = new SearchHandlerTester()) {
+            Chain<Searcher> chain = tester.searchHandler.getSearchChainRegistry().getChain("default");
+            recorder.record(() -> tester.searchHandler.searchAndFill(new Query("?query=test"), chain));
+        }
+
+        SpanData chainSpan = recorder.spanNamed("chain.search");
+        assertEquals("chain.search", chainSpan.getName());
+        assertEquals(SpanKind.INTERNAL, chainSpan.getKind());
+        assertEquals("ai.vespa", chainSpan.getInstrumentationScopeInfo().getName());
+        assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), chainSpan.getParentSpanId(),
+                     "the chain span must be a child of the current span");
+
+        recorder.close();
+    }
+
+    @Test
+    void chain_span_carries_the_chain_id_and_rank_profile_as_attributes() {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("parent");
+
+        try (SearchHandlerTester tester = new SearchHandlerTester()) {
+            Chain<Searcher> chain = tester.searchHandler.getSearchChainRegistry().getChain("default");
+            Query query = new Query("?query=test");
+            query.getRanking().setProfile("a_rank_profile");   // set explicitly so it cannot be confused with the chain id
+            recorder.record(() -> tester.searchHandler.searchAndFill(query, chain));
+        }
+
+        SpanData chainSpan = recorder.spanNamed("chain.search");
+        assertEquals("default", chainSpan.getAttributes().get(TraceAttributes.SEARCH_CHAIN));
+        assertEquals("a_rank_profile", chainSpan.getAttributes().get(TraceAttributes.QUERY_RANK_PROFILE));
+
+        recorder.close();
+    }
+
+
+}

--- a/container-search/src/test/java/com/yahoo/search/searchchain/AsyncExecutionTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/search/searchchain/AsyncExecutionTracingTest.java
@@ -1,0 +1,114 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.searchchain;
+
+import com.yahoo.component.ComponentId;
+import com.yahoo.component.chain.Chain;
+import com.yahoo.language.simple.SimpleLinguistics;
+import com.yahoo.prelude.IndexFacts;
+import com.yahoo.processing.rendering.AsynchronousSectionedRenderer;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.rendering.RendererRegistry;
+import com.yahoo.search.schema.SchemaInfo;
+import com.yahoo.search.test.SpanRecorder;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Verifies L4 fork context propagation at {@link AsyncExecution}: a sub-chain executed on a pool thread must
+ * still produce spans, parented under the span that was current on the forking thread.
+ *
+ * <p>Without the propagation these spans are not merely mis-parented — they are never created. The tracer is
+ * resolved from the context ({@link Telemetry#from}), so a fork thread with no context yields the no-op
+ * telemetry, a non-recording span, and nothing exported at all.</p>
+ *
+ * @author onur
+ */
+class AsyncExecutionTracingTest {
+
+    @Test
+    void a_forked_sub_chain_produces_spans_parented_under_the_forking_span() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("forking");
+
+        AtomicReference<String> threadThatRanTheSubChain = new AtomicReference<>();
+        Chain<Searcher> target = new Chain<>(new ComponentId("target"),
+                                             new ThreadRecordingSearcher("A", threadThatRanTheSubChain));
+        // createContextStub gives a real Executors.newSingleThreadExecutor(), so this is a genuine thread hand-off
+        Execution.Context context = Execution.Context.createContextStub();
+
+        recorder.record(() -> new AsyncExecution(target, context).search(new Query("?query=test"))
+                                                                 .get(30, TimeUnit.SECONDS));
+
+        assertNotEquals(Thread.currentThread().getName(), threadThatRanTheSubChain.get(),
+                        "the sub-chain must really run on another thread, or this test proves nothing");
+
+        SpanData searcherSpan = recorder.spanNamed("searcher.search");
+        assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), searcherSpan.getParentSpanId(),
+                     "a span created on the fork thread must be a child of the forking span");
+        assertEquals(recorder.parentSpan().getSpanContext().getTraceId(), searcherSpan.getTraceId(),
+                     "and must stay in the same trace");
+
+        recorder.close();
+    }
+
+    @Test
+    void the_rejection_fallback_stays_correctly_parented_because_it_runs_on_the_calling_thread() throws Exception {
+        SpanRecorder recorder = SpanRecorder.underParentSpan("forking");
+
+        AtomicReference<String> threadThatRanTheSubChain = new AtomicReference<>();
+        Chain<Searcher> target = new Chain<>(new ComponentId("target"),
+                                             new ThreadRecordingSearcher("A", threadThatRanTheSubChain));
+        Executor alwaysRejects = task -> { throw new RejectedExecutionException("pool full"); };
+
+        recorder.record(() -> new AsyncExecution(target, contextWith(alwaysRejects)).search(new Query("?query=test"))
+                                                                                    .get(30, TimeUnit.SECONDS));
+
+        assertEquals(Thread.currentThread().getName(), threadThatRanTheSubChain.get(),
+                     "a rejected task runs inline on the calling thread");
+
+        SpanData searcherSpan = recorder.spanNamed("searcher.search");
+        assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), searcherSpan.getParentSpanId(),
+                     "the inline fallback needs no propagation: the context is already current here");
+
+        recorder.close();
+    }
+
+    /** An Execution.Context like createContextStub, but with an executor we control. */
+    private static Execution.Context contextWith(Executor executor) {
+        return new Execution.Context(new SearchChainRegistry(),
+                                     new IndexFacts(),
+                                     SchemaInfo.empty(),
+                                     null,
+                                     new RendererRegistry(Runnable::run),
+                                     new SimpleLinguistics(),
+                                     executor);
+    }
+
+
+
+    /** Terminal searcher which records the thread it ran on, so the tests can prove a hand-off did or did not happen. */
+    private static final class ThreadRecordingSearcher extends Searcher {
+
+        private final AtomicReference<String> threadName;
+
+        ThreadRecordingSearcher(String id, AtomicReference<String> threadName) {
+            super(new ComponentId(id));
+            this.threadName = threadName;
+        }
+
+        @Override
+        public Result search(Query query, Execution execution) {
+            threadName.set(Thread.currentThread().getName());
+            return new Result(query);
+        }
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/test/SpanRecorder.java
+++ b/container-search/src/test/java/com/yahoo/search/test/SpanRecorder.java
@@ -1,0 +1,133 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.test;
+
+import ai.vespa.telemetry.api.NoopTelemetry;
+import ai.vespa.telemetry.api.Telemetry;
+import ai.vespa.telemetry.api.trace.ScopedTracer;
+import ai.vespa.telemetry.api.trace.OtelTracing;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test fixture for the internal OpenTelemetry span instrumentation. It installs a RECORDING {@link Telemetry}
+ * into an OpenTelemetry {@link Context} beneath a parent span, makes that context current while the code under
+ * test runs — exactly as L2 does on the worker thread and L4 does on a fork thread — and collects whatever the
+ * instrumentation emitted.
+ *
+ * <p>Using this rather than hand-rolling the setup also removes a silent-failure mode: with no telemetry in the
+ * current context, {@link Telemetry#from} yields the no-op instance and the code under test emits nothing, so a
+ * test that forgot the fixture would PASS while asserting on an empty exporter.</p>
+ *
+ * <p>Typical use:</p>
+ * <pre>
+ * SpanRecorder recorder = SpanRecorder.underParentSpan("chain");
+ * recorder.record(() -&gt; execution.search(new Query("?query=test")));
+ *
+ * SpanData searcherSpan = recorder.spanNamed("searcher A");
+ * assertEquals(recorder.parentSpan().getSpanContext().getSpanId(), searcherSpan.getParentSpanId());
+ * recorder.close();
+ * </pre>
+ *
+ * @author onur
+ */
+public final class SpanRecorder implements AutoCloseable {
+
+    /** A {@link Runnable} that may throw a checked exception, so code under test declaring {@code throws} fits. */
+    @FunctionalInterface
+    public interface ThrowingRunnable<E extends Exception> {
+        void run() throws E;
+    }
+
+    private final InMemorySpanExporter exporter;
+    private final SdkTracerProvider tracerProvider;
+    private final Telemetry telemetry;
+    private final Span parent;
+    private final Context context;
+
+    /** Snapshot taken before the provider is shut down; see {@link #spans()}. */
+    private List<SpanData> collected;
+
+    private SpanRecorder(String parentSpanName) {
+        exporter = InMemorySpanExporter.create();
+        tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+        telemetry = new Telemetry() {
+            @Override public ScopedTracer tracer(String scope) { return new ScopedTracer(tracerProvider.get(scope)); }
+            @Override public TextMapPropagator textMapPropagator() { return NoopTelemetry.INSTANCE.textMapPropagator(); }
+        };
+        parent = telemetry.tracer(OtelTracing.DEFAULT_SCOPE).startSpan(parentSpanName, SpanKind.INTERNAL, Context.root());
+        context = Telemetry.store(Context.root().with(parent), telemetry);
+    }
+
+    /** A recorder whose emitted spans will hang beneath a recording parent span with the given name. */
+    public static SpanRecorder underParentSpan(String parentSpanName) {
+        return new SpanRecorder(parentSpanName);
+    }
+
+    /** The parent span; assert against {@code parentSpan().getSpanContext().getSpanId()} to check parenting. */
+    public Span parentSpan() { return parent; }
+
+    /** The context carrying the parent span and the recording telemetry, for tests that must make it current themselves. */
+    public Context context() { return context; }
+
+    /** The recording telemetry, for tests that need to create spans of their own. */
+    public Telemetry telemetry() { return telemetry; }
+
+    /** Runs {@code body} with the recording context current. */
+    public <E extends Exception> void record(ThrowingRunnable<E> body) throws E {
+        // Explicit Scope + finally rather than try-with-resources: container-search compiles tests with
+        // -Werror -Xlint:try, which rejects an unreferenced auto-closeable resource.
+        Scope scope = context.makeCurrent();
+        try {
+            body.run();
+        } finally {
+            scope.close();
+        }
+    }
+
+    /**
+     * Every span emitted, including the parent, which is ended on the first call.
+     *
+     * <p>The result is snapshotted, because {@code tracerProvider.close()} shuts the exporter down and
+     * {@link InMemorySpanExporter#shutdown} CLEARS what it collected. Snapshotting here makes the
+     * assert-after-close mistake impossible.</p>
+     */
+    public List<SpanData> spans() {
+        if (collected == null) {
+            parent.end();
+            collected = List.copyOf(exporter.getFinishedSpanItems());
+        }
+        return collected;
+    }
+
+    /** The single span with this exact name; fails the test if there is not exactly one. */
+    public SpanData spanNamed(String name) {
+        List<SpanData> matching = spans().stream().filter(s -> s.getName().equals(name)).toList();
+        assertEquals(1, matching.size(), "expected exactly one span named '" + name + "', got " + spans());
+        return matching.get(0);
+    }
+
+    /** How many spans have a name starting with {@code prefix} — for asserting that none were emitted. */
+    public long countSpans(String prefix) {
+        return spans().stream().filter(s -> s.getName().startsWith(prefix)).count();
+    }
+
+    /** Idempotent; safe to call after asserting, and safe not to call at all. */
+    @Override
+    public void close() {
+        spans();                  // snapshot before the exporter is cleared
+        tracerProvider.close();
+    }
+}

--- a/metrics-proxy/pom.xml
+++ b/metrics-proxy/pom.xml
@@ -110,7 +110,17 @@
 
     <!-- test scope -->
 
-
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>container-opentelemetry</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>


### PR DESCRIPTION
## Goal

Earlier work put the OpenTelemetry seam in place and emitted one SERVER span per HTTP request. This PR is the next step: it instruments the container's query path underneath that span, so a request breaks down into the search chain, each searcher, the dispatch to each content cluster, and each RPC to each content node — for both phases of Vespa's search, matching and summary fill. Outbound HTTP clients and embedding searchers are separate work packages.

## The three concepts, one sentence each

- **Trace** — the end-to-end record of one request, identified by a trace id shared by everything in it.
- **Span** — one named, timed operation inside that trace; each span names its parent, so the spans of a request form a tree.
- **Span attributes** — typed key/value pairs on a span (`vespa.schema=music`, `vespa.content.node_key=3`); this is what you filter and group by when querying traces.

## How the context travels

A span can only be created if two things are reachable at the site: the **parent span**, and the **tracer**. Both live in the OpenTelemetry `Context`. So the design reduces to one question — how does that context reach every place a span is created? It takes four different mechanisms, because no single one spans all of it.

| # | Hop | Mechanism | Where |
|---|---|---|---|
| 1 | upstream caller → Jetty thread | W3C `traceparent` header extracted into a `Context`. If the caller sent one, this request continues *their* trace; if not, a fresh trace starts here. | `JettyServerSpanHandler:104` |
| 2 | Jetty thread → the request object | The SERVER span and the `Telemetry` go into the `Context`, and the `Context` is stored **on the Jetty request as an attribute** | `JettyServerSpanHandler:109-110` |
| 3 | Jetty request → jdisc request | Copied into the jdisc request's context map, because the jdisc layer never sees the Jetty request | `HttpRequestFactory:47-48` |
| 4 | jdisc request → container worker thread | The handler reads the `Context` back off the request and hands it to `instrument`, which **makes it current** on this thread | `ThreadedRequestHandler:190, 212-215` |
| 5 | worker thread → the whole synchronous search path | Free. Every span below reads `Context.current()`; nothing is plumbed through `SearchHandler`, `Execution`, the searchers or the invokers | all search-path sites |
| 6 | worker thread → executor pool threads | `OtelTracing.withCurrentContext(task)` captures the context at submit time; the pool thread makes it current and closes the scope when the task returns | `ClusterSearcher`, `AsyncExecution` ×2 |
| 7 | worker thread → JRT reply thread | **No context at all.** The span is created on the worker thread and carried to the reply as an object — a field on the per-node invoker, or a captured local. The transport thread only ends it. | `RpcSearchInvoker`, `RpcProtobufFillInvoker` |

Steps 2–4 exist because a thread-local cannot cross the Jetty-to-worker hand-off, but the request object can. Steps 6–7 exist because the same problem recurs at every fork: OpenTelemetry's context thread-local is **not inheritable**.

Worth reading in the diff: step 1 extracts from `Context.root()`, not `Context.current()`. Jetty threads are reused, so extracting from the root makes a request immune to a scope left behind by a previous one on the same thread.

```mermaid
sequenceDiagram
    autonumber
    participant U as Upstream caller
    participant J as Jetty thread
    participant R as jdisc request object
    participant W as Container worker thread
    participant P as Executor pool thread
    participant T as JRT transport thread

    U->>J: HTTP request with an optional traceparent header
    Note over J: extract from Context.root<br/>continue the upstream trace or start a new one
    Note over J: create the SERVER span<br/>put the span and the Telemetry into a Context
    J->>R: store the Context on the request object
    Note over R: an object survives the thread hand-off<br/>a thread-local would not
    R->>W: jdisc dispatches the request
    Note over W: read the Context back and make it current<br/>every span below now finds it automatically
    W->>P: per-schema and federation forks wrapped with withCurrentContext
    Note over P: the task makes the Context current<br/>and closes the scope when it returns
    W->>T: RPC sent and the span travels as an object
    Note over T: the reply thread ends the span<br/>and never reads a Context
```

**If a hop is missed:** because the tracer itself comes from the context, a thread without one produces a *non-recording* span. Work below a missed hop does not appear mis-parented — it does not appear at all. That is why every fork site is wrapped explicitly, and why each has a test that fails if the wrapping is removed.

**Why the telemetry rides in the context rather than being injected.** The container injects dependencies into components it constructs and owns. The places that need to create spans are not those: they are per-request objects (`Execution`, `SearchInvoker`, `FillInvoker` and the RPC invokers, built per query by factories) and public base classes (`Searcher`, `ThreadedRequestHandler`) whose constructors are `@PublicApi` and are extended by third-party code. Adding a `Telemetry` constructor parameter there would break every custom searcher. The context already reaches all of them.

### Storing and loading the Telemetry

The context is a key/value map, so the `Telemetry` rides in it under a key that is deliberately private:

```java
static Context store(Context ctx, Telemetry telemetry) {
    return (telemetry == null || telemetry == NoopTelemetry.INSTANCE) ? ctx : ctx.with(Key.INSTANCE, telemetry);
}

static Telemetry from(Context ctx) {
    Telemetry telemetry = ctx.get(Key.INSTANCE);
    return telemetry != null ? telemetry : NoopTelemetry.INSTANCE;
}

final class Key {
    private static final ContextKey<Telemetry> INSTANCE = ContextKey.named("ai.vespa.telemetry");
    private Key() { }
}
```

Three properties matter. The key is **private**: a bare field on an interface would be implicitly `public static final`, which would turn the carrier into a public extension point — but `ContextKey` is compared by reference, so it must stay one shared instance, which the nested `Key` class provides while the enclosing interface reaches it as a nestmate. `store` **short-circuits** when telemetry is absent or the no-op instance, so a disabled deployment does not even allocate a new context. And `from` **never returns null** — absent means the no-op instance, which is what lets every span site skip a null check.

### Making it current, then carrying it across a fork

`instrument` makes the span current for the duration of the body, which pushes the context into OpenTelemetry's `ThreadLocalContextStorage`. From there every nested call finds it through `Context.current()` with no plumbing. The fork helper is two lines, and the second one is the OpenTelemetry API's own:

```java
public static Runnable withCurrentContext(Runnable task) {
    return Context.current().wrap(task);
}

// io.opentelemetry.context.Context
default Runnable wrap(Runnable runnable) {
    return () -> {
        try (Scope ignored = makeCurrent()) {
            runnable.run();
        }
    };
}
```

The capture happens at **wrap time, on the forking thread** — not when the task later runs — and the scope is closed when the task returns, so a pooled thread never leaks context into an unrelated later task.

Worked example, the per-schema fan-out in `ClusterSearcher`:

```java
// ---- worker thread -------------------------------------------------------
// Context.current() holds:  SERVER -> handler.SearchHandler -> chain.search
//                           -> searcher.search (ClusterSearcher)
//                           plus the Telemetry under "ai.vespa.telemetry"

FutureTask<Result> task = new FutureTask<>(() -> perSchemaSearch(schema, query));
executor.execute(OtelTracing.withCurrentContext(task));
//                           `-- Context.current() is captured HERE, on this thread

// ---- pool thread ---------------------------------------------------------
// the wrapper runs:  makeCurrent()  ->  task.run()  ->  scope.close()
//   perSchemaSearch -> ... -> SearchInvoker.search
//       OtelTracing.instrument("dispatch.search", ...)
//         -> Telemetry.from(Context.current())   the SAME Telemetry, carried across
//         -> parent = the searcher.search span   so dispatch.search attaches correctly
```

Remove that one `withCurrentContext` and `Context.current()` on the pool thread is `Context.root()`. `Telemetry.from` then returns the no-op instance, `dispatch.search` and every `node.search` beneath it become non-recording, and the entire subtree vanishes from the trace without any error anywhere. That is what the fork tests assert against.


## What we built

Three additive classes in `container-opentelemetry`, so a span site is one line and no site handles a tracer, a parent, a scope or an exception path by hand:

- **`OtelTracing`** — `instrument(name, body)` runs the body inside a span: reads the tracer and parent from the context, starts the span, makes it current for the duration, records and rethrows any exception, and always ends it. `startSpan(...)` for spans that must be ended on a different thread. `withCurrentContext(task)` for a thread hand-off — this one **returns a wrapper and runs nothing**.
- **`TraceAttributes`** — the complete emitted attribute vocabulary, 28 keys, in one file, so what we publish is reviewable in one place.
- **`ThrowingSupplier`** — lets a body declaring `throws` be instrumented without the instrumentation altering its exception behaviour.

`ScopedTracer` (pre-existing) gained the matching `instrument` methods. Its `startSpan` is the single creation choke point and **never throws**: on any failure it logs and returns a non-recording span, so instrumentation cannot break request handling.

A site therefore looks like this, with existing logic unchanged and only re-indented:

```java
public Result search(Query query, double contentShare) throws IOException {
    return OtelTracing.instrument("dispatch.search", () -> {
        Span.current().setAttribute(TraceAttributes.SCHEMA, schemaOf(query));
        ...existing body...
    });
}
```

## When tracing is disabled

Every span site in this PR runs unconditionally. There is no `if (tracingEnabled)` anywhere, and that is deliberate: the OpenTelemetry API ships no-op implementations precisely so instrumentation can be written once and left alone. The chain, when tracing is off:

1. `TelemetryProvider` hands out `NoopTelemetry` instead of the SDK-backed one. `Telemetry.from(context)` also returns it whenever nothing was stored in the context, so an unpropagated thread behaves identically to a disabled deployment.
2. Its tracer is the API's `DefaultTracer`, whose `spanBuilder(...)` returns a `NoopSpanBuilder` — every `setAttribute` on the builder returns `this` and stores nothing.
3. `NoopSpanBuilder.startSpan()` returns `Span.wrap(spanContext)`, a **`PropagatedSpan`**: `setAttribute` returns `this`, `setStatus` returns `this`, `end()` is an empty method, and `isRecording()` returns `false`.
4. No `SdkSpan` is ever constructed, so **no `SpanProcessor` runs and no exporter is reached**. Nothing is built and then discarded downstream — the recording machinery is never entered at all.

What a site costs in that state is a context lookup, one `PropagatedSpan`, a `Scope` open/close pair, and the lambda. No benchmark was run for this PR, so that is a description of the code path rather than a measurement.

**Why this is preferable to guarding each site with an `if`.** A per-site guard duplicates the same condition across every span site, drifts the moment one site forgets it, and makes the traced and untraced paths structurally different — which is where behaviour differences hide. It also saves very little, because the no-op path short-circuits at the first call.

The one thing a guard genuinely buys is skipping the *computation of an attribute value*, since arguments are evaluated before the no-op method is entered. That is handled surgically rather than everywhere: exactly one site guards on `span.isRecording()`, in `Searcher.ensureFilled`, because `result.hits().getConcreteSize()` walks the entire hit tree when the result has subgroups. Every other attribute in this PR is a field read, a parameter or a constant, and is set unguarded.

`isRecording()` appears twice more, in `RpcSearchInvoker` and `RpcProtobufFillInvoker`, for an unrelated reason: those spans can be ended from more than one path, and the check makes ending idempotent so a late call cannot re-stamp a finished span with an error.

## What was instrumented

| Stage | Span |
|---|---|
| Jetty accepts the request | SERVER — **existing work, unchanged** |
| jdisc hands the request to a container worker thread | **`handler.<Name>`** — covers the whole handler, including reading the request body |
| `SearchHandler` resolves and executes the search chain | **`chain.search`** |
| each searcher in the chain, in turn | **`searcher.search`**, nested one per searcher |
| `ClusterSearcher` fans out per schema, if the query spans several | context propagated across the fork; no span of its own |
| the backend dispatches to a content cluster | **`dispatch.search`** |
| one protobuf/JRT request per content node | **`node.search`** (CLIENT) |
| the fill phase walks the chain again | **`searcher.ensureFilled`**, nested one per searcher |
| `ClusterSearcher` fills against each backend | **`cluster.fill`** |
| one fill connection per partition of the surviving hits | **`dispatch.fill`** |
| one `getDocsums` request per node, plus any retry wave | **`node.fill`** (CLIENT) |

**Not instrumented:** result rendering, and everything past the RPC boundary — the trace stops where the request leaves for the content node.

## Span names and attributes

| Span | Kind | Parent | Attributes |
|---|---|---|---|
| `GET /search` | SERVER | root | HTTP semantic conventions *(existing)* |
| `handler.<Name>` | INTERNAL | SERVER span | none |
| `chain.search` | INTERNAL | handler | `vespa.search.chain`, `vespa.query.rank_profile` |
| `searcher.search` | INTERNAL | `chain.search`, then the previous `searcher.search` | `vespa.searcher.id`, `vespa.searcher.class` |
| `dispatch.search` | INTERNAL | `searcher.search` (ClusterSearcher's) | `vespa.schema`, `vespa.coverage.percentage`, `.nodes`, `.nodes_tried`, `.degraded`; on failure `vespa.error_code`, `vespa.error_message` |
| `node.search` | CLIENT | `dispatch.search` | `vespa.content.cluster`, `.node_key`, `.node_host`, `.group`, `rpc.system`, `rpc.method` |
| `searcher.ensureFilled` | INTERNAL | handler, then the previous `searcher.ensureFilled` | `vespa.searcher.id`, `vespa.searcher.class`, `vespa.fill.summary_class`, `vespa.fill.hits` |
| `cluster.fill` | INTERNAL | `searcher.ensureFilled` | `vespa.content.cluster`, `vespa.fill.summary_class`, `vespa.fill.backends` |
| `dispatch.fill` | INTERNAL | `cluster.fill` | `vespa.schema`, `vespa.fill.nodes`, `.hits`, `.hits_filled`; on failure `vespa.error_code`, `vespa.error_message`; on a retry `vespa.fill.skipped`, `.retried`, `.retry_nodes`, `.unfilled` |
| `node.fill` | CLIENT | `dispatch.fill` | `vespa.content.node_key`, `rpc.system`, `rpc.method`, `vespa.fill.hits_requested`, `vespa.fill.retry` |

Span names are **low-cardinality — bounded by configuration, never by traffic or cluster size**. Per-request identity stays in attributes: a content node's distribution key would grow the name set with the cluster, so it is an attribute; a handler or chain name is fixed by the deployed application, so it can sit in the name. `searcher.ensureFilled` is a sibling of `chain.search`, not a child — `SearchHandler` closes the chain span before the fill phase begins.

## Trace view

```mermaid
gantt
    title Query trace with one schema and three content nodes then fill
    dateFormat x
    axisFormat %Lms
    todayMarker off

    section HTTP
    GET /search SERVER               :a1, 0, 118

    section Handler
    handler.SearchHandler            :a2, 2, 117

    section Search
    chain.search                     :b1, 4, 86
    searcher.search JuniperSearcher  :b2, 5, 85
    searcher.search ClusterSearcher  :b3, 6, 84
    dispatch.search schema music     :b4, 8, 82
    node.search key 0                :crit, b5, 9, 74
    node.search key 3                :crit, b6, 9, 81
    node.search key 7                :crit, b7, 10, 60

    section Fill
    searcher.ensureFilled            :c1, 88, 116
    cluster.fill                     :c2, 89, 115
    dispatch.fill                    :c3, 90, 114
    node.fill key 0                  :crit, c4, 92, 112
    node.fill key 3                  :crit, c5, 92, 108
```

The highlighted bars are the CLIENT spans — the actual network calls. Times are illustrative.

## Notes for reviewers

- **No query text, YQL, document ids or hit contents ever become attributes.** Only the short `ErrorMessage` is used, never `getDetailedMessage()`, which carries the request URI and with it the query string.
- **`OtelTracing`, not `Tracing`** — Vespa already has `com.yahoo.search.query.Trace`, the legacy per-query diagnostic trace, and the two sit within ten lines of each other in one file.
- **All changes to `@PublicApi` classes are body-only.** No public or protected signature changed.
- **`setFinalStatus` is preserved, not introduced** in `SearchInvoker`, and deliberately not added to `FillInvoker`, which never had it — instrumentation must not change what the metrics teardown records.
- **`Metric.Context` qualification** in `ThreadedRequestHandler`'s private `NullRequestMetric`: importing OpenTelemetry's `Context` made the simple name ambiguous. Same type, no behaviour change.

## Testing

52 new tests across 8 classes plus a shared `SpanRecorder` fixture; `NodeFillTracingTest` is the first unit test of `RpcProtobufFillInvoker` in the codebase. Green: container-opentelemetry 46, container-disc 551, container-search 2997, container-search-and-docproc builds. Every span and attribute block was verified by removing it and confirming the tests fail.
