### PR TITLE
Add StringRangeMatcher class for lexicographical range functionality

### DIFF
--- a/searchlib/src/tests/attribute/searchable/attribute_weighted_set_blueprint_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_weighted_set_blueprint_test.cpp
@@ -203,10 +203,10 @@ TEST(AttributeWeightedSetBlueprintTest, attribute_weighted_set_single_token_filt
               "search::attribute::NumericMatcher<long> > >",
               normalize_class_name(ws.createSearch(adapter, "integer", false)->getClassName()));
     EXPECT_EQ("search::FilterAttributeIteratorStrict<search::attribute::SingleEnumSearchContext<char const*, "
-              "search::attribute::StringSearchContext> >",
+              "search::attribute::StringSearchContextT<search::attribute::StringMatcher> > >",
               normalize_class_name(ws.createSearch(adapter, "string", true)->getClassName()));
     EXPECT_EQ("search::FilterAttributeIteratorT<search::attribute::SingleEnumSearchContext<char const*, "
-              "search::attribute::StringSearchContext> >",
+              "search::attribute::StringSearchContextT<search::attribute::StringMatcher> > >",
               normalize_class_name(ws.createSearch(adapter, "string", false)->getClassName()));
     EXPECT_TRUE(ws.isWeightedSetTermSearch(adapter, "multi", true));
     EXPECT_TRUE(ws.isWeightedSetTermSearch(adapter, "multi", false));

--- a/searchlib/src/tests/attribute/stringattribute/stringattribute_test.cpp
+++ b/searchlib/src/tests/attribute/stringattribute/stringattribute_test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchlib/attribute/single_string_enum_search_context.h>
 #include <vespa/searchlib/attribute/singlestringattribute.h>
 #include <vespa/searchlib/attribute/singlestringpostattribute.h>
+#include <vespa/searchlib/attribute/string_range_search_helper.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/util/casts.h>
 
@@ -538,6 +539,68 @@ TEST_F(StringAttributeTest, test_fuzzy_match) {
     EXPECT_TRUE(helper.isMatch("x"));
     EXPECT_TRUE(helper.isMatch("xvv"));
     EXPECT_FALSE(helper.isMatch("vvv"));
+}
+
+TEST_F(StringAttributeTest, test_range_match_cased) {
+    StringRangeSpec                    range = {"BAR", true, false, "FOO", true, false};
+    attribute::StringRangeSearchHelper helper(&range, true);
+
+    // "BAR", "FOO", "bar", "foo"
+    EXPECT_TRUE(helper.is_match("BAR"));
+    EXPECT_TRUE(helper.is_match("FOO"));
+    EXPECT_FALSE(helper.is_match("bar"));
+    EXPECT_FALSE(helper.is_match("foo"));
+}
+
+TEST_F(StringAttributeTest, test_range_match_uncased) {
+    StringRangeSpec                    range = {"BAR", true, false, "FOO", true, false};
+    attribute::StringRangeSearchHelper helper(&range, false);
+
+    // "BAR", "bar", "FOO", "foo"
+    EXPECT_TRUE(helper.is_match("BAR"));
+    EXPECT_TRUE(helper.is_match("bar"));
+    EXPECT_TRUE(helper.is_match("FOO"));
+    EXPECT_TRUE(helper.is_match("foo"));
+}
+
+namespace {
+void verify_range(const StringRangeSpec& range, bool aaa, bool abb, bool acc, bool add, bool aee) {
+    for (bool cased : {true, false}) {
+        attribute::StringRangeSearchHelper helper(&range, cased);
+
+        EXPECT_EQ(aaa, helper.is_match("Aaa"));
+        EXPECT_EQ(abb, helper.is_match("Abb"));
+        EXPECT_EQ(acc, helper.is_match("Acc"));
+        EXPECT_EQ(add, helper.is_match("Add"));
+        EXPECT_EQ(aee, helper.is_match("Aee"));
+    }
+}
+} // namespace
+
+TEST_F(StringAttributeTest, test_range_is_match) {
+    // ["Abb", "Add"]
+    verify_range({"Abb", true, false, "Add", true, false}, false, true, true, true, false);
+
+    // ("Abb", "Add"]
+    verify_range({"Abb", false, false, "Add", true, false}, false, false, true, true, false);
+
+    // ["Abb", "Add")
+    verify_range({"Abb", true, false, "Add", false, false}, false, true, true, false, false);
+
+    // ("Abb", "Add")
+    verify_range({"Abb", false, false, "Add", false, false}, false, false, true, false, false);
+
+    // (\infty, "Add")
+    verify_range({"Abb", false, true, "Add", false, false}, true, true, true, false, false);
+
+    // ("Abb", \infty)
+    verify_range({"Abb", false, false, "Add", false, true}, false, false, true, true, true);
+
+    // (\infty, \infty)
+    verify_range({"Abb", false, true, "Add", false, true}, true, true, true, true, true);
+
+    // ["Add", "Abb"] = \varnothing
+    verify_range({"Add", true, false, "Abb", true, false}, false, false, false, false, false);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -936,9 +936,9 @@ TEST(StreamingQueryTest, weighted_set_term) {
 }
 
 TEST(StreamingQueryTest, control_the_size_of_query_terms) {
-    EXPECT_EQ(32u + sizeof(std::string), sizeof(QueryTermSimple));
-    EXPECT_EQ(48u + sizeof(std::string), sizeof(QueryTermUCS4));
-    EXPECT_EQ(128u + 2 * sizeof(std::string), sizeof(QueryTerm));
+    EXPECT_EQ(40u + sizeof(std::string), sizeof(QueryTermSimple));
+    EXPECT_EQ(56u + sizeof(std::string), sizeof(QueryTermUCS4));
+    EXPECT_EQ(136u + 2 * sizeof(std::string), sizeof(QueryTerm));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
@@ -155,6 +155,7 @@ vespa_add_library(searchlib_attribute OBJECT
     sourceselector.cpp
     string_matcher.cpp
     string_posting_search_context.cpp
+    string_range_search_helper.cpp
     string_search_context.cpp
     string_search_helper.cpp
     string_sort_blob_writer.cpp

--- a/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
@@ -155,6 +155,7 @@ vespa_add_library(searchlib_attribute OBJECT
     sourceselector.cpp
     string_matcher.cpp
     string_posting_search_context.cpp
+    string_range_matcher.cpp
     string_range_search_helper.cpp
     string_search_context.cpp
     string_search_helper.cpp

--- a/searchlib/src/vespa/searchlib/attribute/multi_string_enum_hint_search_context.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multi_string_enum_hint_search_context.hpp
@@ -14,7 +14,7 @@ MultiStringEnumHintSearchContext<M>::MultiStringEnumHintSearchContext(
     : MultiStringEnumSearchContext<M>(std::move(qTerm), cased, fuzzy_matching_algorithm, toBeSearched,
                                       mv_mapping_read_view, enum_store),
       EnumHintSearchContext(enum_store.get_dictionary(), doc_id_limit, num_values) {
-    this->setup_enum_hint_sc(enum_store, *this);
+    this->set_and_setup_enum_hint_sc(enum_store, *this);
 }
 
 template <typename M> MultiStringEnumHintSearchContext<M>::~MultiStringEnumHintSearchContext() = default;

--- a/searchlib/src/vespa/searchlib/attribute/single_string_enum_hint_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/single_string_enum_hint_search_context.cpp
@@ -13,7 +13,7 @@ SingleStringEnumHintSearchContext::SingleStringEnumHintSearchContext(
     : SingleStringEnumSearchContext(std::move(qTerm), cased, fuzzy_matching_algorithm, toBeSearched, enum_indices,
                                     enum_store),
       EnumHintSearchContext(enum_store.get_dictionary(), enum_indices.size(), num_values) {
-    setup_enum_hint_sc(enum_store, *this);
+    set_and_setup_enum_hint_sc(enum_store, *this);
 }
 
 SingleStringEnumHintSearchContext::~SingleStringEnumHintSearchContext() = default;

--- a/searchlib/src/vespa/searchlib/attribute/string_matcher.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_matcher.cpp
@@ -2,7 +2,12 @@
 
 #include "string_matcher.h"
 
+#include "enumhintsearchcontext.h"
+#include "enumstore.h"
+
 #include <vespa/searchlib/query/query_term_ucs4.h>
+#include <vespa/vespalib/fuzzy/fuzzy_matcher.h>
+#include <vespa/vespalib/util/regexp.h>
 
 namespace search::attribute {
 
@@ -18,6 +23,27 @@ StringMatcher::~StringMatcher() = default;
 
 bool StringMatcher::isValid() const {
     return (_query_term && (!_query_term->empty()));
+}
+
+void StringMatcher::setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store,
+                                       EnumHintSearchContext&         enum_hint_sc) {
+    if (isValid()) {
+        if (isPrefix()) {
+            auto comp = enum_store.make_folded_comparator_prefix(get_query_term_ptr()->getTerm());
+            enum_hint_sc.lookupRange(comp, comp);
+        } else if (isRegex()) {
+            std::string prefix(vespalib::RegexpUtil::get_prefix(get_query_term_ptr()->getTerm()));
+            auto        comp = enum_store.make_folded_comparator_prefix(prefix.c_str());
+            enum_hint_sc.lookupRange(comp, comp);
+        } else if (isFuzzy()) {
+            std::string prefix(getFuzzyMatcher().getPrefix());
+            auto        comp = enum_store.make_folded_comparator_prefix(prefix.c_str());
+            enum_hint_sc.lookupRange(comp, comp);
+        } else {
+            auto comp = enum_store.make_folded_comparator(get_query_term_ptr()->getTerm());
+            enum_hint_sc.lookupTerm(comp);
+        }
+    }
 }
 
 } // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_matcher.h
+++ b/searchlib/src/vespa/searchlib/attribute/string_matcher.h
@@ -8,9 +8,12 @@
 
 namespace search {
 class QueryTermSimple;
-}
+template <class EntryT> class EnumStoreT;
+} // namespace search
 
 namespace search::attribute {
+
+class EnumHintSearchContext;
 
 /*
  * Class used to determine if an attribute vector string value is a match for
@@ -43,6 +46,7 @@ protected:
                         const DfaStringComparator::DataStoreType& data_store) const {
         return _helper.is_fuzzy_match(word, itr, data_store);
     }
+    void setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store, EnumHintSearchContext& enum_hint_sc);
 };
 
 } // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_range_matcher.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_matcher.cpp
@@ -1,0 +1,37 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "string_range_matcher.h"
+
+#include "enumhintsearchcontext.h"
+#include "enumstore.h"
+
+#include <vespa/searchlib/query/query_term_ucs4.h>
+
+namespace search::attribute {
+
+StringRangeMatcher::StringRangeMatcher(std::unique_ptr<QueryTermSimple> query_term, bool cased,
+                                       vespalib::FuzzyMatchingAlgorithm /*fuzzy_matching_algorithm*/)
+    : StringRangeMatcher(std::move(query_term), cased) {
+}
+
+StringRangeMatcher::StringRangeMatcher(std::unique_ptr<QueryTermSimple> query_term, bool cased)
+    : _query_term(std::move(query_term)),
+      _helper(_query_term ? _query_term->get_string_range_spec() : nullptr, cased) {
+}
+
+StringRangeMatcher::StringRangeMatcher(StringRangeMatcher&&) noexcept = default;
+
+StringRangeMatcher::~StringRangeMatcher() = default;
+
+void StringRangeMatcher::setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store,
+                                            EnumHintSearchContext&         enum_hint_sc) {
+    if (_helper.is_valid()) {
+        auto* range_spec = _helper.get_string_range_spec();
+        // TODO respect unbounded ranges and test
+        auto comp_left = enum_store.make_folded_comparator(range_spec->left.c_str());
+        auto comp_right = enum_store.make_folded_comparator(range_spec->right.c_str());
+        enum_hint_sc.lookupRange(comp_left, comp_right);
+    }
+}
+
+} // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_range_matcher.h
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_matcher.h
@@ -1,0 +1,47 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "string_range_search_helper.h"
+
+#include <vespa/searchlib/query/query_term_simple.h>
+#include <vespa/searchlib/query/query_term_ucs4.h>
+#include <vespa/vespalib/fuzzy/fuzzy_matching_algorithm.h>
+
+namespace search {
+template <class EntryT> class EnumStoreT;
+} // namespace search
+
+namespace search::attribute {
+
+class EnumHintSearchContext;
+
+/*
+ * Class used to determine if an attribute vector string value is a match for
+ * the query string range.
+ */
+class StringRangeMatcher {
+private:
+    std::unique_ptr<QueryTermSimple> _query_term;
+    StringRangeSearchHelper          _helper;
+
+public:
+    StringRangeMatcher(std::unique_ptr<QueryTermSimple> query_term, bool cased,
+                       vespalib::FuzzyMatchingAlgorithm fuzzy_matching_algorithm);
+    StringRangeMatcher(std::unique_ptr<QueryTermSimple> query_term, bool cased);
+    StringRangeMatcher(StringRangeMatcher&&) noexcept;
+    ~StringRangeMatcher();
+
+    [[nodiscard]] const StringRangeSpec* get_string_range_spec() const { return _helper.get_string_range_spec(); }
+
+protected:
+    [[nodiscard]] bool isValid() const { return _helper.is_valid(); }
+    [[nodiscard]] bool match(const char* src) const { return _helper.is_match(src); }
+    [[nodiscard]] const QueryTermUCS4* get_query_term_ptr() const noexcept {
+        return dynamic_cast<QueryTermUCS4*>(_query_term.get());
+    }
+
+    void setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store, EnumHintSearchContext& enum_hint_sc);
+};
+
+} // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_range_search_helper.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_search_helper.cpp
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "string_range_search_helper.h"
+
+#include <vespa/searchlib/query/string_range_spec.h>
+#include <vespa/searchlib/util/foldedstringcompare.h>
+
+namespace search::attribute {
+
+StringRangeSearchHelper::StringRangeSearchHelper(const StringRangeSpec* range_spec, bool cased)
+    : _range_spec(range_spec), _cased(cased) {
+}
+
+StringRangeSearchHelper::~StringRangeSearchHelper() = default;
+
+bool StringRangeSearchHelper::is_match(const char* src) const {
+    if (_cased) {
+        return is_match_internal<false>(src);
+    } else {
+        return is_match_internal<true>(src);
+    }
+}
+
+template <bool fold>
+bool StringRangeSearchHelper::is_match_internal(const char* src) const {
+    if (is_valid()) {
+        return (_range_spec->left_unbounded ||
+                (_range_spec->left_closed
+                     ? FoldedStringCompare::compareFolded<fold, fold>(_range_spec->left.c_str(), src) <= 0
+                     : FoldedStringCompare::compareFolded<fold, fold>(_range_spec->left.c_str(), src) < 0)) &&
+               (_range_spec->right_unbounded ||
+                (_range_spec->right_closed
+                     ? FoldedStringCompare::compareFolded<fold, fold>(src, _range_spec->right.c_str()) <= 0
+                     : FoldedStringCompare::compareFolded<fold, fold>(src, _range_spec->right.c_str()) < 0));
+    } else {
+        return true;
+    }
+}
+
+} // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_range_search_helper.h
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_search_helper.h
@@ -1,0 +1,34 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace search {
+struct StringRangeSpec;
+}
+
+namespace search::attribute {
+
+/**
+ * Helper class for StringRangeMatcher that implements the actual matching logic.
+ * Separate class from StringRangeMatcher for unit testing.
+ * It handles different search settings like prefix, regex and cased/uncased.
+ */
+class StringRangeSearchHelper {
+private:
+    const StringRangeSpec* _range_spec;
+    bool                   _cased;
+
+public:
+    StringRangeSearchHelper(const StringRangeSpec* range_spec, bool cased);
+    ~StringRangeSearchHelper();
+
+    [[nodiscard]] bool is_valid() const noexcept { return _range_spec != nullptr; }
+    [[nodiscard]] const StringRangeSpec* get_string_range_spec() const { return _range_spec; }
+    [[nodiscard]] bool is_match(const char* src) const;
+
+private:
+    template <bool fold>
+    [[nodiscard]] bool is_match_internal(const char* src) const;
+};
+
+} // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_search_context.cpp
@@ -1,57 +1,11 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "string_search_context.h"
+#include "string_search_context.hpp"
 
-#include "enumhintsearchcontext.h"
-#include "enumstore.h"
-
-#include <vespa/searchlib/query/query_term_ucs4.h>
-#include <vespa/vespalib/fuzzy/fuzzy_matcher.h>
-#include <vespa/vespalib/util/regexp.h>
+#include "string_matcher.h"
 
 namespace search::attribute {
 
-StringSearchContext::StringSearchContext(const AttributeVector&           to_be_searched,
-                                         std::unique_ptr<QueryTermSimple> query_term, bool cased,
-                                         vespalib::FuzzyMatchingAlgorithm fuzzy_matching_algorithm)
-    : SearchContext(to_be_searched), StringMatcher(std::move(query_term), cased, fuzzy_matching_algorithm) {
-}
-
-StringSearchContext::StringSearchContext(const AttributeVector& to_be_searched, StringMatcher&& matcher)
-    : SearchContext(to_be_searched), StringMatcher(std::move(matcher)) {
-}
-
-StringSearchContext::StringSearchContext(StringSearchContext&&) noexcept = default;
-StringSearchContext::~StringSearchContext() = default;
-
-const QueryTermUCS4* StringSearchContext::queryTerm() const {
-    return get_query_term_ptr();
-}
-
-bool StringSearchContext::valid() const {
-    return StringMatcher::isValid();
-}
-
-void StringSearchContext::setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store,
-                                             EnumHintSearchContext&         enum_hint_sc) {
-    _plsc = &enum_hint_sc;
-    if (valid()) {
-        if (isPrefix()) {
-            auto comp = enum_store.make_folded_comparator_prefix(queryTerm()->getTerm());
-            enum_hint_sc.lookupRange(comp, comp);
-        } else if (isRegex()) {
-            std::string prefix(vespalib::RegexpUtil::get_prefix(queryTerm()->getTerm()));
-            auto        comp = enum_store.make_folded_comparator_prefix(prefix.c_str());
-            enum_hint_sc.lookupRange(comp, comp);
-        } else if (isFuzzy()) {
-            std::string prefix(getFuzzyMatcher().getPrefix());
-            auto        comp = enum_store.make_folded_comparator_prefix(prefix.c_str());
-            enum_hint_sc.lookupRange(comp, comp);
-        } else {
-            auto comp = enum_store.make_folded_comparator(queryTerm()->getTerm());
-            enum_hint_sc.lookupTerm(comp);
-        }
-    }
-}
+template class StringSearchContextT<StringMatcher>;
 
 } // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_search_context.cpp
@@ -3,9 +3,12 @@
 #include "string_search_context.hpp"
 
 #include "string_matcher.h"
+#include "string_range_matcher.h"
 
 namespace search::attribute {
 
 template class StringSearchContextT<StringMatcher>;
+
+template class StringSearchContextT<StringRangeMatcher>;
 
 } // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/string_search_context.h
@@ -35,7 +35,7 @@ public:
     const QueryTermUCS4* queryTerm() const override;
     bool valid() const override;
 
-    void setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store, EnumHintSearchContext& enum_hint_sc);
+    void set_and_setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store, EnumHintSearchContext& enum_hint_sc);
 };
 
 using StringSearchContext = StringSearchContextT<StringMatcher>;

--- a/searchlib/src/vespa/searchlib/attribute/string_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/string_search_context.h
@@ -21,20 +21,23 @@ class EnumHintSearchContext;
  * StringSearchContext is an abstract base class for search contexts
  * handling a query term on a string attribute vector.
  */
-class StringSearchContext : public SearchContext, public StringMatcher {
+template <typename Matcher>
+class StringSearchContextT : public SearchContext, public Matcher {
 protected:
-    using MatcherType = StringMatcher;
+    using MatcherType = Matcher;
 
 public:
-    StringSearchContext(const AttributeVector& to_be_searched, std::unique_ptr<QueryTermSimple> query_term,
-                        bool cased, vespalib::FuzzyMatchingAlgorithm fuzzy_matching_algorithm);
-    StringSearchContext(const AttributeVector& to_be_searched, StringMatcher&& matcher);
-    StringSearchContext(StringSearchContext&&) noexcept;
-    ~StringSearchContext() override;
+    StringSearchContextT(const AttributeVector& to_be_searched, std::unique_ptr<QueryTermSimple> query_term,
+                         bool cased, vespalib::FuzzyMatchingAlgorithm fuzzy_matching_algorithm);
+    StringSearchContextT(const AttributeVector& to_be_searched, Matcher&& matcher);
+    StringSearchContextT(StringSearchContextT&&) noexcept;
+    ~StringSearchContextT() override;
     const QueryTermUCS4* queryTerm() const override;
     bool valid() const override;
 
     void setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store, EnumHintSearchContext& enum_hint_sc);
 };
+
+using StringSearchContext = StringSearchContextT<StringMatcher>;
 
 } // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_search_context.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_search_context.hpp
@@ -1,0 +1,66 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "enumhintsearchcontext.h"
+#include "enumstore.h"
+#include "string_search_context.h"
+
+#include <vespa/searchlib/query/query_term_ucs4.h>
+#include <vespa/vespalib/fuzzy/fuzzy_matcher.h>
+#include <vespa/vespalib/util/regexp.h>
+
+namespace search::attribute {
+
+template <typename Matcher>
+StringSearchContextT<Matcher>::StringSearchContextT(const AttributeVector&           to_be_searched,
+                                                    std::unique_ptr<QueryTermSimple> query_term, bool cased,
+                                                    vespalib::FuzzyMatchingAlgorithm fuzzy_matching_algorithm)
+    : SearchContext(to_be_searched), Matcher(std::move(query_term), cased, fuzzy_matching_algorithm) {
+}
+
+template <typename Matcher>
+StringSearchContextT<Matcher>::StringSearchContextT(const AttributeVector& to_be_searched, Matcher&& matcher)
+    : SearchContext(to_be_searched), Matcher(std::move(matcher)) {
+}
+
+template <typename Matcher>
+StringSearchContextT<Matcher>::StringSearchContextT(StringSearchContextT&&) noexcept = default;
+
+template <typename Matcher>
+StringSearchContextT<Matcher>::~StringSearchContextT() = default;
+
+template <typename Matcher>
+const QueryTermUCS4* StringSearchContextT<Matcher>::queryTerm() const {
+    return this->get_query_term_ptr();
+}
+
+template <typename Matcher>
+bool StringSearchContextT<Matcher>::valid() const {
+    return Matcher::isValid();
+}
+
+template <typename Matcher>
+void StringSearchContextT<Matcher>::setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store,
+                                                       EnumHintSearchContext&         enum_hint_sc) {
+    _plsc = &enum_hint_sc;
+    if (valid()) {
+        if (this->isPrefix()) {
+            auto comp = enum_store.make_folded_comparator_prefix(queryTerm()->getTerm());
+            enum_hint_sc.lookupRange(comp, comp);
+        } else if (this->isRegex()) {
+            std::string prefix(vespalib::RegexpUtil::get_prefix(queryTerm()->getTerm()));
+            auto        comp = enum_store.make_folded_comparator_prefix(prefix.c_str());
+            enum_hint_sc.lookupRange(comp, comp);
+        } else if (this->isFuzzy()) {
+            std::string prefix(this->getFuzzyMatcher().getPrefix());
+            auto        comp = enum_store.make_folded_comparator_prefix(prefix.c_str());
+            enum_hint_sc.lookupRange(comp, comp);
+        } else {
+            auto comp = enum_store.make_folded_comparator(queryTerm()->getTerm());
+            enum_hint_sc.lookupTerm(comp);
+        }
+    }
+}
+
+} // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_search_context.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_search_context.hpp
@@ -41,26 +41,10 @@ bool StringSearchContextT<Matcher>::valid() const {
 }
 
 template <typename Matcher>
-void StringSearchContextT<Matcher>::setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store,
-                                                       EnumHintSearchContext&         enum_hint_sc) {
+void StringSearchContextT<Matcher>::set_and_setup_enum_hint_sc(const EnumStoreT<const char*>& enum_store,
+                                                               EnumHintSearchContext&         enum_hint_sc) {
     _plsc = &enum_hint_sc;
-    if (valid()) {
-        if (this->isPrefix()) {
-            auto comp = enum_store.make_folded_comparator_prefix(queryTerm()->getTerm());
-            enum_hint_sc.lookupRange(comp, comp);
-        } else if (this->isRegex()) {
-            std::string prefix(vespalib::RegexpUtil::get_prefix(queryTerm()->getTerm()));
-            auto        comp = enum_store.make_folded_comparator_prefix(prefix.c_str());
-            enum_hint_sc.lookupRange(comp, comp);
-        } else if (this->isFuzzy()) {
-            std::string prefix(this->getFuzzyMatcher().getPrefix());
-            auto        comp = enum_store.make_folded_comparator_prefix(prefix.c_str());
-            enum_hint_sc.lookupRange(comp, comp);
-        } else {
-            auto comp = enum_store.make_folded_comparator(queryTerm()->getTerm());
-            enum_hint_sc.lookupTerm(comp);
-        }
-    }
+    this->setup_enum_hint_sc(enum_store, enum_hint_sc);
 }
 
 } // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/query/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/query/CMakeLists.txt
@@ -9,5 +9,6 @@ vespa_add_library(searchlib_query OBJECT
     query_term_decoder.cpp
     query_term_simple.cpp
     query_term_ucs4.cpp
+    string_range_spec.cpp
     DEPENDS
 )

--- a/searchlib/src/vespa/searchlib/query/query_term_simple.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_term_simple.cpp
@@ -156,6 +156,10 @@ template <> QueryTermSimple::RangeResult<int64_t> QueryTermSimple::getRange() co
     return getIntegerRange<int64_t>();
 }
 
+const StringRangeSpec* QueryTermSimple::get_string_range_spec() const noexcept {
+    return _string_range.get();
+}
+
 bool QueryTermSimple::getAsIntegerTerm(int64_t& lower, int64_t& upper) const noexcept {
     lower = NEG_MIN_I64;
     upper = POS_MAX_I64;
@@ -211,6 +215,16 @@ QueryTermSimple::QueryTermSimple(Type type, std::unique_ptr<NumericRangeSpec> ra
       _fuzzy_max_edit_distance(0),
       _fuzzy_prefix_lock_length(0) {
     _numeric_range = std::move(range);
+}
+
+QueryTermSimple::QueryTermSimple(Type type, std::unique_ptr<StringRangeSpec> range)
+    : _type(type),
+      _valid(range),
+      _fuzzy_prefix_match(false),
+      _term("<range>"),
+      _fuzzy_max_edit_distance(0),
+      _fuzzy_prefix_lock_length(0) {
+    _string_range = std::move(range);
 }
 
 std::string QueryTermSimple::getClassName() const {

--- a/searchlib/src/vespa/searchlib/query/query_term_simple.h
+++ b/searchlib/src/vespa/searchlib/query/query_term_simple.h
@@ -3,6 +3,7 @@
 
 #include "numeric_range_spec.h"
 #include "query_normalization.h"
+#include "string_range_spec.h"
 
 #include <vespa/vespalib/objects/objectvisitor.h>
 #include <vespa/vespalib/util/memory.h>
@@ -36,12 +37,14 @@ public:
     QueryTermSimple& operator=(QueryTermSimple&&) = delete;
     QueryTermSimple(const string& term_, Type type);
     QueryTermSimple(Type type, std::unique_ptr<NumericRangeSpec> range);
+    QueryTermSimple(Type type, std::unique_ptr<StringRangeSpec> range);
     virtual ~QueryTermSimple();
 
     /**
      * Extracts the content of this query term as a range with low and high values.
      */
     template <typename N> RangeResult<N> getRange() const noexcept;
+    const StringRangeSpec* get_string_range_spec() const noexcept;
     int getRangeLimit() const noexcept { return activeRange().rangeLimit; }
     size_t getMaxPerGroup() const noexcept { return activeRange().maxPerGroup; }
     size_t getDiversityCutoffGroups() const noexcept { return activeRange().diversityCutoffGroups; }
@@ -75,6 +78,7 @@ public:
 private:
     static NumericRangeSpec           emptyNumericRange;
     std::unique_ptr<NumericRangeSpec> _numeric_range = {};
+    std::unique_ptr<StringRangeSpec>  _string_range = {};
     bool getRangeInternal(int64_t& low, int64_t& high) const noexcept;
     template <typename N> RangeResult<N> getIntegerRange() const noexcept;
     template <typename N> RangeResult<N> getFloatRange() const noexcept;

--- a/searchlib/src/vespa/searchlib/query/query_term_ucs4.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_term_ucs4.cpp
@@ -24,6 +24,10 @@ QueryTermUCS4::QueryTermUCS4(Type type, std::unique_ptr<NumericRangeSpec> range)
     : QueryTermSimple(type, std::move(range)), _termUCS4(nullptr), _cachedTermLen(0) {
 }
 
+QueryTermUCS4::QueryTermUCS4(Type type, std::unique_ptr<StringRangeSpec> range)
+    : QueryTermSimple(type, std::move(range)), _termUCS4(nullptr), _cachedTermLen(0) {
+}
+
 QueryTermUCS4::QueryTermUCS4(const string& termS, Type type)
     : QueryTermSimple(termS, type), _termUCS4(nullptr), _cachedTermLen(0) {
     vespalib::Utf8Reader r(termS);

--- a/searchlib/src/vespa/searchlib/query/query_term_ucs4.h
+++ b/searchlib/src/vespa/searchlib/query/query_term_ucs4.h
@@ -19,6 +19,7 @@ public:
     QueryTermUCS4& operator=(QueryTermUCS4&&) = delete;
     QueryTermUCS4(const string& term_, Type type);
     QueryTermUCS4(Type type, std::unique_ptr<NumericRangeSpec> range);
+    QueryTermUCS4(Type type, std::unique_ptr<StringRangeSpec> range);
     ~QueryTermUCS4() override;
     uint32_t getTermLen() const { return _cachedTermLen; }
     uint32_t term(const char*& t) const {

--- a/searchlib/src/vespa/searchlib/query/string_range_spec.cpp
+++ b/searchlib/src/vespa/searchlib/query/string_range_spec.cpp
@@ -1,0 +1,15 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "string_range_spec.h"
+
+#include <vespa/vespalib/locale/c.h>
+
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+
+namespace search {
+
+StringRangeSpec::~StringRangeSpec() = default;
+
+} // namespace search

--- a/searchlib/src/vespa/searchlib/query/string_range_spec.h
+++ b/searchlib/src/vespa/searchlib/query/string_range_spec.h
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+
+namespace search {
+
+/**
+ * Basic representation of a string range specification
+ */
+
+struct StringRangeSpec {
+    std::string left;
+    bool        left_closed = true;
+    bool        left_unbounded = false;
+    std::string right;
+    bool        right_closed = true;
+    bool        right_unbounded = false;
+    int32_t     range_limit = 0;
+
+    ~StringRangeSpec();
+
+    bool has_range_limit() const noexcept { return range_limit != 0; }
+
+    constexpr auto operator<=>(const StringRangeSpec& rhs) const noexcept = default;
+};
+
+} // namespace search


### PR DESCRIPTION
This PR makes way for adding a lexicographical range operator on strings. It is neatly split up in individual commits that make sense on their own and in the order they are in, so I'd recommend to take a look at them individually.

For numbers, there is a `NumericSearchContext` that takes either the `NumericMatcher` or the `NumericRangeMatcher` as a template argument. This PR makes the existing `StringMatcher` a template argument of the existing `StringSearchContext`. Moreover, a bit of functionality specific to the `StringMatcher` is moved from the search context into the matcher. Then, a new `StringRangeMatcher` class and some related helper classes are added.

The new `StringRangeMatcher` class is not used yet, so this PR should not make any functional difference at all.

@johansolbakken fyi