### PR TITLE
Sort by rank feature

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/RankProfile.java
@@ -51,6 +51,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,6 +65,8 @@ public class RankProfile implements Cloneable {
     public final static String FIRST_PHASE = "firstphase";
     public final static String SECOND_PHASE = "secondphase";
     public final static String GLOBAL_PHASE = "globalphase";
+
+    private static final Pattern SCHEMA_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
 
     /** The schema-unique name of this rank profile */
     private final String name;
@@ -135,6 +138,8 @@ public class RankProfile implements Cloneable {
     private final List<String> inheritedMatchFeaturesProfileNames = new ArrayList<>();
 
     private Set<ReferenceNode> rankFeatures;
+
+    private Set<ReferenceNode> sortFeatures;
 
     /** The properties of this - a multimap */
     private Map<String, List<RankProperty>> rankProperties = new LinkedHashMap<>();
@@ -718,6 +723,33 @@ public class RankProfile implements Cloneable {
         }
     }
 
+    /** Returns a read-only view of the sort features to use in this profile. This is never null */
+    public Set<ReferenceNode> getSortFeatures() {
+        if (sortFeatures != null) return Collections.unmodifiableSet(sortFeatures);
+        return uniquelyInherited(RankProfile::getSortFeatures, f -> ! f.isEmpty(), "sort-features")
+                .orElse(Set.of());
+    }
+
+    /**
+     * Adds the content of the given feature list to the internal list of sort features.
+     * Each entry must be a bare schema identifier.
+     */
+    public void addSortFeatures(FeatureList features) {
+        if (sortFeatures == null)
+            sortFeatures = new LinkedHashSet<>();
+        for (ReferenceNode feature : features) {
+            validateSortFeature(feature);
+            sortFeatures.add(feature);
+        }
+    }
+
+    private void validateSortFeature(ReferenceNode feature) {
+        var reference = feature.reference();
+        if ( ! reference.isIdentifier() || ! SCHEMA_IDENTIFIER.matcher(reference.name()).matches())
+            throw new IllegalArgumentException("sort-features entries must be bare schema identifiers " +
+                                               "([A-Za-z_][A-Za-z0-9_]*), got '" + feature + "'");
+    }
+
     /** Returns a read only flattened list view of the rank properties to use in this profile. This is never null. */
     public List<RankProperty> getRankProperties() {
         List<RankProperty> properties = new ArrayList<>();
@@ -1199,6 +1231,7 @@ public class RankProfile implements Cloneable {
             clone.summaryFeatures = summaryFeatures != null ? new LinkedHashSet<>(this.summaryFeatures) : null;
             clone.matchFeatures = matchFeatures != null ? new LinkedHashSet<>(this.matchFeatures) : null;
             clone.rankFeatures = rankFeatures != null ? new LinkedHashSet<>(this.rankFeatures) : null;
+            clone.sortFeatures = sortFeatures != null ? new LinkedHashSet<>(this.sortFeatures) : null;
             clone.rankProperties = new LinkedHashMap<>(this.rankProperties);
             clone.inputs = new LinkedHashMap<>(this.inputs);
             clone.functions = new LinkedHashMap<>(this.functions);
@@ -1259,6 +1292,9 @@ public class RankProfile implements Cloneable {
         }
         for (ReferenceNode sf : getSummaryFeatures()) {
             verifyNoNormalizers("summary-feature " + sf, sf, allNormalizers, context);
+        }
+        for (ReferenceNode sortFeature : getSortFeatures()) {
+            verifyNoNormalizers("sort-feature " + sortFeature, sortFeature, allNormalizers, context);
         }
         if (globalPhaseRanking != null) {
             var needInputs = new HashSet<String>();

--- a/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
@@ -152,6 +152,7 @@ public class RawRankProfile {
         private final Set<ReferenceNode> matchFeatures;
         private final Set<ReferenceNode> hiddenMatchFeatures;
         private final Set<ReferenceNode> rankFeatures;
+        private final Set<ReferenceNode> sortFeatures;
         private final Map<String, String> featureRenames = new java.util.LinkedHashMap<>();
         private final List<RankProfile.RankProperty> rankProperties;
 
@@ -220,6 +221,7 @@ public class RawRankProfile {
             hiddenMatchFeatures = compiled.getHiddenMatchFeatures();
             matchFeatures.addAll(hiddenMatchFeatures);
             rankFeatures = compiled.getRankFeatures();
+            sortFeatures = new LinkedHashSet<>(compiled.getSortFeatures());
             rerankCount = compiled.getRerankCount();
             globalPhaseRerankCount = compiled.getGlobalPhaseRerankCount();
             matchPhaseSettings = compiled.getMatchPhase();
@@ -299,6 +301,7 @@ public class RawRankProfile {
                                                               SerializationContext functionContext) {
             replaceFunctionFeatures(summaryFeatures, functionContext);
             replaceFunctionFeatures(matchFeatures, functionContext);
+            replaceFunctionFeatures(sortFeatures, functionContext);
 
             // First phase, second phase and summary features should add all required functions to the context.
             // However, we need to add any functions not referenced in those anyway for model-evaluation.
@@ -478,6 +481,9 @@ public class RawRankProfile {
             }
             for (ReferenceNode feature : rankFeatures) {
                 properties.add(new Pair<>("vespa.dump.feature", feature.toString()));
+            }
+            for (ReferenceNode feature : sortFeatures) {
+                properties.add(new Pair<>("vespa.sort.feature", feature.toString()));
             }
             for (var entry : featureRenames.entrySet()) {
                 properties.add(new Pair<>("vespa.feature.rename", entry.getKey()));

--- a/config-model/src/main/java/com/yahoo/schema/derived/SchemaInfo.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/SchemaInfo.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -201,6 +202,9 @@ public final class SchemaInfo extends Derived {
             rankProfile.getTotalKeepRankCount().ifPresent(rankProfileConfig::totalKeepRankCount);
             rankProfile.getRerankCount().ifPresent(rankProfileConfig::rerankCount);
             rankProfile.getTotalRerankCount().ifPresent(rankProfileConfig::totalRerankCount);
+            for (String sortFeature : rankProfile.sortFeatures()) {
+                rankProfileConfig.sortFeature(sortFeature);
+            }
             for (var input : rankProfile.inputs().entrySet()) {
                 var inputConfig = new SchemaInfoConfig.Schema.Rankprofile.Input.Builder();
                 inputConfig.name(input.getKey().toString());
@@ -248,6 +252,7 @@ public final class SchemaInfo extends Derived {
         private final Optional<Integer> totalRerankCount;
         private final boolean useSignificanceModel;
         private final Map<Reference, RankProfile.Input> inputs;
+        private final List<String> sortFeatures;
 
         public RankProfileInfo(RankProfile profile) {
             this.name = profile.name();
@@ -263,6 +268,7 @@ public final class SchemaInfo extends Derived {
             this.rerankCount = profile.getRerankCount();
             this.totalRerankCount = profile.getTotalRerankCount();
             useSignificanceModel = profile.useSignificanceModel();
+            this.sortFeatures = profile.getSortFeatures().stream().map(feature -> feature.getName()).toList();
         }
 
         public String name() { return name; }
@@ -276,6 +282,7 @@ public final class SchemaInfo extends Derived {
         public Optional<Integer> getTotalRerankCount() { return totalRerankCount; }
         public boolean useSignificanceModel() { return useSignificanceModel; }
         public Map<Reference, RankProfile.Input> inputs() { return inputs; }
+        public List<String> sortFeatures() { return sortFeatures; }
 
     }
 

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankProfile.java
@@ -42,6 +42,7 @@ public class ParsedRankProfile extends ParsedBlock {
     private Double targetHitsMaxAdjustmentFactor = null;
     private final List<FeatureList> matchFeatures = new ArrayList<>();
     private final List<FeatureList> rankFeatures = new ArrayList<>();
+    private final List<FeatureList> sortFeatures = new ArrayList<>();
     private final List<FeatureList> summaryFeatures = new ArrayList<>();
     private Integer keepRankCount = null;
     private Integer totalKeepRankCount = null;
@@ -104,6 +105,7 @@ public class ParsedRankProfile extends ParsedBlock {
     Optional<Double> getTargetHitsMaxAdjustmentFactor() { return Optional.ofNullable(this.targetHitsMaxAdjustmentFactor); }
     List<FeatureList> getMatchFeatures() { return List.copyOf(this.matchFeatures); }
     List<FeatureList> getRankFeatures() { return List.copyOf(this.rankFeatures); }
+    List<FeatureList> getSortFeatures() { return List.copyOf(this.sortFeatures); }
     List<FeatureList> getSummaryFeatures() { return List.copyOf(this.summaryFeatures); }
     Optional<Integer> getKeepRankCount() { return Optional.ofNullable(this.keepRankCount); }
     Optional<Integer> getTotalKeepRankCount() { return Optional.ofNullable(this.totalKeepRankCount); }
@@ -147,6 +149,7 @@ public class ParsedRankProfile extends ParsedBlock {
     public void addSummaryFeatures(FeatureList features) { this.summaryFeatures.add(features); }
     public void addMatchFeatures(FeatureList features) { this.matchFeatures.add(features); }
     public void addRankFeatures(FeatureList features) { this.rankFeatures.add(features); }
+    public void addSortFeatures(FeatureList features) { this.sortFeatures.add(features); }
 
     public void inherit(String other) { inherited.add(other); }
 

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankingConverter.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedRankingConverter.java
@@ -100,6 +100,7 @@ public class ParsedRankingConverter {
 
         parsed.getMatchFeatures().forEach(profile::addMatchFeatures);
         parsed.getRankFeatures().forEach(profile::addRankFeatures);
+        parsed.getSortFeatures().forEach(profile::addSortFeatures);
         parsed.getSummaryFeatures().forEach(profile::addSummaryFeatures);
         parsed.getInheritedMatchFeatures().forEach(profile::addInheritedMatchFeatures);
         parsed.getInheritedSummaryFeatures().forEach(profile::addInheritedSummaryFeatures);

--- a/config-model/src/main/java/com/yahoo/schema/processing/RankingExpressionTypeResolver.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/RankingExpressionTypeResolver.java
@@ -87,6 +87,9 @@ public class RankingExpressionTypeResolver extends Processor {
             ensureValidDouble(profile.getFirstPhaseRanking(), "first-phase expression", context);
             ensureValidDouble(profile.getSecondPhaseRanking(), "second-phase expression", context);
             ensureValidDouble(profile.getGlobalPhaseRanking(), "global-phase expression", context);
+            for (var sortFeature : profile.getSortFeatures()) {
+                ensureValidDouble(sortFeature, "sort feature " + sortFeature, context);
+            }
             if ( ( context.tensorsAreUsed() || profile.isStrict())
                  && ! context.queryFeaturesNotDeclared().isEmpty()
                  && ! warnedAbout.containsAll(context.queryFeaturesNotDeclared())) {
@@ -127,6 +130,10 @@ public class RankingExpressionTypeResolver extends Processor {
 
     private void ensureValidDouble(RankingExpression expression, String expressionDescription, TypeContext<Reference> context) {
         if (expression == null) return;
+        ensureValidDouble(expression.getRoot(), expressionDescription, context);
+    }
+
+    private void ensureValidDouble(ExpressionNode expression, String expressionDescription, TypeContext<Reference> context) {
         TensorType type = resolveType(expression, expressionDescription, context);
         if ( ! type.equals(TensorType.empty))
             throw new IllegalArgumentException("The " + expressionDescription + " must produce a double " +

--- a/config-model/src/main/javacc/SchemaParser.jj
+++ b/config-model/src/main/javacc/SchemaParser.jj
@@ -325,6 +325,8 @@ TOKEN :
 | < SUMMARYFEATURES_ML_INHERITS: "summary-features inherits " (<IDENTIFIER_WITH_DASH> ("," (" ")* <IDENTIFIER_WITH_DASH>)* ) (<SEARCHLIB_SKIP>)? "{" (~["}"])* "}" >
 | < RANKFEATURES_SL: "rank-features" (" ")* ":" (~["}","\n"])* ("\n")? >
 | < RANKFEATURES_ML: "rank-features" (<SEARCHLIB_SKIP>)? "{" (~["}"])* "}" >
+| < SORTFEATURES_SL: "sort-features" (" ")* ":" (~["}","\n"])* ("\n")? >
+| < SORTFEATURES_ML: "sort-features" (<SEARCHLIB_SKIP>)? "{" (~["}"])* "}" >
 | < EXPRESSION_SL: "expression" (" ")* ":" (("{"<BRACE_SL_LEVEL_1>)|<BRACE_SL_CONTENT>)* ("\n")? >
 | < EXPRESSION_ML: "expression" (<SEARCHLIB_SKIP>)? "{" (("{"<BRACE_ML_LEVEL_1>)|<BRACE_ML_CONTENT>)* "}" >
 | < #BRACE_SL_LEVEL_1: (("{"<BRACE_SL_LEVEL_2>)|<BRACE_SL_CONTENT>)* "}" >
@@ -1882,6 +1884,7 @@ void rankProfileItem(ParsedSchema schema, ParsedRankProfile profile) : { }
       | prefetchTensors(profile)
       | targetHitsMaxAdjustmentFactor(profile)
       | rankFeatures(profile)
+      | sortFeatures(profile)
       | rankProperties(profile)
       | secondPhase(profile)
       | globalPhase(profile)
@@ -2367,6 +2370,20 @@ void rankFeatures(ParsedRankProfile profile) :
                                                            token.image.lastIndexOf("}")).trim(); } )
     {
         profile.addRankFeatures(getFeatureList(features));
+    }
+}
+
+/** Consumes a sort-features block of a rank profile */
+void sortFeatures(ParsedRankProfile profile) :
+{
+    String features;
+}
+{
+    ( <SORTFEATURES_SL> { features = token.image.substring(token.image.indexOf(":") + 1).trim(); } |
+      <SORTFEATURES_ML> { features = token.image.substring(token.image.indexOf("{") + 1,
+                                                           token.image.lastIndexOf("}")).trim(); } )
+    {
+        profile.addSortFeatures(getFeatureList(features));
     }
 }
 

--- a/config-model/src/test/java/com/yahoo/schema/NoNormalizersTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/NoNormalizersTestCase.java
@@ -170,4 +170,31 @@ public class NoNormalizersTestCase extends AbstractSchemaTestCase {
                          Exceptions.toMessageString(e));
         }
     }
+
+    @Test
+    void requireThatNormalizerInSortFeatureIsChecked() throws ParseException {
+        try {
+            compileSchema("""
+                          search test {
+                            document test { }
+                            rank-profile p6 {
+                                function foobar() {
+                                    expression: normalize_linear(nativeRank)
+                                }
+                                first-phase {
+                                    expression: nativeRank
+                                }
+                                sort-features {
+                                    foobar
+                                }
+                            }
+                          }
+                          """);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Rank profile 'p6' is invalid: " +
+                         "Cannot use normalize_linear(nativeRank) from sort-feature foobar, only valid in global-phase expression",
+                         Exceptions.toMessageString(e));
+        }
+    }
 }

--- a/config-model/src/test/java/com/yahoo/schema/RankProfileTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/RankProfileTestCase.java
@@ -27,6 +27,7 @@ import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import static com.yahoo.config.model.test.TestUtil.joinLines;
 
 import com.yahoo.searchlib.rankingexpression.Reference;
+import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
@@ -860,6 +861,169 @@ rank-profile feature_logging {
         assertTrue(expression.contains("attribute(myrank)"), "Expression should contain discriminant: " + expression);
         assertTrue(expression.contains("10000"), "Expression should contain case result: " + expression);
         assertTrue(expression.contains("2500"), "Expression should contain case result: " + expression);
+    }
+
+    @Test
+    void sortFeaturesAreDeclaredInheritedReplacedAndCleared() throws ParseException {
+        RankProfileRegistry registry = new RankProfileRegistry();
+        ApplicationBuilder builder = new ApplicationBuilder(registry);
+        builder.addSchema("""
+            schema test {
+              document test {}
+              rank-profile parent {
+                function title_bm25() { expression: 1.0 }
+                sort-features {
+                  title_bm25
+                }
+              }
+              rank-profile child inherits parent {}
+              rank-profile cleared inherits parent {
+                sort-features {}
+              }
+              rank-profile replaced inherits parent {
+                function other_key() { expression: 2.0 }
+                sort-features: other_key
+              }
+            }
+            """);
+        builder.build(true);
+        Schema schema = builder.getSchema();
+        assertEquals(Set.of("title_bm25"), names(registry.get(schema, "parent").getSortFeatures()));
+        assertEquals(Set.of("title_bm25"), names(registry.get(schema, "child").getSortFeatures()));
+        assertEquals(Set.of(), names(registry.get(schema, "cleared").getSortFeatures()));
+        assertEquals(Set.of("other_key"), names(registry.get(schema, "replaced").getSortFeatures()));
+
+        var compiledCleared = registry.get(schema, "cleared").compile(new QueryProfileRegistry(), new ImportedMlModels());
+        assertEquals(Set.of(), names(compiledCleared.getSortFeatures()));
+    }
+
+    @Test
+    void sortFeaturesRejectNonIdentifiers() throws ParseException {
+        assertIllegalSortFeature("bm25(title)");
+        assertIllegalSortFeature("foo.out");
+        assertIllegalSortFeature("foo$");
+        assertIllegalSortFeature("foo$()");
+    }
+
+    @Test
+    void sortFeaturesRejectTensorOutput() throws ParseException {
+        try {
+            buildSchema("""
+                schema test {
+                  document test {}
+                  rank-profile test {
+                    function tensor_key() {
+                      expression: tensor(x[1]):[1]
+                    }
+                    sort-features { tensor_key }
+                  }
+                }
+                """);
+            fail();
+        }
+        catch (IllegalArgumentException e) {
+            String message = Exceptions.toMessageString(e);
+            assertTrue(message.contains("sort feature"), message);
+            assertTrue(message.contains("must produce a double"), message);
+        }
+    }
+
+    @Test
+    void sortFeaturesEmitPublicAndBackendNamesIndependently() throws ParseException {
+        RankProfileRegistry registry = new RankProfileRegistry();
+        ApplicationBuilder builder = new ApplicationBuilder(registry);
+        builder.addSchema("""
+            schema test {
+              document test {}
+              rank-profile test {
+                function foo() { expression: 1.0 }
+                sort-features {
+                  foo
+                  nativeRank
+                }
+              }
+            }
+            """);
+        builder.build(true);
+        Schema schema = builder.getSchema();
+        RankProfile profile = registry.get(schema, "test");
+        assertEquals(Set.of("foo", "nativeRank"), names(profile.getSortFeatures()));
+
+        RawRankProfile rawProfile = createRawRankProfile(profile, schema);
+        assertEquals(Set.of("rankingExpression(foo)", "nativeRank"),
+                     Set.copyOf(findProperties(rawProfile.configProperties(), "vespa.sort.feature")));
+        assertTrue(hasRename(rawProfile.configProperties(), "rankingExpression(foo)", "foo"));
+        assertFalse(hasRename(rawProfile.configProperties(), "nativeRank", "nativeRank"));
+    }
+
+    @Test
+    void sortFeaturesConflictAcrossParents() throws ParseException {
+        try {
+            buildSchema("""
+                schema test {
+                  document test {}
+                  rank-profile p1 {
+                    sort-features { a }
+                  }
+                  rank-profile p2 {
+                    sort-features { b }
+                  }
+                  rank-profile child inherits p1, p2 {}
+                }
+                """);
+            fail();
+        }
+        catch (IllegalArgumentException e) {
+            String message = Exceptions.toMessageString(e);
+            assertTrue(message.contains("sort-features"), message);
+        }
+    }
+
+    private static Application buildSchema(String schema) throws ParseException {
+        RankProfileRegistry registry = new RankProfileRegistry();
+        ApplicationBuilder builder = new ApplicationBuilder(registry);
+        builder.addSchema(schema);
+        return builder.build(true);
+    }
+
+    private static void assertIllegalSortFeature(String entry) throws ParseException {
+        try {
+            buildSchema("""
+                schema test {
+                  document test {}
+                  rank-profile test {
+                    sort-features { %s }
+                  }
+                }
+                """.formatted(entry));
+            fail("Should reject sort-features entry: " + entry);
+        }
+        catch (IllegalArgumentException | ParseException e) {
+            String message = Exceptions.toMessageString(e);
+            assertTrue(message.contains("sort-features") ||
+                       message.contains("identifier") ||
+                       message.contains("feature"),
+                       message);
+        }
+    }
+
+    private static Set<String> names(Set<com.yahoo.searchlib.rankingexpression.rule.ReferenceNode> features) {
+        return features.stream().map(com.yahoo.searchlib.rankingexpression.rule.ReferenceNode::getName).collect(java.util.stream.Collectors.toSet());
+    }
+
+    private static List<String> findProperties(List<Pair<String, String>> properties, String key) {
+        return properties.stream().filter(p -> p.getFirst().equals(key)).map(Pair::getSecond).toList();
+    }
+
+    private static boolean hasRename(List<Pair<String, String>> properties, String backend, String publicName) {
+        for (int i = 0; i + 1 < properties.size(); i++) {
+            if (properties.get(i).getFirst().equals("vespa.feature.rename") &&
+                properties.get(i).getSecond().equals(backend) &&
+                properties.get(i + 1).getFirst().equals("vespa.feature.rename") &&
+                properties.get(i + 1).getSecond().equals(publicName))
+                return true;
+        }
+        return false;
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
@@ -960,6 +960,12 @@ public class SchemaTestCase {
                         second-phase {
                             rerank-count: 43
                         }
+                        function foo() {
+                            expression: attribute(test)
+                        }
+                        sort-features {
+                            foo
+                        }
                     }
                 }""";
         ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
@@ -968,10 +974,17 @@ public class SchemaTestCase {
         var derived = new DerivedConfiguration(application.schemas().get("doc"), application.rankProfileRegistry());
         var schemaInfoConfigBuilder = new SchemaInfoConfig.Builder();
         derived.getSchemaInfo().getConfig(schemaInfoConfigBuilder);
-        var schemaInfoConfig = schemaInfoConfigBuilder.build().toString();
-        assertTrue(schemaInfoConfig.contains("rerankCount 43"));
-        assertTrue(schemaInfoConfig.contains("keepRankCount 1234"));
-        assertTrue(schemaInfoConfig.contains("matchPhaseMaxHits 456"));
+        var schemaInfoConfig = schemaInfoConfigBuilder.build();
+        var schemaInfoConfigText = schemaInfoConfig.toString();
+        assertTrue(schemaInfoConfigText.contains("rerankCount 43"));
+        assertTrue(schemaInfoConfigText.contains("keepRankCount 1234"));
+        assertTrue(schemaInfoConfigText.contains("matchPhaseMaxHits 456"));
+        var testProfile = schemaInfoConfig.schema().get(0).rankprofile().stream()
+                .filter(profile -> profile.name().equals("test"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(List.of("foo"), testProfile.sortFeature());
+        assertFalse(schemaInfoConfigText.contains("rankingExpression(foo)"));
     }
 
     @Test

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -6045,6 +6045,20 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.search.query.Sorting$FeatureSorter" : {
+    "superClass" : "com.yahoo.search.query.Sorting$AttributeSorter",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(java.lang.String)",
+      "public java.lang.String toSerialForm()",
+      "public int hashCode()",
+      "public boolean equals(java.lang.Object)"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.search.query.Sorting$LowerCaseSorter" : {
     "superClass" : "com.yahoo.search.query.Sorting$AttributeSorter",
     "interfaces" : [ ],
@@ -6165,7 +6179,8 @@
       "public static final java.lang.String STRENGTH_PRIMARY",
       "public static final java.lang.String UCA",
       "public static final java.lang.String RAW",
-      "public static final java.lang.String LOWERCASE"
+      "public static final java.lang.String LOWERCASE",
+      "public static final java.lang.String FEATURE"
     ]
   },
   "com.yahoo.search.query.Trace" : {
@@ -9297,6 +9312,7 @@
       "public com.yahoo.search.schema.RankProfile$Builder setTotalKeepRankCount(int)",
       "public com.yahoo.search.schema.RankProfile$Builder setMatchPhase(com.yahoo.search.schema.MatchPhase)",
       "public com.yahoo.search.schema.RankProfile$Builder setSecondPhase(com.yahoo.search.schema.SecondPhase)",
+      "public com.yahoo.search.schema.RankProfile$Builder addSortFeature(java.lang.String)",
       "public com.yahoo.search.schema.RankProfile build()"
     ],
     "fields" : [ ]
@@ -9337,6 +9353,7 @@
       "public java.util.OptionalInt totalKeepRankCount()",
       "public com.yahoo.search.schema.MatchPhase matchPhase()",
       "public com.yahoo.search.schema.SecondPhase secondPhase()",
+      "public java.util.List sortFeatures()",
       "public boolean equals(java.lang.Object)",
       "public int hashCode()",
       "public java.lang.String toString()"

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/NoRankingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/NoRankingSearcher.java
@@ -8,11 +8,14 @@ import com.yahoo.component.chain.dependencies.Before;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
+import com.yahoo.search.query.Sorting;
 import com.yahoo.search.query.Sorting.FieldOrder;
 import com.yahoo.search.searchchain.Execution;
 
 /**
- * Avoid doing relevance calculations if sorting only on attributes.
+ * Avoid doing relevance calculations when sorting does not need ranking.
+ * {@code feature(...)} keeps the selected rank profile so the content node
+ * can compile that profile's sort resolvers; it does not count as {@code [rank]}.
  *
  * @author Steinar Knutsen
  */
@@ -30,7 +33,7 @@ public class NoRankingSearcher extends Searcher {
             return execution.search(query);
         }
         for (FieldOrder f : s) {
-            if (RANK.equals(f.getFieldName())) {
+            if (RANK.equals(f.getFieldName()) || f.getSorter() instanceof Sorting.FeatureSorter) {
                 return execution.search(query);
             }
         }

--- a/container-search/src/main/java/com/yahoo/prelude/searcher/ValidateSortingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/ValidateSortingSearcher.java
@@ -3,17 +3,22 @@ package com.yahoo.prelude.searcher;
 
 import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.component.chain.dependencies.Before;
+import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
 import com.yahoo.search.config.ClusterConfig;
 import com.yahoo.search.query.Sorting;
 import com.yahoo.search.result.ErrorMessage;
+import com.yahoo.search.schema.RankProfile;
+import com.yahoo.search.schema.Schema;
+import com.yahoo.search.schema.SchemaInfo;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.searchchain.PhaseNames;
 import com.yahoo.vespa.config.search.AttributesConfig;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,23 +34,37 @@ import static com.yahoo.prelude.querytransform.NormalizingSearcher.ACCENT_REMOVA
 @After(ACCENT_REMOVAL)
 public class ValidateSortingSearcher extends Searcher {
 
-    // TODO: Use SchemaInfo instead and validate with streaming as well
-
+    // TODO: Move attribute-sort metadata and validation to SchemaInfo,
+    // including validation of streaming schemas.
     private final boolean isStreaming;
 
     private Map<String, AttributesConfig.Attribute> attributeNames = null;
     private String clusterName = "";
+    private final Map<String, DocumentdbInfoConfig.Documentdb.Mode.Enum> schemaModes;
 
-    public ValidateSortingSearcher(ClusterConfig clusterConfig, AttributesConfig attributesConfig) {
+    public ValidateSortingSearcher(ClusterConfig clusterConfig,
+                                   AttributesConfig attributesConfig,
+                                   DocumentdbInfoConfig documentdbInfoConfig) {
         initAttributeNames(attributesConfig);
         setClusterName(clusterConfig.clusterName());
         isStreaming = clusterConfig.indexMode() == ClusterConfig.IndexMode.Enum.STREAMING;
+        schemaModes = schemaModesFrom(documentdbInfoConfig);
+    }
+
+    private static Map<String, DocumentdbInfoConfig.Documentdb.Mode.Enum> schemaModesFrom(DocumentdbInfoConfig config) {
+        Map<String, DocumentdbInfoConfig.Documentdb.Mode.Enum> modes = new LinkedHashMap<>();
+        for (DocumentdbInfoConfig.Documentdb docDb : config.documentdb()) {
+            if (docDb.mode() == DocumentdbInfoConfig.Documentdb.Mode.Enum.STORE_ONLY)
+                continue;
+            modes.put(docDb.name(), docDb.mode());
+        }
+        return Map.copyOf(modes);
     }
 
     @Override
     public Result search(Query query, Execution execution) {
-        ErrorMessage error = validate(query);
-        if (! isStreaming && error != null)
+        ErrorMessage error = validate(query, execution.context().schemaInfo());
+        if (error != null)
             return new Result(query, error);
         return execution.search(query);
     }
@@ -69,7 +88,7 @@ public class ValidateSortingSearcher extends Searcher {
         setAttributeNames(attributes);
     }
 
-    private ErrorMessage validate(Query query) {
+    private ErrorMessage validate(Query query, SchemaInfo schemaInfo) {
         Sorting sorting = query.getRanking().getSorting();
         List<Sorting.FieldOrder> l = (sorting != null) ? sorting.fieldOrders() : null;
 
@@ -87,6 +106,12 @@ public class ValidateSortingSearcher extends Searcher {
         }
 
         for (Sorting.FieldOrder f : l) {
+            if (f.getSorter() instanceof Sorting.FeatureSorter) {
+                ErrorMessage featureError = validateFeatureSort(query, schemaInfo, f.getFieldName());
+                if (featureError != null)
+                    return featureError;
+                continue;
+            }
             String name = f.getFieldName();
             if ("[rank]".equals(name) || "[docid]".equals(name)) {
                 // built-in constants
@@ -155,8 +180,32 @@ public class ValidateSortingSearcher extends Searcher {
                     }
                 }
             } else {
+                if (isStreaming)
+                    continue;
                 return ErrorMessage.createInvalidQueryParameter("Cluster '" + getClusterName() +
                                                                 "' has no sortable attribute named '" + name + "'");
+            }
+        }
+        return null;
+    }
+
+    private ErrorMessage validateFeatureSort(Query query, SchemaInfo schemaInfo, String featureName) {
+        String profileName = query.getRanking().getProfile();
+        for (Schema schema : schemaInfo.newSession(query).schemas()) {
+            var mode = schemaModes.get(schema.name());
+            if (mode == null)
+                continue;
+            if (mode != DocumentdbInfoConfig.Documentdb.Mode.Enum.INDEX) {
+                return ErrorMessage.createInvalidQueryParameter(
+                        "Cluster '" + getClusterName() + "' cannot sort by feature(" + featureName +
+                        ") because schema '" + schema.name() + "' is not indexed");
+            }
+            RankProfile profile = schema.rankProfiles().get(profileName);
+            if (profile == null || ! profile.sortFeatures().contains(featureName)) {
+                return ErrorMessage.createInvalidQueryParameter(
+                        "Cluster '" + getClusterName() + "' cannot sort by feature(" + featureName +
+                        "): rank profile '" + profileName + "' in schema '" + schema.name() +
+                        "' does not allow it");
             }
         }
         return null;

--- a/container-search/src/main/java/com/yahoo/search/Query.java
+++ b/container-search/src/main/java/com/yahoo/search/Query.java
@@ -880,6 +880,12 @@ public class Query extends com.yahoo.processing.Request implements Cloneable {
                        .append('"');
                 }
                 yql.append("}]");
+            } else if (sorterType == Sorting.FeatureSorter.class) {
+                yql.append("[{\"")
+                   .append(YqlParser.SORTING_FUNCTION)
+                   .append("\": \"")
+                   .append(Sorting.FEATURE)
+                   .append("\"}]");
             }
             yql.append(maybeQuote(f.getFieldName()));
             if (f.getSortOrder() == Order.DESCENDING) {

--- a/container-search/src/main/java/com/yahoo/search/grouping/UniqueGroupingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/UniqueGroupingSearcher.java
@@ -3,7 +3,7 @@ package com.yahoo.search.grouping;
 
 import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.component.chain.dependencies.Before;
-import java.util.logging.Level;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -28,6 +28,7 @@ import com.yahoo.search.searchchain.PhaseNames;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -77,12 +78,20 @@ public class UniqueGroupingSearcher extends Searcher {
      */
     private static Result dedupe(Query query, Execution execution, String dedupField) {
         Sorting sorting = query.getRanking().getSorting();
-        if (sorting != null && sorting.fieldOrders().size() > 1) {
-            query.trace("Can not use grouping for deduping with multi-level sorting.", 3);
-            // To support this we'd have to generate a grouping expression with as many levels
-            // as there are levels in the sort spec. This is probably too slow and costly that
-            // we'd ever want to actually use it (and a bit harder to implement as well).
-            return execution.search(query);
+        if (sorting != null) {
+            for (Sorting.FieldOrder fieldOrder : sorting.fieldOrders()) {
+                if (fieldOrder.getSorter() instanceof Sorting.FeatureSorter) {
+                    throw new IllegalInputException(
+                            "Cannot use unique grouping with feature(...) sorting");
+                }
+            }
+            if (sorting.fieldOrders().size() > 1) {
+                query.trace("Can not use grouping for deduping with multi-level sorting.", 3);
+                // To support this we'd have to generate a grouping expression with as many levels
+                // as there are levels in the sort spec. This is probably too slow and costly that
+                // we'd ever want to actually use it (and a bit harder to implement as well).
+                return execution.search(query);
+            }
         }
 
         int hits = query.getHits();

--- a/container-search/src/main/java/com/yahoo/search/query/Sorting.java
+++ b/container-search/src/main/java/com/yahoo/search/query/Sorting.java
@@ -30,6 +30,7 @@ public class Sorting implements Cloneable {
     public static final String UCA = "uca";
     public static final String RAW = "raw";
     public static final String LOWERCASE = "lowercase";
+    public static final String FEATURE = "feature";
     static final String MISSING = "missing";
 
     private final List<FieldOrder> fieldOrders = new ArrayList<>(2);
@@ -82,7 +83,13 @@ public class Sorting implements Cloneable {
             AttributeSorter sorter;
             if (tokenizer.peek() == '(') {
                 tokenizer.step();
-                if (LOWERCASE.equalsIgnoreCase(functionName)) {
+                if (FEATURE.equalsIgnoreCase(functionName)) {
+                    if (inMissing) {
+                        throw new IllegalInputException("Cannot use missing() with feature(...) sorting in '" + rawSortSpec + "'");
+                    }
+                    sorter = new FeatureSorter(tokenizer.token());
+                    tokenizer.expectChar(')');
+                } else if (LOWERCASE.equalsIgnoreCase(functionName)) {
                     sorter = new LowerCaseSorter(canonic(tokenizer.token(), indexFacts));
                     tokenizer.expectChar(')');
                 } else if (RAW.equalsIgnoreCase(functionName)) {
@@ -333,6 +340,35 @@ public class Sorting implements Cloneable {
         }
     }
 
+    public static class FeatureSorter extends AttributeSorter {
+
+        private static final Pattern SCHEMA_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+        public FeatureSorter(String fieldName) {
+            super(validateFeatureName(fieldName));
+        }
+
+        private static String validateFeatureName(String fieldName) {
+            if ( ! SCHEMA_IDENTIFIER.matcher(fieldName).matches())
+                throw new IllegalInputException("Illegal feature name '" + fieldName + "' for sorting. Requires '" + SCHEMA_IDENTIFIER.pattern() + "'");
+            return fieldName;
+        }
+
+        @Override
+        public String toSerialForm() { return FEATURE + "(" + getName() + ')'; }
+
+        @Override
+        public int hashCode() { return 1 + 5 * super.hashCode(); }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof FeatureSorter)) {
+                return false;
+            }
+            return super.equals(other);
+        }
+    }
+
     public static class UcaSorter extends AttributeSorter {
 
         public enum Strength { PRIMARY, SECONDARY, TERTIARY, QUATERNARY, IDENTICAL, UNDEFINED };
@@ -529,7 +565,7 @@ public class Sorting implements Cloneable {
          */
         FieldOrder(AttributeSorter fieldSorter, Order sortOrder, MissingPolicy missingPolicy, String missingValue) {
             this.fieldSorter = fieldSorter;
-            this.sortOrder = sortOrder;
+            this.sortOrder = normalizeFeatureOrder(fieldSorter, sortOrder);
             this.missingValueSettings = new MissingValueSettings(missingPolicy, missingValue);
         }
 
@@ -544,7 +580,16 @@ public class Sorting implements Cloneable {
          * Returns the sorter of this attribute
          */
         public AttributeSorter getSorter() { return fieldSorter; }
-        public void setSorter(AttributeSorter sorter) { fieldSorter = sorter; }
+        public void setSorter(AttributeSorter sorter) {
+            fieldSorter = sorter;
+            sortOrder = normalizeFeatureOrder(sorter, sortOrder);
+        }
+
+        private static Order normalizeFeatureOrder(AttributeSorter sorter, Order order) {
+            if (sorter instanceof FeatureSorter && order == Order.UNDEFINED)
+                return Order.ASCENDING;
+            return order;
+        }
 
         /**
          * Returns the sorting order of this attribute

--- a/container-search/src/main/java/com/yahoo/search/querytransform/SortingDegrader.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/SortingDegrader.java
@@ -59,7 +59,10 @@ public class SortingDegrader extends Searcher {
         if ( ! query.getSelect().getGrouping().isEmpty()) return false;
         if ( ! query.properties().getBoolean(DEGRADING, true)) return false;
 
-        Index index = indexFacts.getIndex(query.getRanking().getSorting().fieldOrders().get(0).getFieldName());
+        Sorting.FieldOrder primarySort = query.getRanking().getSorting().fieldOrders().get(0); // ensured above
+        if (primarySort.getSorter() instanceof Sorting.FeatureSorter) return false;
+
+        Index index = indexFacts.getIndex(primarySort.getFieldName());
         if (index == null) return false;
         if ( ! index.isFastSearch()) return false;
         if ( ! index.isNumerical()) return false;

--- a/container-search/src/main/java/com/yahoo/search/result/FieldComparator.java
+++ b/container-search/src/main/java/com/yahoo/search/result/FieldComparator.java
@@ -3,6 +3,7 @@ package com.yahoo.search.result;
 
 import com.yahoo.data.access.Inspector;
 import com.yahoo.data.access.Inspectable;
+import com.yahoo.processing.IllegalInputException;
 import com.yahoo.search.query.Sorting;
 
 import java.util.Comparator;
@@ -52,6 +53,10 @@ public class FieldComparator extends ChainableComparator {
     @Override
     public int compare(Hit first, Hit second) {
         for (Sorting.FieldOrder fieldOrder : sorting.fieldOrders() ) {
+            if (fieldOrder.getSorter() instanceof Sorting.FeatureSorter) {
+                throw new IllegalInputException(
+                        "Cannot sort hits by feature(" + fieldOrder.getFieldName() + ") without backend sort data");
+            }
             String fieldName = fieldOrder.getFieldName();
             Object a = getField(first,fieldName);
             Object b = getField(second,fieldName);

--- a/container-search/src/main/java/com/yahoo/search/schema/RankProfile.java
+++ b/container-search/src/main/java/com/yahoo/search/schema/RankProfile.java
@@ -5,9 +5,12 @@ import com.yahoo.tensor.TensorType;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
+import java.util.Set;
 
 /**
  * Information about a rank profile
@@ -25,6 +28,7 @@ public class RankProfile {
     private final Map<String, InputType> inputs;
     private final MatchPhase  matchPhase;
     private final SecondPhase secondPhase;
+    private final List<String> sortFeatures;
 
     // Assigned when this is added to a schema
     private Schema schema = null;
@@ -39,6 +43,7 @@ public class RankProfile {
         this.totalKeepRankCount = builder.totalKeepRankCount;
         this.matchPhase = builder.matchPhase;
         this.secondPhase = builder.secondPhase;
+        this.sortFeatures = List.copyOf(builder.sortFeatures);
     }
 
     public String name() { return name; }
@@ -77,6 +82,9 @@ public class RankProfile {
     /** Returns information about the second phase reranking of this. */
     public SecondPhase secondPhase() { return secondPhase; }
 
+    /** Returns the public names of rank features that may be used as sorting keys. */
+    public List<String> sortFeatures() { return sortFeatures; }
+
     @Override
     public boolean equals(Object o) {
         if (o == this) return true;
@@ -90,12 +98,13 @@ public class RankProfile {
         if ( ! other.totalKeepRankCount.equals(this.totalKeepRankCount)) return false;
         if ( ! other.matchPhase.equals(this.matchPhase)) return false;
         if ( ! other.secondPhase.equals(this.secondPhase)) return false;
+        if ( ! other.sortFeatures.equals(this.sortFeatures)) return false;
         return true;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, hasSummaryFeatures, hasRankFeatures, useSignificanceModel, inputs, keepRankCount, totalKeepRankCount, matchPhase, secondPhase);
+        return Objects.hash(name, hasSummaryFeatures, hasRankFeatures, useSignificanceModel, inputs, keepRankCount, totalKeepRankCount, matchPhase, secondPhase, sortFeatures);
     }
 
     @Override
@@ -133,6 +142,7 @@ public class RankProfile {
         private OptionalInt totalKeepRankCount = OptionalInt.empty();
         private MatchPhase matchPhase = new MatchPhase.Builder().build();
         private SecondPhase secondPhase = new SecondPhase.Builder().build();
+        private final Set<String> sortFeatures = new LinkedHashSet<>();
 
         public Builder(String name) {
             this.name = Objects.requireNonNull(name);
@@ -172,6 +182,11 @@ public class RankProfile {
 
         public Builder setSecondPhase(SecondPhase secondPhase) {
             this.secondPhase = Objects.requireNonNull(secondPhase);
+            return this;
+        }
+
+        public Builder addSortFeature(String name) {
+            sortFeatures.add(Objects.requireNonNull(name));
             return this;
         }
 

--- a/container-search/src/main/java/com/yahoo/search/schema/SchemaInfoConfigurer.java
+++ b/container-search/src/main/java/com/yahoo/search/schema/SchemaInfoConfigurer.java
@@ -42,6 +42,8 @@ class SchemaInfoConfigurer {
                 profileBuilder.setTotalKeepRankCount(profileConfig.totalKeepRankCount());
             for (var inputConfig : profileConfig.input())
                 profileBuilder.addInput(inputConfig.name(), RankProfile.InputType.fromSpec(inputConfig.type()));
+            for (String sortFeature : profileConfig.sortFeature())
+                profileBuilder.addSortFeature(sortFeature);
 
             var matchPhaseBuilder = new MatchPhase.Builder();
             if (profileConfig.matchPhaseMaxHits() >= 0)

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -91,6 +91,7 @@ import com.yahoo.search.query.QueryTree;
 import com.yahoo.search.query.QueryType;
 import com.yahoo.search.query.Sorting;
 import com.yahoo.search.query.Sorting.AttributeSorter;
+import com.yahoo.search.query.Sorting.FeatureSorter;
 import com.yahoo.search.query.Sorting.FieldOrder;
 import com.yahoo.search.query.Sorting.LowerCaseSorter;
 import com.yahoo.search.query.Sorting.Order;
@@ -1262,6 +1263,8 @@ public class YqlParser implements Parser {
                 sorter = new LowerCaseSorter(field);
             } else if (Sorting.RAW.equals(function)) {
                 sorter = new RawSorter(field);
+            } else if (Sorting.FEATURE.equals(function)) {
+                sorter = new FeatureSorter(field);
             } else if (Sorting.UCA.equals(function)) {
                 if (locale != null) {
                     UcaSorter.Strength ucaStrength = UcaSorter.Strength.UNDEFINED;
@@ -1296,7 +1299,7 @@ public class YqlParser implements Parser {
                     sorter = new UcaSorter(field);
                 }
             } else {
-                throw newUnexpectedArgumentException(function, "lowercase", "raw", "uca");
+                throw newUnexpectedArgumentException(function, "lowercase", "raw", "uca", "feature");
             }
             switch ((SortOperator) op.getOperator()) {
                 case ASC -> sortingInit.add(new FieldOrder(sorter, Order.ASCENDING));

--- a/container-search/src/main/resources/configdefinitions/container.search.schema-info.def
+++ b/container-search/src/main/resources/configdefinitions/container.search.schema-info.def
@@ -42,6 +42,8 @@ schema[].rankprofile[].rerankCount int default=-1
 # The second-phase rerank count across all nodes, or -1 to use rerankCount
 schema[].rankprofile[].totalRerankCount int default=-1
 schema[].rankprofile[].significance.useModel bool default=false
+# Public names of rank features that may be used as sorting keys
+schema[].rankprofile[].sortFeature[] string
 # The name of an input (query rank feature) accepted by this profile
 schema[].rankprofile[].input[].name string
 # The tensor type of an input (query rank feature) accepted by this profile

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/NoRankingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/NoRankingSearcherTestCase.java
@@ -42,4 +42,11 @@ public class NoRankingSearcherTestCase {
         assertEquals("default", q.getRanking().getProfile());
     }
 
+    @Test
+    void testSortOnFeatureKeepsProfile() {
+        Query q = new Query("?query=a&sorting=-feature(foo)&ranking=hello");
+        new Execution(s, Execution.Context.createContextStub()).search(q);
+        assertEquals("hello", q.getRanking().getProfile());
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/prelude/searcher/test/ValidateSortingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/searcher/test/ValidateSortingSearcherTestCase.java
@@ -3,13 +3,22 @@ package com.yahoo.prelude.searcher.test;
 
 import com.yahoo.component.chain.Chain;
 import com.yahoo.config.subscription.ConfigGetter;
+import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
 import com.yahoo.prelude.searcher.ValidateSortingSearcher;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
 import com.yahoo.search.config.ClusterConfig;
+import com.yahoo.search.query.Sorting;
+import com.yahoo.search.query.parser.Parsable;
+import com.yahoo.search.query.parser.ParserEnvironment;
+import com.yahoo.search.schema.Cluster;
+import com.yahoo.search.schema.RankProfile;
+import com.yahoo.search.schema.Schema;
+import com.yahoo.search.schema.SchemaInfo;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.test.QueryTestCase;
+import com.yahoo.search.yql.YqlParser;
 import com.yahoo.vespa.config.search.AttributesConfig;
 import org.junit.jupiter.api.Test;
 
@@ -17,8 +26,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -36,7 +47,8 @@ public class ValidateSortingSearcherTestCase {
                 .clusterName("giraffes");
         String attributesCfg = "file:src/test/java/com/yahoo/prelude/searcher/test/validate_sorting.cfg";
         searcher = new ValidateSortingSearcher(new ClusterConfig(clusterCfg),
-                                               ConfigGetter.getConfig(AttributesConfig.class, attributesCfg));
+                                               ConfigGetter.getConfig(AttributesConfig.class, attributesCfg),
+                                               new DocumentdbInfoConfig.Builder().build());
     }
 
     @Test
@@ -64,6 +76,173 @@ public class ValidateSortingSearcherTestCase {
     @Test
     void testInvalidSpec() {
         assertNull(quoteAndTransform("+a -e +c"));
+    }
+
+    @Test
+    void featureSortRequiresAllowlistOnIndexedSchema() {
+        var searcher = featureSearcher(List.of(indexed("products")), false);
+        Result ok = featureSearch(searcher, schemaInfo(indexed("products")),
+                                  "?query=a&ranking=products&sorting=" + QueryTestCase.httpEncode("-feature(title_bm25)"));
+        assertNull(ok.hits().getError());
+        assertEquals("[DESCENDING:feature(title_bm25)]",
+                     ok.getQuery().getRanking().getSorting().fieldOrders().toString());
+
+        Result undeclared = featureSearch(searcher, schemaInfo(indexed("products")),
+                                          "?query=a&ranking=products&sorting=" + QueryTestCase.httpEncode("-feature(unknown)"));
+        assertNotNull(undeclared.hits().getError());
+        assertTrue(undeclared.hits().getError().getDetailedMessage().contains("feature(unknown)"));
+    }
+
+    @Test
+    void featureSortDoesNotInheritAttributeDirectionOrSorter() {
+        var searcher = featureSearcher(List.of(indexed("products")), false);
+        Result r = featureSearch(searcher, schemaInfo(indexed("products")),
+                                 "?query=a&ranking=products&sorting=" + QueryTestCase.httpEncode("feature(foo)"));
+        assertNull(r.hits().getError());
+        assertEquals("[ASCENDING:feature(foo)]",
+                     r.getQuery().getRanking().getSorting().fieldOrders().toString());
+    }
+
+    @Test
+    void featureSortFailsForStreamingSchema() {
+        var searcher = featureSearcher(List.of(streaming("streaming")), true);
+        Result r = featureSearch(searcher, schemaInfo(streaming("streaming")),
+                                 "?query=a&ranking=products&sorting=" + QueryTestCase.httpEncode("-feature(title_bm25)"));
+        assertNotNull(r.hits().getError());
+        assertTrue(r.hits().getError().getDetailedMessage().contains("not indexed"));
+    }
+
+    @Test
+    void featureSortMixedProviderHonorsRestrict() {
+        var schemas = List.of(indexed("indexed"), streaming("streaming"));
+        var searcher = featureSearcher(schemas, false);
+        SchemaInfo schemaInfo = schemaInfo(schemas.toArray(Schema[]::new));
+
+        Result indexedOnly = featureSearch(searcher, schemaInfo,
+                "?query=a&ranking=products&restrict=indexed&sorting=" + QueryTestCase.httpEncode("-feature(title_bm25)"));
+        assertNull(indexedOnly.hits().getError());
+
+        Result streamingOnly = featureSearch(searcher, schemaInfo,
+                "?query=a&ranking=products&restrict=streaming&sorting=" + QueryTestCase.httpEncode("-feature(title_bm25)"));
+        assertNotNull(streamingOnly.hits().getError());
+
+        Result both = featureSearch(searcher, schemaInfo,
+                "?query=a&ranking=products&sorting=" + QueryTestCase.httpEncode("-feature(title_bm25)"));
+        assertNotNull(both.hits().getError());
+    }
+
+    @Test
+    void featureSortIgnoresStoreOnlyAndForeignSchemas() {
+        Schema products = indexed("products");
+        Schema archived = new Schema.Builder("archived")
+                .add(new RankProfile.Builder("products").build())
+                .build();
+        Schema other = new Schema.Builder("other")
+                .add(new RankProfile.Builder("products").addSortFeature("title_bm25").build())
+                .build();
+        var searcher = featureSearcher(List.of(products, archived), false,
+                List.of(DocumentdbInfoConfig.Documentdb.Mode.Enum.INDEX,
+                        DocumentdbInfoConfig.Documentdb.Mode.Enum.STORE_ONLY));
+        SchemaInfo schemaInfo = new SchemaInfo(
+                List.of(products, archived, other),
+                List.of(new Cluster.Builder("giraffes").addSchema("products").addSchema("archived").build(),
+                        new Cluster.Builder("elsewhere").addSchema("other").build()));
+        Result r = featureSearch(searcher, schemaInfo,
+                                 "?query=a&ranking=products&sources=giraffes&sorting=" + QueryTestCase.httpEncode("-feature(title_bm25)"));
+        assertNull(r.hits().getError());
+    }
+
+    @Test
+    void featureSortAllowlistIsIntersectedAcrossIndexedSchemas() {
+        Schema allowed = indexed("allowed");
+        Schema denied = new Schema.Builder("denied")
+                .add(new RankProfile.Builder("products").build())
+                .add(new RankProfile.Builder("default").build())
+                .build();
+        var searcher = featureSearcher(List.of(allowed, denied), false);
+        SchemaInfo schemaInfo = schemaInfo(allowed, denied);
+
+        Result unrestricted = featureSearch(searcher, schemaInfo,
+                "?query=a&ranking=products&sorting=" + QueryTestCase.httpEncode("-feature(title_bm25)"));
+        assertNotNull(unrestricted.hits().getError());
+        assertTrue(unrestricted.hits().getError().getDetailedMessage().contains("denied"));
+
+        Result restricted = featureSearch(searcher, schemaInfo,
+                "?query=a&ranking=products&restrict=allowed&sorting=" + QueryTestCase.httpEncode("-feature(title_bm25)"));
+        assertNull(restricted.hits().getError());
+    }
+
+    @Test
+    void featureSortFromYqlAnnotationIsValidated() {
+        var parser = new YqlParser(new ParserEnvironment());
+        parser.parse(new Parsable().setQuery(
+                "select * from sources * where true order by {\"function\": \"feature\"}title_bm25 desc"));
+        var searcher = featureSearcher(List.of(indexed("products")), false);
+        Query q = new Query("?query=a&ranking=products");
+        q.getRanking().setSorting(parser.getSorting());
+        Result r = new Execution(chainedAsSearchChainStatic(searcher),
+                                 Execution.Context.createContextStub(schemaInfo(indexed("products")))).search(q);
+        assertNull(r.hits().getError());
+        assertInstanceOf(Sorting.FeatureSorter.class, r.getQuery().getRanking().getSorting().fieldOrders().get(0).getSorter());
+    }
+
+    private static Schema indexed(String name) {
+        return new Schema.Builder(name)
+                .add(new RankProfile.Builder("products").addSortFeature("title_bm25").addSortFeature("foo").build())
+                .add(new RankProfile.Builder("default").addSortFeature("title_bm25").addSortFeature("foo").build())
+                .build();
+    }
+
+    private static Schema streaming(String name) {
+        return indexed(name);
+    }
+
+    private static SchemaInfo schemaInfo(Schema... schemas) {
+        Cluster.Builder cluster = new Cluster.Builder("giraffes");
+        for (Schema schema : schemas)
+            cluster.addSchema(schema.name());
+        return new SchemaInfo(List.of(schemas), List.of(cluster.build()));
+    }
+
+    @SuppressWarnings("deprecation")
+    private static ValidateSortingSearcher featureSearcher(List<Schema> schemas, boolean streaming) {
+        List<DocumentdbInfoConfig.Documentdb.Mode.Enum> modes = new ArrayList<>();
+        for (Schema schema : schemas) {
+            modes.add("streaming".equals(schema.name())
+                    ? DocumentdbInfoConfig.Documentdb.Mode.Enum.STREAMING
+                    : DocumentdbInfoConfig.Documentdb.Mode.Enum.INDEX);
+        }
+        return featureSearcher(schemas, streaming, modes);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static ValidateSortingSearcher featureSearcher(List<Schema> schemas, boolean streaming,
+                                                           List<DocumentdbInfoConfig.Documentdb.Mode.Enum> modes) {
+        ClusterConfig.Builder clusterCfg = new ClusterConfig.Builder().clusterName("giraffes");
+        if (streaming)
+            clusterCfg.indexMode(ClusterConfig.IndexMode.Enum.STREAMING);
+        DocumentdbInfoConfig.Builder dbs = new DocumentdbInfoConfig.Builder();
+        for (int i = 0; i < schemas.size(); i++) {
+            var db = new DocumentdbInfoConfig.Documentdb.Builder().name(schemas.get(i).name());
+            db.mode(modes.get(i));
+            dbs.documentdb(db);
+        }
+        String attributesCfg = "file:src/test/java/com/yahoo/prelude/searcher/test/validate_sorting.cfg";
+        return new ValidateSortingSearcher(new ClusterConfig(clusterCfg),
+                                           ConfigGetter.getConfig(AttributesConfig.class, attributesCfg),
+                                           dbs.build());
+    }
+
+    private static Result featureSearch(Searcher searcher, SchemaInfo schemaInfo, String query) {
+        Query q = new Query(query);
+        q.setHits(10);
+        return new Execution(chainedAsSearchChainStatic(searcher), Execution.Context.createContextStub(schemaInfo)).search(q);
+    }
+
+    private static Chain<Searcher> chainedAsSearchChainStatic(Searcher topOfChain) {
+        List<Searcher> searchers = new ArrayList<>();
+        searchers.add(topOfChain);
+        return new Chain<>(searchers);
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/searcher/test/validate_sorting.cfg
+++ b/container-search/src/test/java/com/yahoo/prelude/searcher/test/validate_sorting.cfg
@@ -1,4 +1,4 @@
-attribute[5]
+attribute[6]
 attribute[0].name                title
 attribute[0].datatype            STRING
 attribute[0].collectiontype      SINGLE
@@ -18,3 +18,6 @@ attribute[3].collectiontype      SINGLE
 attribute[4].name                aTensor
 attribute[4].datatype            TENSOR
 attribute[4].collectiontype      SINGLE
+attribute[5].name                foo
+attribute[5].datatype            STRING
+attribute[5].collectiontype      SINGLE

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
@@ -171,6 +171,20 @@ public class ProtobufSerializationTest {
     }
 
     @Test
+    void feature_sort_is_serialized_as_opaque_field() {
+        Query q = new Query("?query=test&sorting=-feature(foo)");
+        var req = ProtobufSerialization.convertFromQuery(q, 1, "serverId", 1.0, 0.5, new QrSearchersConfig.Builder().build());
+        assertEquals(1, req.getSortingCount());
+        assertEquals("feature(foo)", req.getSorting(0).getField());
+        assertFalse(req.getSorting(0).getAscending());
+
+        Query ascending = new Query("?query=test&sorting=feature(foo)");
+        var req2 = ProtobufSerialization.convertFromQuery(ascending, 1, "serverId", 1.0, 0.5, new QrSearchersConfig.Builder().build());
+        assertEquals("feature(foo)", req2.getSorting(0).getField());
+        assertTrue(req2.getSorting(0).getAscending());
+    }
+
+    @Test
     void soft_timeout_errors_use_timeout_error_code() {
         Query q = new Query("search/?query=test");
         SearchProtocol.SearchReply reply = SearchProtocol.SearchReply.newBuilder()

--- a/container-search/src/test/java/com/yahoo/search/grouping/UniqueGroupingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/UniqueGroupingSearcherTestCase.java
@@ -40,6 +40,18 @@ public class UniqueGroupingSearcherTestCase {
     }
 
     @Test
+    void testRejectFeatureSorting() {
+        try {
+            search("?query=foo&unique=fingerprint&sorting=-feature%28foo%29",
+                    new MockResultProvider(0, false));
+            fail("Above statement should throw");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Cannot use unique grouping with feature(...) sorting",
+                         Exceptions.toMessageString(e));
+        }
+    }
+
+    @Test
     void testIllegalSortingSpec() {
         try {
             search("?query=foo&unique=fingerprint&sorting=-1",

--- a/container-search/src/test/java/com/yahoo/search/query/SortingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/SortingTestCase.java
@@ -11,6 +11,8 @@ import com.yahoo.prelude.IndexModel;
 import com.yahoo.prelude.SearchDefinition;
 import com.yahoo.processing.IllegalInputException;
 import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -170,6 +172,94 @@ public class SortingTestCase {
                      failedSpec("missing(a,as,\"bad \\n default\")"));
         assertEquals("Unknown missing policy 'before' at [missing(a,before][,default)]",
                      failedSpec("missing(a,before,default)"));
+    }
+
+    @Test
+    void featureSortIsParsedAndSerializedCanonically() {
+        assertEquals("+feature(foo)", encodedSpec("feature(foo)"));
+        assertEquals("+feature(foo)", encodedSpec("+feature(foo)"));
+        assertEquals("-feature(foo)", encodedSpec("-feature(foo)"));
+        assertEquals("+feature(foo)", encodedSpec("FeAtUrE(foo)"));
+        assertEquals("+feature(foo) -feature(bar) +a", encodedSpec("+feature(foo) -feature(bar) +a"));
+        assertInstanceOf(Sorting.FeatureSorter.class, Sorting.fromString("feature(foo)").fieldOrders().get(0).getSorter());
+        assertEquals(Sorting.Order.ASCENDING, Sorting.fromString("feature(foo)").fieldOrders().get(0).getSortOrder());
+        assertEquals(Sorting.Order.DESCENDING, Sorting.fromString("-feature(foo)").fieldOrders().get(0).getSortOrder());
+    }
+
+    @Test
+    void featureSortUndefinedOrderIsNormalizedToAscending() {
+        var sorter = new Sorting.FeatureSorter("foo");
+        var order = new Sorting.FieldOrder(sorter, Sorting.Order.UNDEFINED);
+        assertEquals(Sorting.Order.ASCENDING, order.getSortOrder());
+        assertEquals("+feature(foo)", order.toSerialForm(true));
+
+        var attributeOrder = new Sorting.FieldOrder(new Sorting.AttributeSorter("a"), Sorting.Order.UNDEFINED);
+        assertEquals(Sorting.Order.UNDEFINED, attributeOrder.getSortOrder());
+        attributeOrder.setSorter(new Sorting.FeatureSorter("foo"));
+        assertEquals(Sorting.Order.ASCENDING, attributeOrder.getSortOrder());
+    }
+
+    @Test
+    void featureSortRejectsInvalidInput() {
+        assertEquals("Cannot use missing() with feature(...) sorting in 'missing(feature(foo),first)'",
+                     failedSpec("missing(feature(foo),first)"));
+        assertEquals("Illegal feature name 'foo-bar' for sorting. Requires '[A-Za-z_][A-Za-z0-9_]*'",
+                     failedSpec("feature(foo-bar)"));
+        assertEquals("Illegal feature name 'foo$' for sorting. Requires '[A-Za-z_][A-Za-z0-9_]*'",
+                     failedSpec("feature(foo$)"));
+        assertTrue(failedSpec("feature(bm25(title))").contains("Expected ')'"));
+        assertEquals("Illegal feature name 'foo.out' for sorting. Requires '[A-Za-z_][A-Za-z0-9_]*'",
+                     failedSpec("feature(foo.out)"));
+        assertEquals("Illegal feature name '' for sorting. Requires '[A-Za-z_][A-Za-z0-9_]*'",
+                     failedSpec("feature()"));
+    }
+
+    @Test
+    void featureSortEqualsAndHashDifferFromOtherSorters() {
+        var feature = new Sorting.FeatureSorter("foo");
+        var otherFeature = new Sorting.FeatureSorter("foo");
+        var different = new Sorting.FeatureSorter("bar");
+        var lowercase = new Sorting.LowerCaseSorter("foo");
+        assertEquals(feature, otherFeature);
+        assertEquals(feature.hashCode(), otherFeature.hashCode());
+        assertNotEquals(feature, different);
+        assertNotEquals(feature, lowercase);
+        assertNotEquals(feature.hashCode(), lowercase.hashCode());
+    }
+
+    @Test
+    void featureSortIsNotCanonicalizedAsAnAttributeAlias() {
+        Query query = new Query();
+        var schema = new SearchDefinition("test");
+        schema.addIndex(new Index("a"));
+        schema.addAlias("aliasOfA", "a");
+        Execution execution = new Execution(Execution.Context.createContextStub(new IndexFacts(new IndexModel(schema))));
+        query.getModel().setExecution(execution);
+        var sorting = new Sorting("feature(aliasOfA)", query);
+        assertEquals("aliasOfA", sorting.fieldOrders().get(0).getFieldName());
+        assertInstanceOf(Sorting.FeatureSorter.class, sorting.fieldOrders().get(0).getSorter());
+    }
+
+    @Test
+    void featureSortSerializesAsCompleteYqlFragment() {
+        Query query = new Query("?query=a&sorting=-feature(foo)");
+        assertTrue(query.yqlRepresentation().contains("order by [{\"function\": \"feature\"}]foo desc"),
+                   query.yqlRepresentation());
+        Query ascending = new Query("?query=a&sorting=%2Bfeature(foo)");
+        String yql = ascending.yqlRepresentation();
+        int orderBy = yql.indexOf("order by ");
+        assertTrue(orderBy >= 0, yql);
+        assertEquals("[{\"function\": \"feature\"}]foo", yql.substring(orderBy + "order by ".length()));
+    }
+
+    @Test
+    void featureSortFallbackCompareIsRejectedOnCustomHits() {
+        Query query = new Query("?query=a&sorting=-feature(foo)");
+        Result result = new Result(query);
+        result.hits().add(new Hit("id:ns:type::1", 1.0));
+        result.hits().add(new Hit("id:ns:type::2", 2.0));
+        var e = assertThrows(IllegalInputException.class, () -> result.hits().sort());
+        assertTrue(e.getMessage().contains("feature(foo)"), e.getMessage());
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/search/querytransform/test/SortingDegraderTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/test/SortingDegraderTestCase.java
@@ -188,4 +188,20 @@ public class SortingDegraderTestCase {
         return new IndexFacts(new IndexModel(test));
     }
 
+    @Test
+    void testNoDegradingWhenLeadingFeatureSorter() {
+        Query query = new Query("?ranking.sorting=" +
+                                java.net.URLEncoder.encode("-feature(a1)", java.nio.charset.StandardCharsets.UTF_8));
+        execute(query);
+        assertNull(query.getRanking().getMatchPhase().getAttribute());
+    }
+
+    @Test
+    void testDegradingWhenLeadingAttributeBeforeFeature() {
+        Query query = new Query("?ranking.sorting=" +
+                                java.net.URLEncoder.encode("-a1 -feature(foo)", java.nio.charset.StandardCharsets.UTF_8));
+        execute(query);
+        assertEquals("a1", query.getRanking().getMatchPhase().getAttribute());
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/schema/SchemaInfoTester.java
+++ b/container-search/src/test/java/com/yahoo/search/schema/SchemaInfoTester.java
@@ -71,6 +71,7 @@ public class SchemaInfoTester {
                                          .setSecondPhase(new SecondPhase.Builder().setRerankCount(201).build())
                                          .setKeepRankCount(401)
                                          .setMatchPhase(new MatchPhase.Builder().setMaxHits(801).build())
+                                         .addSortFeature("foo")
                                          .build())
                             .add(new RankProfile.Builder("withTotalParameters")
                                          .setSecondPhase(new SecondPhase.Builder().setTotalRerankCount(2001).build())
@@ -127,6 +128,7 @@ public class SchemaInfoTester {
         rankProfileWithParameters.rerankCount(201);
         rankProfileWithParameters.keepRankCount(401);
         rankProfileWithParameters.matchPhaseMaxHits(801);
+        rankProfileWithParameters.sortFeature("foo");
         schemaA.rankprofile(rankProfileWithParameters);
 
         var rankProfileWithTotalParameters = new SchemaInfoConfig.Schema.Rankprofile.Builder();

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -45,6 +45,7 @@ import com.yahoo.search.config.IndexInfoConfig.Indexinfo.Alias;
 import com.yahoo.search.config.IndexInfoConfig.Indexinfo.Command;
 import com.yahoo.search.query.QueryTree;
 import com.yahoo.search.query.Sorting.AttributeSorter;
+import com.yahoo.search.query.Sorting.FeatureSorter;
 import com.yahoo.search.query.Sorting.FieldOrder;
 import com.yahoo.search.query.Sorting.LowerCaseSorter;
 import com.yahoo.search.query.Sorting.Order;
@@ -1247,6 +1248,26 @@ public class YqlParserTestCase {
         String got = query.yqlRepresentation(true);
         // note: above code does not transfer selection or source, so we get '*' here:
         assertEquals("select * from sources * where price < 100 order by \"[rank]\" limit 5", got);
+    }
+
+    @Test
+    void testFeatureSortAnnotationRoundTrip() {
+        var newTree = parse("select foo from bar where title contains \"madonna\" order by {\"function\": \"feature\"}foo desc");
+        FieldOrder fieldOrder = parser.getSorting().fieldOrders().get(0);
+        assertEquals("foo", fieldOrder.getFieldName());
+        assertEquals(Order.DESCENDING, fieldOrder.getSortOrder());
+        assertEquals(FeatureSorter.class, fieldOrder.getSorter().getClass());
+        var query = new Query();
+        query.getModel().getQueryTree().setRoot(newTree.getRoot());
+        query.getRanking().setSorting(parser.getSorting());
+        String emitted = query.yqlRepresentation(true);
+        assertEquals("select * from sources * where title contains \"madonna\" order by [{\"function\": \"feature\"}]foo desc",
+                     emitted);
+        parse(emitted);
+        FieldOrder roundTripped = parser.getSorting().fieldOrders().get(0);
+        assertEquals("foo", roundTripped.getFieldName());
+        assertEquals(Order.DESCENDING, roundTripped.getSortOrder());
+        assertEquals(FeatureSorter.class, roundTripped.getSorter().getClass());
     }
 
     @Test

--- a/searchcore/src/tests/proton/matching/CMakeLists.txt
+++ b/searchcore/src/tests/proton/matching/CMakeLists.txt
@@ -31,6 +31,14 @@ vespa_add_executable(searchcore_sessionmanager_test_app TEST
     GTest::gtest
 )
 vespa_add_test(NAME searchcore_sessionmanager_test_app COMMAND searchcore_sessionmanager_test_app)
+vespa_add_executable(searchcore_sort_feature_store_test_app TEST
+    SOURCES
+    sort_feature_store_test.cpp
+    DEPENDS
+    searchcore_matching
+    GTest::gtest
+)
+vespa_add_test(NAME searchcore_sort_feature_store_test_app COMMAND searchcore_sort_feature_store_test_app)
 vespa_add_executable(searchcore_matching_stats_test_app TEST
     SOURCES
     matching_stats_test.cpp

--- a/searchcore/src/tests/proton/matching/handle_recorder/handle_recorder_test.cpp
+++ b/searchcore/src/tests/proton/matching/handle_recorder/handle_recorder_test.cpp
@@ -92,4 +92,23 @@ TEST(HandleRecorderTest, tagging_of_matchdata_works) {
     check_tagging(*md->resolveTermField(3), false, false, true);
 }
 
+TEST(HandleRecorderTest, registration_attempted_is_set_even_for_already_present_handles) {
+    HandleRecorder recorder(HandleMap({{3, NormalMask}}));
+    EXPECT_FALSE(recorder.registration_attempted());
+    {
+        HandleRecorder::Binder binder(recorder);
+        register_normal_handle(3);
+    }
+    EXPECT_TRUE(recorder.registration_attempted());
+    EXPECT_EQ(HandleMap({{3, NormalMask}}), recorder.get_handles());
+}
+
+TEST(HandleRecorderTest, registration_attempted_stays_false_without_add) {
+    HandleRecorder recorder(HandleMap({{3, NormalMask}}));
+    {
+        HandleRecorder::Binder binder(recorder);
+    }
+    EXPECT_FALSE(recorder.registration_attempted());
+}
+
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -61,7 +61,9 @@ using namespace search::queryeval;
 using namespace search;
 
 using search::attribute::test::MockAttributeContext;
+using search::fef::indexproperties::hitcollector::FirstPhaseRankScoreDropLimit;
 using search::fef::indexproperties::hitcollector::HeapSize;
+using search::fef::indexproperties::hitcollector::SecondPhaseRankScoreDropLimit;
 using search::index::schema::DataType;
 using storage::spi::Timestamp;
 using vespalib::FeatureSet;
@@ -277,6 +279,21 @@ struct MyWorld {
 
         // grouping
         sessionManager = std::make_shared<SessionManager>(100);
+    }
+
+    void setup_sort_feature_by_a1() {
+        config.add(indexproperties::sort::Feature::NAME, "attribute(a1)");
+        config.add(indexproperties::feature_rename::Rename::NAME, "attribute(a1)");
+        config.add(indexproperties::feature_rename::Rename::NAME, "by_a1");
+    }
+
+    void setup_sort_feature_bm25() {
+        config.add(indexproperties::sort::Feature::NAME, "bm25(f1)");
+        config.add(indexproperties::feature_rename::Rename::NAME, "bm25(f1)");
+        config.add(indexproperties::feature_rename::Rename::NAME, "title_bm25");
+        // FakeIndexSearchable reports average field length 0. Override it so the
+        // synthetic BM25 scores are finite and exercise feature ordering.
+        config.add("bm25(f1).averageFieldLength", "10");
     }
 
     void set_property(const std::string& name, const std::string& value) {
@@ -968,6 +985,202 @@ TEST_F(MatchingTest, require_that_sortspec_can_be_used_with_multi_threaded_match
     }
 }
 
+TEST_F(MatchingTest, require_that_feature_sort_orders_hits_without_activating_ranking) {
+    for (size_t threads = 1; threads <= 16; ++threads) {
+        MyWorld world(shared_state());
+        world.basicSetup();
+        world.setup_sort_feature_by_a1();
+        world.basicResults();
+        SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+        request->sortSpec = "-feature(by_a1)";
+        SearchReply::UP reply = world.performSearch(*request, threads);
+        ASSERT_EQ(9u, reply->hits.size());
+        EXPECT_EQ(9u, world.matchingStats.docsMatched());
+        EXPECT_EQ(0u, world.matchingStats.docsRanked());
+        EXPECT_EQ(0u, world.matchingStats.docsReRanked());
+        EXPECT_EQ(document::DocumentId("id:ns:searchdocument::900").getGlobalId(), reply->hits[0].gid);
+        EXPECT_EQ(zero_rank_value, reply->hits[0].metric);
+        EXPECT_EQ(document::DocumentId("id:ns:searchdocument::800").getGlobalId(), reply->hits[1].gid);
+        EXPECT_EQ(document::DocumentId("id:ns:searchdocument::100").getGlobalId(), reply->hits[8].gid);
+        EXPECT_FALSE(reply->sortIndex.empty());
+        EXPECT_FALSE(reply->sortData.empty());
+    }
+}
+
+TEST_F(MatchingTest, require_that_duplicate_feature_sort_clauses_share_an_ordinal) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setup_sort_feature_by_a1();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(by_a1) +feature(by_a1)";
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_EQ(9u, reply->hits.size());
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::900").getGlobalId(), reply->hits[0].gid);
+}
+
+TEST_F(MatchingTest, require_that_second_phase_is_not_run_for_unranked_feature_sort) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setupSecondPhaseRanking();
+    world.setup_sort_feature_by_a1();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(by_a1)";
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_EQ(9u, reply->hits.size());
+    EXPECT_EQ(0u, world.matchingStats.docsRanked());
+    EXPECT_EQ(0u, world.matchingStats.docsReRanked());
+}
+
+TEST_F(MatchingTest, require_that_second_phase_is_not_run_for_unranked_attribute_sort) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setupSecondPhaseRanking();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "+a1";
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_EQ(9u, reply->hits.size());
+    EXPECT_EQ(0u, world.matchingStats.docsRanked());
+    EXPECT_EQ(0u, world.matchingStats.docsReRanked());
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::100").getGlobalId(), reply->hits[0].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::200").getGlobalId(), reply->hits[1].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::300").getGlobalId(), reply->hits[2].gid);
+    EXPECT_EQ(zero_rank_value, reply->hits[0].metric);
+}
+
+TEST_F(MatchingTest, require_that_attribute_sort_with_rank_still_reranks) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setupSecondPhaseRanking();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "+a1 -[rank]";
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_EQ(9u, reply->hits.size());
+    EXPECT_EQ(9u, world.matchingStats.docsRanked());
+    EXPECT_EQ(3u, world.matchingStats.docsReRanked());
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::100").getGlobalId(), reply->hits[0].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::900").getGlobalId(), reply->hits[8].gid);
+}
+
+TEST_F(MatchingTest, require_that_unknown_sort_feature_fails_closed) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setup_sort_feature_by_a1();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(nope)";
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    EXPECT_TRUE(reply->hits.empty());
+    EXPECT_EQ(0u, reply->coverage.getCovered());
+    EXPECT_GT(reply->coverage.getActive(), 0u);
+}
+
+TEST_F(MatchingTest, require_that_zero_hit_feature_sort_returns_no_sort_data) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setup_sort_feature_by_a1();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(by_a1)";
+    request->maxhits = 0;
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    EXPECT_TRUE(reply->hits.empty());
+    EXPECT_EQ(9u, reply->totalHitCount);
+    EXPECT_EQ(9u, world.matchingStats.docsMatched());
+    EXPECT_EQ(0u, world.matchingStats.docsRanked());
+    EXPECT_TRUE(reply->sortIndex.empty());
+    EXPECT_TRUE(reply->sortData.empty());
+}
+
+TEST_F(MatchingTest, require_that_feature_sort_with_rank_keeps_ranking) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setup_sort_feature_by_a1();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(by_a1) -[rank]";
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_EQ(9u, reply->hits.size());
+    EXPECT_EQ(9u, world.matchingStats.docsRanked());
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::900").getGlobalId(), reply->hits[0].gid);
+    EXPECT_EQ(900.0, reply->hits[0].metric);
+}
+
+TEST_F(MatchingTest, require_that_first_phase_drop_skips_sort_rows) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setup_sort_feature_by_a1();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(by_a1) -[rank]";
+    request->propertiesMap.lookupCreate(MapNames::RANK).add(FirstPhaseRankScoreDropLimit::NAME, "550");
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_EQ(4u, reply->hits.size());
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::900").getGlobalId(), reply->hits[0].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::800").getGlobalId(), reply->hits[1].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::700").getGlobalId(), reply->hits[2].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::600").getGlobalId(), reply->hits[3].gid);
+}
+
+TEST_F(MatchingTest, require_that_second_phase_drop_skips_unused_sort_rows) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setupSecondPhaseRanking();
+    world.setup_sort_feature_by_a1();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(by_a1) -[rank]";
+    request->propertiesMap.lookupCreate(MapNames::RANK).add(SecondPhaseRankScoreDropLimit::NAME, "1500");
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_EQ(2u, reply->hits.size());
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::900").getGlobalId(), reply->hits[0].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::800").getGlobalId(), reply->hits[1].gid);
+}
+
+TEST_F(MatchingTest, require_that_mixed_feature_attribute_rank_sort_tuple_works) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setup_sort_feature_by_a1();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(by_a1) +a1 -[rank]";
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_EQ(9u, reply->hits.size());
+    EXPECT_EQ(9u, world.matchingStats.docsRanked());
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::900").getGlobalId(), reply->hits[0].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::800").getGlobalId(), reply->hits[1].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::100").getGlobalId(), reply->hits[8].gid);
+    EXPECT_EQ(900.0, reply->hits[0].metric);
+    EXPECT_FALSE(reply->sortData.empty());
+}
+
+TEST_F(MatchingTest, require_that_bm25_sort_feature_unpacks) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setup_sort_feature_bm25();
+    world.searchContext.idx(0).getFake().addResult("f1", "foo", FakeResult().doc(10).doc(20).doc(30));
+    FakeResult spread;
+    // Interleaved num_occs/field_length, not pos(): BM25 reads getNumOccs().
+    // Identical TFs (or skipped unpack) would not produce this descending order.
+    for (uint32_t i = 1; i <= 9; ++i) {
+        spread.doc(i * 100).num_occs(i).field_length(10);
+    }
+    world.searchContext.idx(0).getFake().addResult("f1", "spread", spread);
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(title_bm25)";
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_EQ(9u, reply->hits.size());
+    EXPECT_EQ(0u, world.matchingStats.docsRanked());
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::900").getGlobalId(), reply->hits[0].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::800").getGlobalId(), reply->hits[1].gid);
+    EXPECT_EQ(document::DocumentId("id:ns:searchdocument::100").getGlobalId(), reply->hits[8].gid);
+    EXPECT_EQ(zero_rank_value, reply->hits[0].metric);
+    EXPECT_FALSE(reply->sortData.empty());
+}
+
 ExpressionNode::UP createAttr() {
     return std::make_unique<AttributeNode>("a1");
 }
@@ -1003,6 +1216,45 @@ TEST_F(MatchingTest, require_that_grouping_is_performed_with_multi_threaded_matc
             EXPECT_EQ(gexpect.root().asString(), gresult.root().asString());
         }
         EXPECT_GT(world.matchingStats.groupingTimeAvg(), 0.0000001);
+    }
+}
+
+TEST_F(MatchingTest, require_that_zero_hit_grouping_still_groups_with_feature_sort_spec) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    world.setup_sort_feature_by_a1();
+    world.basicResults();
+    SearchRequest::SP request = MyWorld::createSimpleRequest("f1", "spread");
+    request->sortSpec = "-feature(by_a1)";
+    request->maxhits = 0;
+    {
+        vespalib::nbostream     buf;
+        vespalib::NBOSerializer os(buf);
+        uint32_t                n = 1;
+        os << n;
+        Grouping grequest;
+        grequest.setRoot(Group().addResult(SumAggregationResult().setExpression(createAttr())));
+        grequest.serialize(os);
+        request->groupSpec.assign(buf.data(), buf.data() + buf.size());
+    }
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    EXPECT_TRUE(reply->hits.empty());
+    EXPECT_EQ(9u, reply->totalHitCount);
+    EXPECT_EQ(9u, world.matchingStats.docsMatched());
+    EXPECT_EQ(0u, world.matchingStats.docsRanked());
+    EXPECT_GT(reply->coverage.getCovered(), 0u);
+    {
+        vespalib::nbostream     buf(&reply->groupResult[0], reply->groupResult.size());
+        vespalib::NBOSerializer is(buf);
+        uint32_t                n;
+        is >> n;
+        EXPECT_EQ(1u, n);
+        Grouping gresult;
+        gresult.deserialize(is);
+        Grouping gexpect;
+        gexpect.setRoot(Group().addResult(
+            SumAggregationResult().setExpression(createAttr()).setResult(Int64ResultNode(4500))));
+        EXPECT_EQ(gexpect.root().asString(), gresult.root().asString());
     }
 }
 

--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -1253,7 +1253,7 @@ TEST_F(MatchingTest, require_that_zero_hit_grouping_still_groups_with_feature_so
         gresult.deserialize(is);
         Grouping gexpect;
         gexpect.setRoot(Group().addResult(
-            SumAggregationResult().setExpression(createAttr()).setResult(Int64ResultNode(4500))));
+            SumAggregationResult().setExpression(createAttr()).resultForUnitTest(Int64ResultNode(4500))));
         EXPECT_EQ(gexpect.root().asString(), gresult.root().asString());
     }
 }

--- a/searchcore/src/tests/proton/matching/sort_feature_store_test.cpp
+++ b/searchcore/src/tests/proton/matching/sort_feature_store_test.cpp
@@ -9,7 +9,7 @@
 
 using proton::matching::SortFeatureStore;
 
-TEST(SortFeatureStoreTest, records_and_consumes_monotonic_rows_in_order) {
+TEST(SortFeatureStoreTest, rows_recorded_in_docid_order_are_read_in_order) {
     SortFeatureStore store({"foo", "bar"});
     EXPECT_EQ(0u, store.ordinal("foo"));
     EXPECT_EQ(1u, store.ordinal("bar"));
@@ -21,9 +21,9 @@ TEST(SortFeatureStoreTest, records_and_consumes_monotonic_rows_in_order) {
     store.record(10, r0);
     store.record(20, r1);
     store.record(30, r2);
-    EXPECT_TRUE(store.monotonic());
     EXPECT_EQ(3u, store.num_rows());
 
+    store.ensure_sorted_for_read();
     store.seek(10);
     EXPECT_EQ(1.5, store.get(0));
     EXPECT_EQ(2.5, store.get(1));
@@ -35,7 +35,7 @@ TEST(SortFeatureStoreTest, records_and_consumes_monotonic_rows_in_order) {
     EXPECT_EQ(5.5, store.get(0));
 }
 
-TEST(SortFeatureStoreTest, sequential_consume_skips_unrequested_rows) {
+TEST(SortFeatureStoreTest, seek_skips_unrequested_rows) {
     SortFeatureStore store({"foo"});
     const double     a[] = {1.0};
     const double     b[] = {2.0};
@@ -43,13 +43,14 @@ TEST(SortFeatureStoreTest, sequential_consume_skips_unrequested_rows) {
     store.record(10, a);
     store.record(20, b);
     store.record(30, c);
+    store.ensure_sorted_for_read();
     store.seek(10);
     EXPECT_EQ(1.0, store.get(0));
     store.seek(30);
     EXPECT_EQ(3.0, store.get(0));
 }
 
-TEST(SortFeatureStoreTest, permutation_is_built_only_for_non_monotonic_rows) {
+TEST(SortFeatureStoreTest, out_of_order_rows_are_read_in_docid_order) {
     SortFeatureStore store({"foo"});
     const double     a[] = {1.0};
     const double     b[] = {2.0};
@@ -57,8 +58,8 @@ TEST(SortFeatureStoreTest, permutation_is_built_only_for_non_monotonic_rows) {
     store.record(30, a);
     store.record(10, b);
     store.record(20, c);
-    EXPECT_FALSE(store.monotonic());
-    store.finalize_permutation();
+    store.ensure_sorted_for_read();
+    store.ensure_sorted_for_read(); // Preparation is idempotent.
     store.seek(10);
     EXPECT_EQ(2.0, store.get(0));
     store.seek(20);
@@ -73,6 +74,7 @@ TEST(SortFeatureStoreTest, sanitizes_non_finite_values_and_consumed_clears_stora
     const double     inf[] = {std::numeric_limits<double>::infinity()};
     store.record(1, nan);
     store.record(2, inf);
+    store.ensure_sorted_for_read();
     store.seek(1);
     EXPECT_EQ(-HUGE_VAL, store.get(0));
     store.seek(2);
@@ -91,6 +93,7 @@ TEST(SortFeatureStoreTest, grows_across_chunk_boundaries) {
         store.record(i + 1, value);
     }
     EXPECT_EQ(n, store.num_rows());
+    store.ensure_sorted_for_read();
     store.seek(1);
     EXPECT_EQ(0.0, store.get(0));
     store.seek(n);

--- a/searchcore/src/tests/proton/matching/sort_feature_store_test.cpp
+++ b/searchcore/src/tests/proton/matching/sort_feature_store_test.cpp
@@ -1,0 +1,100 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchcore/proton/matching/sort_feature_store.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+using proton::matching::SortFeatureStore;
+
+TEST(SortFeatureStoreTest, records_and_consumes_monotonic_rows_in_order) {
+    SortFeatureStore store({"foo", "bar"});
+    EXPECT_EQ(0u, store.ordinal("foo"));
+    EXPECT_EQ(1u, store.ordinal("bar"));
+    EXPECT_EQ(INumericSortValueProvider::invalid_ordinal, store.ordinal("missing"));
+
+    const double r0[] = {1.5, 2.5};
+    const double r1[] = {3.5, 4.5};
+    const double r2[] = {5.5, 6.5};
+    store.record(10, r0);
+    store.record(20, r1);
+    store.record(30, r2);
+    EXPECT_TRUE(store.monotonic());
+    EXPECT_EQ(3u, store.num_rows());
+
+    store.seek(10);
+    EXPECT_EQ(1.5, store.get(0));
+    EXPECT_EQ(2.5, store.get(1));
+    EXPECT_EQ(1.5, store.get(0));
+    store.seek(20);
+    EXPECT_EQ(3.5, store.get(0));
+    EXPECT_EQ(4.5, store.get(1));
+    store.seek(30);
+    EXPECT_EQ(5.5, store.get(0));
+}
+
+TEST(SortFeatureStoreTest, sequential_consume_skips_unrequested_rows) {
+    SortFeatureStore store({"foo"});
+    const double     a[] = {1.0};
+    const double     b[] = {2.0};
+    const double     c[] = {3.0};
+    store.record(10, a);
+    store.record(20, b);
+    store.record(30, c);
+    store.seek(10);
+    EXPECT_EQ(1.0, store.get(0));
+    store.seek(30);
+    EXPECT_EQ(3.0, store.get(0));
+}
+
+TEST(SortFeatureStoreTest, permutation_is_built_only_for_non_monotonic_rows) {
+    SortFeatureStore store({"foo"});
+    const double     a[] = {1.0};
+    const double     b[] = {2.0};
+    const double     c[] = {3.0};
+    store.record(30, a);
+    store.record(10, b);
+    store.record(20, c);
+    EXPECT_FALSE(store.monotonic());
+    store.finalize_permutation();
+    store.seek(10);
+    EXPECT_EQ(2.0, store.get(0));
+    store.seek(20);
+    EXPECT_EQ(3.0, store.get(0));
+    store.seek(30);
+    EXPECT_EQ(1.0, store.get(0));
+}
+
+TEST(SortFeatureStoreTest, sanitizes_non_finite_values_and_consumed_clears_storage) {
+    SortFeatureStore store({"foo"});
+    const double     nan[] = {std::numeric_limits<double>::quiet_NaN()};
+    const double     inf[] = {std::numeric_limits<double>::infinity()};
+    store.record(1, nan);
+    store.record(2, inf);
+    store.seek(1);
+    EXPECT_EQ(-HUGE_VAL, store.get(0));
+    store.seek(2);
+    EXPECT_EQ(-HUGE_VAL, store.get(0));
+    store.consumed();
+    EXPECT_EQ(0u, store.num_rows());
+}
+
+TEST(SortFeatureStoreTest, grows_across_chunk_boundaries) {
+    SortFeatureStore    store({"foo"});
+    std::vector<double> value(1);
+    // Private chunk size is 1024; one extra chunk of 3 rows.
+    uint32_t n = 1024 + 3;
+    for (uint32_t i = 0; i < n; ++i) {
+        value[0] = i;
+        store.record(i + 1, value);
+    }
+    EXPECT_EQ(n, store.num_rows());
+    store.seek(1);
+    EXPECT_EQ(0.0, store.get(0));
+    store.seek(n);
+    EXPECT_EQ(double(n - 1), store.get(0));
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchcore/src/vespa/searchcore/proton/matching/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/matching/CMakeLists.txt
@@ -36,6 +36,7 @@ vespa_add_library(searchcore_matching STATIC
     search_session.cpp
     session_manager_explorer.cpp
     sessionmanager.cpp
+    sort_feature_store.cpp
     tag_needed_handles.cpp
     termdataextractor.cpp
     termdatafromnode.cpp

--- a/searchcore/src/vespa/searchcore/proton/matching/handlerecorder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/handlerecorder.cpp
@@ -24,10 +24,11 @@ __thread HandleRecorder* _T_recorder TLS_LINKAGE = nullptr;
 __thread bool                        _T_assert_all_handles_are_registered = false;
 } // namespace
 
-HandleRecorder::HandleRecorder() : _handles() {
+HandleRecorder::HandleRecorder() : _handles(), _registration_attempted(false) {
 }
 
-HandleRecorder::HandleRecorder(const HandleRecorder::HandleMap& initial_handles) : _handles(initial_handles) {
+HandleRecorder::HandleRecorder(const HandleRecorder::HandleMap& initial_handles)
+    : _handles(initial_handles), _registration_attempted(false) {
 }
 
 namespace {
@@ -91,6 +92,7 @@ void HandleRecorder::register_handle(TermFieldHandle handle, MatchDataDetails re
 void HandleRecorder::add(TermFieldHandle handle, MatchDataDetails requested_details)
 
 {
+    _registration_attempted = true;
     if (requested_details == MatchDataDetails::Normal || requested_details == MatchDataDetails::Interleaved) {
         _handles[handle] =
             static_cast<MatchDataDetails>(static_cast<int>(_handles[handle]) | static_cast<int>(requested_details));

--- a/searchcore/src/vespa/searchcore/proton/matching/handlerecorder.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/handlerecorder.h
@@ -40,6 +40,7 @@ public:
     ~HandleRecorder();
     const HandleMap& get_handles() const { return _handles; }
     HandleMap steal_handles() && { return std::move(_handles); }
+    bool registration_attempted() const noexcept { return _registration_attempted; }
     static void register_handle(search::fef::TermFieldHandle handle, search::fef::MatchDataDetails requested_details);
     std::string to_string() const;
     void tag_match_data(search::fef::MatchData& match_data);
@@ -47,6 +48,7 @@ public:
 private:
     void add(search::fef::TermFieldHandle handle, search::fef::MatchDataDetails requested_details);
     HandleMap _handles;
+    bool      _registration_attempted;
 };
 
 } // namespace proton::matching

--- a/searchcore/src/vespa/searchcore/proton/matching/match_thread.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_thread.cpp
@@ -5,6 +5,7 @@
 #include "document_scorer.h"
 #include "match_tools.h"
 #include "partial_result.h"
+#include "sort_feature_store.h"
 
 #include <vespa/searchcore/grouping/groupingcontext.h>
 #include <vespa/searchcore/grouping/groupingmanager.h>
@@ -19,6 +20,7 @@
 #include <vespa/vespalib/data/slime/inserter.h>
 
 #include <limits>
+#include <optional>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.matching.match_thread");
@@ -95,18 +97,24 @@ void fillPartialResult(ResultProcessor::Context& context, size_t totalHits, size
 //-----------------------------------------------------------------------------
 
 MatchThread::Context::Context(std::optional<double> first_phase_rank_score_drop_limit, MatchTools& tools,
-                              HitCollector& hits, uint32_t num_threads)
+                              HitCollector& hits, uint32_t num_threads, std::optional<LazyValue> score_feature,
+                              SortFeatureStore* sort_store, std::span<const LazyValue> sort_seeds,
+                              bool sort_needs_unpack)
     : matches(0),
       _matches_limit(tools.match_limiter().sample_hits_per_thread(num_threads)),
-      _score_feature(get_score_feature(tools.rank_program())),
+      _score_feature(std::move(score_feature)),
       _first_phase_rank_score_drop_limit(first_phase_rank_score_drop_limit.value_or(0.0 /* ignored */)),
       _hits(hits),
       _doom(tools.getDoom()),
+      _sort_store(sort_store),
+      _sort_seeds(sort_seeds),
+      _sort_needs_unpack(sort_needs_unpack),
+      _sort_scratch(sort_store ? sort_store->num_features() : 0),
       dropped() {
 }
 
-template <MatchThread::RankDropLimitE use_rank_drop_limit> void MatchThread::Context::rankHit(uint32_t docId) {
-    double score = _score_feature.as_number(docId);
+template <MatchThread::RankDropLimitE use_rank_drop_limit> bool MatchThread::Context::rankHit(uint32_t docId) {
+    double score = (*_score_feature).as_number(docId);
     // convert NaN and Inf scores to -Inf
     if (__builtin_expect(std::isnan(score) || std::isinf(score), false)) {
         score = -HUGE_VAL;
@@ -114,12 +122,22 @@ template <MatchThread::RankDropLimitE use_rank_drop_limit> void MatchThread::Con
     if (use_rank_drop_limit != RankDropLimitE::no) {
         if (__builtin_expect(score > _first_phase_rank_score_drop_limit, true)) {
             _hits.addHit(docId, score);
+            return true;
         } else if (use_rank_drop_limit == RankDropLimitE::track) {
             dropped.emplace_back(docId);
         }
-    } else {
-        _hits.addHit(docId, score);
+        return false;
     }
+    _hits.addHit(docId, score);
+    return true;
+}
+
+void MatchThread::Context::record_sort(uint32_t docId) {
+    // Sort features are captured during matching and are not recomputed during result sorting.
+    for (uint32_t i = 0; i < _sort_scratch.size(); ++i) {
+        _sort_scratch[i] = _sort_seeds[i].as_number(docId);
+    }
+    _sort_store->record(docId, _sort_scratch);
 }
 
 //-----------------------------------------------------------------------------
@@ -169,16 +187,26 @@ bool MatchThread::try_share(DocidRange& docid_range, uint32_t next_docid) {
 }
 
 template <typename Strategy, bool do_rank, bool do_limit, bool do_share_work,
-          MatchThread::RankDropLimitE use_rank_drop_limit>
+          MatchThread::RankDropLimitE use_rank_drop_limit, bool do_sort>
 uint32_t MatchThread::inner_match_loop(Context& context, MatchTools& tools, DocidRange& docid_range) {
     SearchIterator* search = &tools.search();
     search->initRange(docid_range.begin, docid_range.end);
-    uint32_t docId = search->seekFirst(docid_range.begin);
+    uint32_t   docId = search->seekFirst(docid_range.begin);
+    const bool sort_needs_unpack = do_sort && context.sort_needs_unpack();
     while ((docId < docid_range.end) && !context.atSoftDoom()) {
         if (do_rank) {
             search->unpack(docId);
-            context.rankHit<use_rank_drop_limit>(docId);
+            [[maybe_unused]] bool accepted = context.rankHit<use_rank_drop_limit>(docId);
+            if (do_sort && accepted) {
+                context.record_sort(docId);
+            }
         } else {
+            if (sort_needs_unpack) {
+                search->unpack(docId);
+            }
+            if (do_sort) {
+                context.record_sort(docId);
+            }
             context.addHit(docId);
         }
         context.matches++;
@@ -198,18 +226,30 @@ uint32_t MatchThread::inner_match_loop(Context& context, MatchTools& tools, Doci
 template <typename Strategy, bool do_rank, bool do_limit, bool do_share_work,
           MatchThread::RankDropLimitE use_rank_drop_limit>
 void MatchThread::match_loop(MatchTools& tools, HitCollector& hits) {
-    bool               softDoomed = false;
-    uint32_t           docsCovered = 0;
-    vespalib::duration overtime(vespalib::duration::zero());
-    Context            context(matchParams.first_phase_rank_score_drop_limit, tools, hits, num_threads);
+    bool                     softDoomed = false;
+    uint32_t                 docsCovered = 0;
+    vespalib::duration       overtime(vespalib::duration::zero());
+    std::optional<LazyValue> score_feature;
+    if constexpr (do_rank) {
+        score_feature = get_score_feature(tools.rank_program());
+    }
+    Context context(matchParams.first_phase_rank_score_drop_limit, tools, hits, num_threads, std::move(score_feature),
+                    tools.sort_store(), tools.sort_seeds(), tools.sort_needs_unpack());
     for (DocidRange docid_range = scheduler.first_range(thread_id); !docid_range.empty();
          docid_range = scheduler.next_range(thread_id))
     {
         // Due to some schedulers communicating across threads, it is vital that all complete this
         // loop. Do not break out.
         if (!softDoomed) {
-            uint32_t lastCovered = inner_match_loop<Strategy, do_rank, do_limit, do_share_work, use_rank_drop_limit>(
-                context, tools, docid_range);
+            uint32_t lastCovered;
+            if (tools.sort_store() == nullptr) {
+                lastCovered =
+                    inner_match_loop<Strategy, do_rank, do_limit, do_share_work, use_rank_drop_limit, false>(
+                        context, tools, docid_range);
+            } else {
+                lastCovered = inner_match_loop<Strategy, do_rank, do_limit, do_share_work, use_rank_drop_limit, true>(
+                    context, tools, docid_range);
+            }
             softDoomed = (lastCovered < docid_range.end);
             if (softDoomed) {
                 overtime = -context.timeLeft();
@@ -314,12 +354,17 @@ void MatchThread::secondPhase(MatchTools& tools, HitCollector& hits) {
     hits.setReRankedHits(std::move(kept_hits));
     hits.setRanges(ranges);
     if (auto onReRankTask = matchToolsFactory.createOnSecondPhaseTask()) {
+        // Submit the mutation asynchronously; result sorting does not wait for it.
         onReRankTask->run(hits.getReRankedHits());
     }
 }
 
 search::ResultSet::UP MatchThread::findMatches(MatchTools& tools) {
-    tools.setup_first_phase(first_phase_profiler.get());
+    if (tools.has_sort_selection()) {
+        tools.setup_first_phase_and_sort(first_phase_profiler.get(), match_with_ranking);
+    } else {
+        tools.setup_first_phase(first_phase_profiler.get());
+    }
     if (isFirstThread()) {
         LOG(spam, "SearchIterator: %s", tools.search().asString().c_str());
     }
@@ -345,11 +390,13 @@ search::ResultSet::UP MatchThread::findMatches(MatchTools& tools) {
      * If not you will have deadlock.
      */
     match_loop_helper(tools, hits);
-    if (tools.has_second_phase_rank()) {
+    tools.release_sort_programs(); // sort RankPrograms gone before second phase
+    const bool run_second_phase = match_with_ranking && tools.has_second_phase_rank();
+    if (run_second_phase) {
         secondPhase(tools, hits);
     }
     trace->addEvent(4, "Create result set");
-    if (tools.has_second_phase_rank() && matchParams.second_phase_rank_score_drop_limit.has_value()) {
+    if (run_second_phase && matchParams.second_phase_rank_score_drop_limit.has_value()) {
         return get_matches_after_second_phase_rank_score_drop(hits);
     } else {
         return hits.getResultSet();
@@ -481,6 +528,16 @@ void MatchThread::run() {
             matchTools->getDoom(), scheduler.total_size(thread_id), result->getNumHits(),
             resultContext->sort->hasSortData(), bool(resultContext->grouping)));
         get_token_timer.done();
+        if (SortFeatureStore* store = matchTools->sort_store()) {
+            if (matchTools->getDoom().hard_doom()) {
+                store->consumed();
+            } else {
+                store->finalize_permutation();
+                if (resultContext->sort->hasSortData()) {
+                    resultContext->sort->sortSpec.bind_numeric_provider(*store);
+                }
+            }
+        }
         trace->addEvent(5, "Start result processing");
         processResult(matchTools->getDoom(), std::move(result), *resultContext);
     }

--- a/searchcore/src/vespa/searchcore/proton/matching/match_thread.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_thread.cpp
@@ -532,7 +532,7 @@ void MatchThread::run() {
             if (matchTools->getDoom().hard_doom()) {
                 store->consumed();
             } else {
-                store->finalize_permutation();
+                store->ensure_sorted_for_read();
                 if (resultContext->sort->hasSortData()) {
                     resultContext->sort->sortSpec.bind_numeric_provider(*store);
                 }

--- a/searchcore/src/vespa/searchcore/proton/matching/match_thread.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_thread.h
@@ -17,6 +17,9 @@
 #include <vespa/vespalib/util/execution_profiler.h>
 #include <vespa/vespalib/util/runnable.h>
 
+#include <optional>
+#include <span>
+
 namespace search::engine {
 class Trace;
 class RelativeTime;
@@ -34,6 +37,7 @@ namespace proton::matching {
 
 class MatchTools;
 class MatchToolsFactory;
+class SortFeatureStore;
 
 /**
  * Runs a single match thread and keeps track of local state.
@@ -78,9 +82,12 @@ private:
     class Context {
     public:
         Context(std::optional<double> first_phase_rank_score_drop_limit, MatchTools& tools, HitCollector& hits,
-                uint32_t num_threads) __attribute__((noinline));
-        template <RankDropLimitE use_rank_drop_limit> void rankHit(uint32_t docId);
+                uint32_t num_threads, std::optional<LazyValue> score_feature, SortFeatureStore* sort_store,
+                std::span<const LazyValue> sort_seeds, bool sort_needs_unpack) __attribute__((noinline));
+        template <RankDropLimitE use_rank_drop_limit> bool rankHit(uint32_t docId);
         void addHit(uint32_t docId) { _hits.addHit(docId, search::zero_rank_value); }
+        void record_sort(uint32_t docId);
+        bool sort_needs_unpack() const noexcept { return _sort_needs_unpack; }
         bool isBelowLimit() const { return matches < _matches_limit; }
         bool isAtLimit() const { return matches == _matches_limit; }
         bool atSoftDoom() const { return _doom.soft_doom(); }
@@ -88,11 +95,15 @@ private:
         uint32_t matches;
 
     private:
-        uint32_t      _matches_limit;
-        LazyValue     _score_feature;
-        double        _first_phase_rank_score_drop_limit;
-        HitCollector& _hits;
-        const Doom    _doom;
+        uint32_t                   _matches_limit;
+        std::optional<LazyValue>   _score_feature;
+        double                     _first_phase_rank_score_drop_limit;
+        HitCollector&              _hits;
+        const Doom                 _doom;
+        SortFeatureStore*          _sort_store;
+        std::span<const LazyValue> _sort_seeds;
+        bool                       _sort_needs_unpack;
+        std::vector<double>        _sort_scratch;
 
     public:
         std::vector<uint32_t> dropped;
@@ -105,7 +116,8 @@ private:
     bool any_idle() const { return (idle_observer.get() > 0); }
     bool try_share(DocidRange& docid_range, uint32_t next_docid) __attribute__((noinline));
 
-    template <typename Strategy, bool do_rank, bool do_limit, bool do_share_work, RankDropLimitE use_rank_drop_limit>
+    template <typename Strategy, bool do_rank, bool do_limit, bool do_share_work, RankDropLimitE use_rank_drop_limit,
+              bool do_sort>
     uint32_t inner_match_loop(Context& context, MatchTools& tools, DocidRange& docid_range) __attribute__((noinline));
 
     template <typename Strategy, bool do_rank, bool do_limit, bool do_share_work, RankDropLimitE use_rank_drop_limit>

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -4,6 +4,7 @@
 
 #include "querynodes.h"
 #include "rangequerylocator.h"
+#include "sort_feature_store.h"
 #include "tag_needed_handles.h"
 
 #include <vespa/searchcorespi/index/indexsearchable.h>
@@ -11,7 +12,9 @@
 #include <vespa/searchlib/attribute/diversity.h>
 #include <vespa/searchlib/engine/trace.h>
 #include <vespa/searchlib/features/first_phase_rank_lookup.h>
+#include <vespa/searchlib/fef/feature_resolver.h>
 #include <vespa/searchlib/fef/indexproperties.h>
+#include <vespa/searchlib/fef/rank_program.h>
 #include <vespa/searchlib/fef/ranksetup.h>
 #include <vespa/searchlib/queryeval/create_blueprint_params.h>
 #include <vespa/searchlib/queryeval/flow.h>
@@ -19,6 +22,9 @@
 #include <vespa/vespalib/util/execution_profiler.h>
 #include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/thread_bundle.h>
+
+#include <cassert>
+#include <cstdlib>
 
 using search::SerializedQueryTree;
 using search::attribute::BasicType;
@@ -102,7 +108,7 @@ void MatchTools::setup(std::unique_ptr<RankProgram> rank_program, ExecutionProfi
 MatchTools::MatchTools(QueryLimiter& queryLimiter, const vespalib::Doom& doom, const Query& query,
                        MaybeMatchPhaseLimiter& match_limiter_in, const QueryEnvironment& queryEnv,
                        const MatchDataLayout& mdl, const RankSetup& rankSetup, const Properties& featureOverrides,
-                       const HandleRecorder::HandleMap& needed_handles)
+                       const HandleRecorder::HandleMap& needed_handles, std::vector<std::string> sort_public_names)
     : _queryLimiter(queryLimiter),
       _doom(doom),
       _query(query),
@@ -115,7 +121,12 @@ MatchTools::MatchTools(QueryLimiter& queryLimiter, const vespalib::Doom& doom, c
       _search(),
       _used_handles(),
       _needed_handles(needed_handles),
-      _search_has_changed(false) {
+      _sort_public_names(std::move(sort_public_names)),
+      _sort_programs(),
+      _sort_seeds(),
+      _sort_store(),
+      _search_has_changed(false),
+      _sort_needs_unpack(false) {
 }
 
 MatchTools::~MatchTools() = default;
@@ -127,6 +138,45 @@ bool MatchTools::has_second_phase_rank() const {
 void MatchTools::setup_first_phase(ExecutionProfiler* profiler) {
     setup(_rankSetup.create_first_phase_program(), profiler,
           TermwiseLimit::lookup(_queryEnv.getProperties(), _rankSetup.get_termwise_limit()));
+}
+
+void MatchTools::setup_first_phase_and_sort(ExecutionProfiler* first_phase_profiler, bool match_with_ranking) {
+    _sort_programs.clear();
+    _sort_seeds.clear();
+    _sort_store.reset();
+    _sort_needs_unpack = false;
+    _sort_programs.reserve(_sort_public_names.size());
+    _sort_seeds.reserve(_sort_public_names.size());
+    HandleRecorder recorder(_needed_handles);
+    {
+        HandleRecorder::Binder bind(recorder);
+        for (const auto& public_name : _sort_public_names) {
+            auto program = _rankSetup.create_sort_program(public_name);
+            program->setup(*_match_data, _queryEnv, _featureOverrides, nullptr);
+            search::fef::FeatureResolver seeds(program->get_seeds());
+            assert(seeds.num_features() == 1u);
+            _sort_seeds.push_back(seeds.resolve(0));
+            _sort_programs.push_back(std::move(program));
+        }
+        // Re-registering an existing handle still means sort evaluation needs unpack.
+        _sort_needs_unpack = recorder.registration_attempted();
+        if (match_with_ranking) {
+            _rank_program = _rankSetup.create_first_phase_program();
+            _rank_program->setup(*_match_data, _queryEnv, _featureOverrides, first_phase_profiler);
+        }
+    }
+    recorder.tag_match_data(*_match_data);
+    _match_data->set_termwise_limit(
+        TermwiseLimit::lookup(_queryEnv.getProperties(), _rankSetup.get_termwise_limit()));
+    _search = _query.createSearch(*_match_data);
+    _used_handles = std::move(recorder).steal_handles();
+    _search_has_changed = false;
+    _sort_store = std::make_unique<SortFeatureStore>(_sort_public_names);
+}
+
+void MatchTools::release_sort_programs() {
+    _sort_seeds.clear();
+    _sort_programs.clear();
 }
 
 void MatchTools::setup_second_phase(ExecutionProfiler* profiler) {
@@ -171,7 +221,8 @@ MatchToolsFactory::MatchToolsFactory(
       _valid(false),
       _object_store(nullptr),
       _metaStore(metaStore),
-      _needed_handles() {
+      _needed_handles(),
+      _sort_public_names() {
     if (doom.soft_doom()) {
         return;
     }
@@ -253,7 +304,13 @@ MatchToolsFactory::~MatchToolsFactory() = default;
 MatchTools::UP MatchToolsFactory::createMatchTools() const {
     assert(_valid);
     return std::make_unique<MatchTools>(_queryLimiter, _requestContext.getDoom(), _query, *_match_limiter, _queryEnv,
-                                        _mdl, _rankSetup, _featureOverrides, _needed_handles);
+                                        _mdl, _rankSetup, _featureOverrides, _needed_handles, _sort_public_names);
+}
+
+void MatchToolsFactory::prepare_and_install_sort_features(const std::vector<std::string>& public_names) {
+    assert(_object_store != nullptr);
+    _rankSetup.prepare_sort_shared_state(_queryEnv, *_object_store, public_names);
+    _sort_public_names = public_names;
 }
 
 std::unique_ptr<IDiversifier> MatchToolsFactory::createDiversifier(uint32_t want_hits) const {

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
@@ -17,10 +17,15 @@
 #include <vespa/searchlib/common/idocumentmetastore.h>
 #include <vespa/searchlib/common/serialized_query_tree.h>
 #include <vespa/searchlib/common/stringmap.h>
+#include <vespa/searchlib/fef/featureexecutor.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/queryeval/idiversifier.h>
 #include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/vespalib/util/doom.h>
+
+#include <span>
+#include <string>
+#include <vector>
 
 namespace vespalib {
 class ExecutionProfiler;
@@ -43,6 +48,8 @@ class RankSetup;
 
 namespace proton::matching {
 
+class SortFeatureStore;
+
 class MatchTools {
 private:
     using IRequestContext = search::queryeval::IRequestContext;
@@ -52,20 +59,26 @@ private:
     using Properties = search::fef::Properties;
     using RankProgram = search::fef::RankProgram;
     using RankSetup = search::fef::RankSetup;
+    using LazyValue = search::fef::LazyValue;
     using ExecutionProfiler = vespalib::ExecutionProfiler;
-    QueryLimiter&                    _queryLimiter;
-    const vespalib::Doom             _doom;
-    const Query&                     _query;
-    MaybeMatchPhaseLimiter&          _match_limiter;
-    const QueryEnvironment&          _queryEnv;
-    const RankSetup&                 _rankSetup;
-    const Properties&                _featureOverrides;
-    MatchData::UP                    _match_data;
-    std::unique_ptr<RankProgram>     _rank_program;
-    std::unique_ptr<SearchIterator>  _search;
-    HandleRecorder::HandleMap        _used_handles;
-    const HandleRecorder::HandleMap& _needed_handles;
-    bool                             _search_has_changed;
+    QueryLimiter&                             _queryLimiter;
+    const vespalib::Doom                      _doom;
+    const Query&                              _query;
+    MaybeMatchPhaseLimiter&                   _match_limiter;
+    const QueryEnvironment&                   _queryEnv;
+    const RankSetup&                          _rankSetup;
+    const Properties&                         _featureOverrides;
+    MatchData::UP                             _match_data;
+    std::unique_ptr<RankProgram>              _rank_program;
+    std::unique_ptr<SearchIterator>           _search;
+    HandleRecorder::HandleMap                 _used_handles;
+    const HandleRecorder::HandleMap&          _needed_handles;
+    std::vector<std::string>                  _sort_public_names;
+    std::vector<std::unique_ptr<RankProgram>> _sort_programs;
+    std::vector<LazyValue>                    _sort_seeds;
+    std::unique_ptr<SortFeatureStore>         _sort_store;
+    bool                                      _search_has_changed;
+    bool                                      _sort_needs_unpack;
     void setup(std::unique_ptr<RankProgram>, ExecutionProfiler* profiler, double termwise_limit = 1.0);
 
 public:
@@ -75,7 +88,7 @@ public:
     MatchTools(QueryLimiter& queryLimiter, const vespalib::Doom& doom, const Query& query,
                MaybeMatchPhaseLimiter& match_limiter_in, const QueryEnvironment& queryEnv, const MatchDataLayout& mdl,
                const RankSetup& rankSetup, const Properties& featureOverrides,
-               const HandleRecorder::HandleMap& needed_handles);
+               const HandleRecorder::HandleMap& needed_handles, std::vector<std::string> sort_public_names);
     ~MatchTools();
     const vespalib::Doom& getDoom() const { return _doom; }
     QueryLimiter& getQueryLimiter() { return _queryLimiter; }
@@ -88,10 +101,16 @@ public:
     void give_back_search(std::unique_ptr<SearchIterator> search_in) { _search = std::move(search_in); }
     void tag_search_as_changed() { _search_has_changed = true; }
     void setup_first_phase(ExecutionProfiler* profiler);
+    void setup_first_phase_and_sort(ExecutionProfiler* first_phase_profiler, bool match_with_ranking);
     void setup_second_phase(ExecutionProfiler* profiler);
     void setup_match_features();
     void setup_summary();
     void setup_dump();
+    void release_sort_programs();
+    bool has_sort_selection() const noexcept { return !_sort_public_names.empty(); }
+    SortFeatureStore* sort_store() const noexcept { return _sort_store.get(); }
+    std::span<const LazyValue> sort_seeds() const noexcept { return _sort_seeds; }
+    bool sort_needs_unpack() const noexcept { return _sort_needs_unpack; }
 
     // explicitly disallow re-using the search iterator tree (for now)
     //
@@ -146,6 +165,7 @@ private:
     IObjectStore*                      _object_store;
     const search::IDocumentMetaStore&  _metaStore;
     HandleRecorder::HandleMap          _needed_handles;
+    std::vector<std::string>           _sort_public_names;
 
     std::unique_ptr<AttributeOperationTask> createTask(std::string_view attribute, std::string_view operation) const;
 
@@ -167,6 +187,7 @@ public:
     bool valid() const { return _valid; }
     const MaybeMatchPhaseLimiter& match_limiter() const { return *_match_limiter; }
     MatchTools::UP createMatchTools() const;
+    void prepare_and_install_sort_features(const std::vector<std::string>& public_names);
     bool should_diversify() const { return _diversityParams.enabled(); }
     std::unique_ptr<IDiversifier> createDiversifier(uint32_t heapSize) const;
     search::queryeval::Blueprint::HitEstimate estimate() const { return _query.estimate(); }

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -14,6 +14,8 @@
 #include <vespa/searchcore/proton/bucketdb/bucket_db_owner.h>
 #include <vespa/searchcore/proton/matching/matching_stats.h>
 #include <vespa/searchlib/common/allocatedbitvector.h>
+#include <vespa/searchlib/common/converters.h>
+#include <vespa/searchlib/common/sortspec.h>
 #include <vespa/searchlib/engine/docsumrequest.h>
 #include <vespa/searchlib/engine/searchreply.h>
 #include <vespa/searchlib/engine/searchrequest.h>
@@ -24,8 +26,10 @@
 #include <vespa/searchlib/queryeval/queryeval_stats.h>
 #include <vespa/vespalib/data/slime/inserter.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/limited_thread_bundle_wrapper.h>
 
+#include <algorithm>
 #include <cinttypes>
 
 #include <vespa/log/log.h>
@@ -52,6 +56,7 @@ using search::queryeval::Blueprint;
 using search::queryeval::SearchIterator;
 using vespalib::Doom;
 using vespalib::FeatureSet;
+using vespalib::Issue;
 using vespalib::make_string_short::fmt;
 
 namespace proton::matching {
@@ -104,6 +109,47 @@ SearchReply::UP handleGroupingSession(SessionManager& sessionMgr, GroupingContex
         sessionMgr.insert(std::move(groupingSession));
     }
     return reply;
+}
+
+struct DummyConverterFactory : search::common::ConverterFactory {
+    search::common::BlobConverter::UP create(std::string_view, std::string_view) const override { return {}; }
+};
+
+struct SelectedSortFeatures {
+    bool                     parse_failed = false;
+    std::vector<std::string> public_names;
+};
+
+SelectedSortFeatures select_sort_features(const std::string& sort_spec, const RankSetup& rank_setup) {
+    SelectedSortFeatures selected;
+    if (sort_spec.find("feature(") == std::string::npos) {
+        return selected;
+    }
+    try {
+        DummyConverterFactory    dummy;
+        search::common::SortSpec spec(sort_spec, dummy);
+        for (const auto& field : spec) {
+            if (!field._is_rank_feature) {
+                continue;
+            }
+            if (std::find(selected.public_names.begin(), selected.public_names.end(), field._field) !=
+                selected.public_names.end()) {
+                continue;
+            }
+            if (!rank_setup.has_sort_feature(field._field)) {
+                Issue::report("sort spec: rank feature '%s' is not an allowed sort feature", field._field.c_str());
+                selected.parse_failed = true;
+                selected.public_names.clear();
+                return selected;
+            }
+            selected.public_names.push_back(field._field);
+        }
+    } catch (const std::exception& e) {
+        Issue::report("Failed parsing sortspec '%s': %s", sort_spec.c_str(), e.what());
+        selected.parse_failed = true;
+        selected.public_names.clear();
+    }
+    return selected;
 }
 
 } // namespace
@@ -329,6 +375,11 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
             return reply;
         }
 
+        auto selected_sort = select_sort_features(request.sortSpec, *_rankSetup);
+        if (selected_sort.parse_failed) {
+            return reply;
+        }
+
         const Properties& rankProperties = request.propertiesMap.rankProperties();
         uint32_t          heapSize = HeapSize::lookup(rankProperties, _rankSetup->getHeapSize());
         uint32_t          arraySize = ArraySize::lookup(rankProperties, _rankSetup->getArraySize());
@@ -343,8 +394,25 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
                            willNeedRanking(request, groupingContext, first_phase_rank_score_drop_limit,
                                            mtf->query().needs_ranking()));
 
-        ResultProcessor rp(attrContext, metaStore, sessionMgr, groupingContext, sessionId, request.sortSpec,
-                           params.offset, params.hits);
+        const bool ordered_hits_needed = (params.hits != 0) || !groupingContext.empty();
+        if (!selected_sort.public_names.empty() && ordered_hits_needed) {
+            mtf->prepare_and_install_sort_features(selected_sort.public_names);
+            if (mtf->get_request_context().getDoom().soft_doom()) {
+                reply->coverage.degradeTimeout();
+                vespalib::Issue::report("Search request soft doomed during query setup and initialization.");
+                return reply;
+            }
+        }
+
+        std::string sort_spec = request.sortSpec;
+        // With neither hits nor grouping there is nothing to order; suppress the
+        // sort so the empty partial result does not advertise sort data.
+        if (!selected_sort.public_names.empty() && !ordered_hits_needed) {
+            sort_spec.clear();
+        }
+
+        ResultProcessor rp(attrContext, metaStore, sessionMgr, groupingContext, sessionId, sort_spec, params.offset,
+                           params.hits);
 
         size_t numThreadsPerSearch = computeNumThreadsPerSearch(mtf->estimate(), rankProperties);
         vespalib::LimitedThreadBundleWrapper limitedThreadBundle(threadBundle, numThreadsPerSearch);

--- a/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.cpp
@@ -1,0 +1,152 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "sort_feature_store.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <numeric>
+
+namespace proton::matching {
+
+namespace {
+
+double sanitize(double value) {
+    if (__builtin_expect(std::isnan(value) || std::isinf(value), false)) {
+        return -HUGE_VAL;
+    }
+    return value;
+}
+
+} // namespace
+
+SortFeatureStore::SortFeatureStore(std::vector<std::string> public_names)
+    : _num_features(public_names.size()),
+      _rows(0),
+      _monotonic(true),
+      _last_docid(0),
+      _seek_row(~0u),
+      _consume_pos(0),
+      _bound_docid(0),
+      _bound(false),
+      _consumed(false),
+      _public_names(std::move(public_names)),
+      _chunks(),
+      _perm() {
+}
+
+void SortFeatureStore::record(uint32_t docid, std::span<const double> values) {
+    if (_consumed || values.size() != _num_features) {
+        abort();
+    }
+    if (_rows > 0 && docid < _last_docid) {
+        _monotonic = false;
+    }
+    _last_docid = docid;
+    if (_chunks.empty() || _chunks.back()->used == chunk_rows) {
+        auto chunk = std::make_unique<Chunk>();
+        chunk->docids.resize(chunk_rows);
+        chunk->values.resize(static_cast<size_t>(chunk_rows) * _num_features);
+        _chunks.push_back(std::move(chunk));
+    }
+    Chunk&   chunk = *_chunks.back();
+    uint32_t local = chunk.used++;
+    chunk.docids[local] = docid;
+    double* dst = chunk.values.data() + static_cast<size_t>(local) * _num_features;
+    for (uint32_t i = 0; i < _num_features; ++i) {
+        dst[i] = sanitize(values[i]);
+    }
+    ++_rows;
+}
+
+void SortFeatureStore::finalize_permutation() {
+    if (_consumed || _monotonic || _rows == 0 || !_perm.empty()) {
+        return;
+    }
+    _perm.resize(_rows);
+    std::iota(_perm.begin(), _perm.end(), 0u);
+    std::sort(_perm.begin(), _perm.end(), [this](uint32_t a, uint32_t b) { return row_docid(a) < row_docid(b); });
+}
+
+uint32_t SortFeatureStore::ordinal(std::string_view public_name) const {
+    for (uint32_t i = 0; i < _public_names.size(); ++i) {
+        if (_public_names[i] == public_name) {
+            return i;
+        }
+    }
+    return invalid_ordinal;
+}
+
+uint32_t SortFeatureStore::ordered_row(uint32_t pos) const noexcept {
+    return _perm.empty() ? pos : _perm[pos];
+}
+
+uint32_t SortFeatureStore::row_docid(uint32_t row) const {
+    uint32_t chunk_idx = row / chunk_rows;
+    uint32_t local = row % chunk_rows;
+    return _chunks[chunk_idx]->docids[local];
+}
+
+const double* SortFeatureStore::row_values(uint32_t row) const {
+    uint32_t chunk_idx = row / chunk_rows;
+    uint32_t local = row % chunk_rows;
+    return _chunks[chunk_idx]->values.data() + static_cast<size_t>(local) * _num_features;
+}
+
+void SortFeatureStore::seek(uint32_t docid) {
+    if (_consumed) {
+        abort();
+    }
+    if (_bound) {
+        if (docid < _bound_docid) {
+            abort();
+        }
+        if (docid == _bound_docid) {
+            return;
+        }
+    }
+    while (_consume_pos < _rows) {
+        uint32_t row = ordered_row(_consume_pos);
+        uint32_t stored = row_docid(row);
+        if (stored >= docid) {
+            if (stored != docid) {
+                abort();
+            }
+            _seek_row = row;
+            _bound_docid = docid;
+            _bound = true;
+            ++_consume_pos;
+            return;
+        }
+        ++_consume_pos;
+    }
+    abort();
+}
+
+double SortFeatureStore::get(uint32_t ordinal) const {
+    if (_seek_row == ~0u || ordinal >= _num_features) {
+        abort();
+    }
+    return row_values(_seek_row)[ordinal];
+}
+
+void SortFeatureStore::consumed() {
+    if (_consumed) {
+        return;
+    }
+    _consumed = true;
+    clear_storage();
+}
+
+void SortFeatureStore::clear_storage() {
+    // vector::clear() keeps capacity. Swap-with-empty releases 4 bytes per
+    // permutation row (and the chunk buffers) before FastS radix scratch.
+    std::vector<std::unique_ptr<Chunk>>().swap(_chunks);
+    std::vector<uint32_t>().swap(_perm);
+    _rows = 0;
+    _seek_row = ~0u;
+    _consume_pos = 0;
+    _bound = false;
+}
+
+} // namespace proton::matching

--- a/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.cpp
@@ -23,24 +23,24 @@ double sanitize(double value) {
 SortFeatureStore::SortFeatureStore(std::vector<std::string> public_names)
     : _num_features(public_names.size()),
       _rows(0),
-      _monotonic(true),
+      _recorded_in_docid_order(true),
       _last_docid(0),
       _seek_row(~0u),
       _consume_pos(0),
       _bound_docid(0),
       _bound(false),
-      _consumed(false),
+      _phase(Phase::recording),
       _public_names(std::move(public_names)),
       _chunks(),
-      _perm() {
+      _read_order() {
 }
 
 void SortFeatureStore::record(uint32_t docid, std::span<const double> values) {
-    if (_consumed || values.size() != _num_features) {
+    if (_phase != Phase::recording || values.size() != _num_features) {
         abort();
     }
     if (_rows > 0 && docid < _last_docid) {
-        _monotonic = false;
+        _recorded_in_docid_order = false;
     }
     _last_docid = docid;
     if (_chunks.empty() || _chunks.back()->used == chunk_rows) {
@@ -59,13 +59,18 @@ void SortFeatureStore::record(uint32_t docid, std::span<const double> values) {
     ++_rows;
 }
 
-void SortFeatureStore::finalize_permutation() {
-    if (_consumed || _monotonic || _rows == 0 || !_perm.empty()) {
+void SortFeatureStore::ensure_sorted_for_read() {
+    if (_phase != Phase::recording) {
         return;
     }
-    _perm.resize(_rows);
-    std::iota(_perm.begin(), _perm.end(), 0u);
-    std::sort(_perm.begin(), _perm.end(), [this](uint32_t a, uint32_t b) { return row_docid(a) < row_docid(b); });
+    _phase = Phase::reading;
+    if (_recorded_in_docid_order || _rows == 0) {
+        return;
+    }
+    _read_order.resize(_rows);
+    std::iota(_read_order.begin(), _read_order.end(), 0u);
+    std::sort(_read_order.begin(), _read_order.end(),
+              [this](uint32_t a, uint32_t b) { return row_docid(a) < row_docid(b); });
 }
 
 uint32_t SortFeatureStore::ordinal(std::string_view public_name) const {
@@ -78,7 +83,7 @@ uint32_t SortFeatureStore::ordinal(std::string_view public_name) const {
 }
 
 uint32_t SortFeatureStore::ordered_row(uint32_t pos) const noexcept {
-    return _perm.empty() ? pos : _perm[pos];
+    return _read_order.empty() ? pos : _read_order[pos];
 }
 
 uint32_t SortFeatureStore::row_docid(uint32_t row) const {
@@ -94,7 +99,7 @@ const double* SortFeatureStore::row_values(uint32_t row) const {
 }
 
 void SortFeatureStore::seek(uint32_t docid) {
-    if (_consumed) {
+    if (_phase != Phase::reading) {
         abort();
     }
     if (_bound) {
@@ -131,18 +136,18 @@ double SortFeatureStore::get(uint32_t ordinal) const {
 }
 
 void SortFeatureStore::consumed() {
-    if (_consumed) {
+    if (_phase == Phase::consumed) {
         return;
     }
-    _consumed = true;
+    _phase = Phase::consumed;
     clear_storage();
 }
 
 void SortFeatureStore::clear_storage() {
     // vector::clear() keeps capacity. Swap-with-empty releases 4 bytes per
-    // permutation row (and the chunk buffers) before FastS radix scratch.
+    // read-order index row (and the chunk buffers) before FastS radix scratch.
     std::vector<std::unique_ptr<Chunk>>().swap(_chunks);
-    std::vector<uint32_t>().swap(_perm);
+    std::vector<uint32_t>().swap(_read_order);
     _rows = 0;
     _seek_row = ~0u;
     _consume_pos = 0;

--- a/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.h
@@ -1,0 +1,66 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchlib/common/sortresults.h>
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace proton::matching {
+
+/**
+ * Per-thread store of selected sort-feature values recorded during matching.
+ * Consumption is a forward cursor over the ordered row view (identity order
+ * when recording was monotonic, permutation order otherwise).
+ * finalize_permutation() establishes docid order after non-monotonic recording.
+ */
+class SortFeatureStore : public INumericSortValueProvider {
+public:
+    SortFeatureStore(std::vector<std::string> public_names);
+    ~SortFeatureStore() override = default;
+
+    uint32_t num_features() const noexcept { return _num_features; }
+    uint32_t num_rows() const noexcept { return _rows; }
+    bool monotonic() const noexcept { return _monotonic; }
+
+    void record(uint32_t docid, std::span<const double> values);
+    void finalize_permutation();
+
+    uint32_t ordinal(std::string_view public_name) const override;
+    void seek(uint32_t docid) override;
+    double get(uint32_t ordinal) const override;
+    void consumed() override;
+
+private:
+    static constexpr uint32_t chunk_rows = 1024;
+
+    struct Chunk {
+        std::vector<uint32_t> docids;
+        std::vector<double>   values; // row-major [local_row * num_features + ordinal]
+        uint32_t              used = 0;
+    };
+
+    uint32_t ordered_row(uint32_t pos) const noexcept;
+    uint32_t row_docid(uint32_t row) const;
+    const double* row_values(uint32_t row) const;
+    void clear_storage();
+
+    uint32_t                            _num_features;
+    uint32_t                            _rows;
+    bool                                _monotonic;
+    uint32_t                            _last_docid;
+    uint32_t                            _seek_row;
+    uint32_t                            _consume_pos;
+    uint32_t                            _bound_docid;
+    bool                                _bound;
+    bool                                _consumed;
+    std::vector<std::string>            _public_names;
+    std::vector<std::unique_ptr<Chunk>> _chunks;
+    std::vector<uint32_t>               _perm;
+};
+
+} // namespace proton::matching

--- a/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.h
@@ -14,9 +14,17 @@ namespace proton::matching {
 
 /**
  * Per-thread store of selected sort-feature values recorded during matching.
- * Consumption is a forward cursor over the ordered row view (identity order
- * when recording was monotonic, permutation order otherwise).
- * finalize_permutation() establishes docid order after non-monotonic recording.
+ *
+ * Lifetime:
+ * - construct with X public names;
+ * - record(docid, X doubles); docids may arrive in any order;
+ * - ensure_sorted_for_read() ends recording; no record() afterward;
+ * - seek(docid) in non-decreasing docid order, then get(ordinal) for the
+ *   bound row;
+ * - consumed() releases storage.
+ *
+ * Unrequested rows between seeks are skipped.
+ * ordinal(name) is the 0..X-1 index used with get().
  */
 class SortFeatureStore : public INumericSortValueProvider {
 public:
@@ -25,10 +33,9 @@ public:
 
     uint32_t num_features() const noexcept { return _num_features; }
     uint32_t num_rows() const noexcept { return _rows; }
-    bool monotonic() const noexcept { return _monotonic; }
 
     void record(uint32_t docid, std::span<const double> values);
-    void finalize_permutation();
+    void ensure_sorted_for_read();
 
     uint32_t ordinal(std::string_view public_name) const override;
     void seek(uint32_t docid) override;
@@ -36,6 +43,8 @@ public:
     void consumed() override;
 
 private:
+    enum class Phase { recording, reading, consumed };
+
     static constexpr uint32_t chunk_rows = 1024;
 
     struct Chunk {
@@ -51,16 +60,16 @@ private:
 
     uint32_t                            _num_features;
     uint32_t                            _rows;
-    bool                                _monotonic;
+    bool                                _recorded_in_docid_order;
     uint32_t                            _last_docid;
     uint32_t                            _seek_row;
     uint32_t                            _consume_pos;
     uint32_t                            _bound_docid;
     bool                                _bound;
-    bool                                _consumed;
+    Phase                               _phase;
     std::vector<std::string>            _public_names;
     std::vector<std::unique_ptr<Chunk>> _chunks;
-    std::vector<uint32_t>               _perm;
+    std::vector<uint32_t>               _read_order;
 };
 
 } // namespace proton::matching

--- a/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
+++ b/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
@@ -101,6 +101,14 @@ TEST_F(SearchRequestTest, require_that_sorting_is_converted) {
     EXPECT_EQ(request.sortSpec, "+foo -bar");
 }
 
+TEST_F(SearchRequestTest, require_that_feature_sorting_is_converted) {
+    auto* sort_field = proto.add_sorting();
+    sort_field->set_ascending(true);
+    sort_field->set_field("feature(foo)");
+    convert();
+    EXPECT_EQ(request.sortSpec, "+feature(foo)");
+}
+
 TEST_F(SearchRequestTest, require_that_session_key_is_converted) {
     proto.set_session_key("my-session");
     convert();

--- a/searchlib/src/tests/fef/properties/properties_test.cpp
+++ b/searchlib/src/tests/fef/properties/properties_test.cpp
@@ -262,6 +262,18 @@ TEST(PropertiesTest, test_stuff) {
             EXPECT_EQ(a[0], std::string("foo"));
             EXPECT_EQ(a[1], std::string("bar"));
         }
+        { // vespa.sort.feature
+            EXPECT_EQ(sort::Feature::NAME, std::string("vespa.sort.feature"));
+            EXPECT_EQ(sort::Feature::DEFAULT_VALUE.size(), 0u);
+            Properties p;
+            EXPECT_EQ(sort::Feature::lookup(p).size(), 0u);
+            p.add("vespa.sort.feature", "foo");
+            p.add("vespa.sort.feature", "rankingExpression(bar)");
+            std::vector<std::string> a = sort::Feature::lookup(p);
+            ASSERT_TRUE(a.size() == 2);
+            EXPECT_EQ(a[0], std::string("foo"));
+            EXPECT_EQ(a[1], std::string("rankingExpression(bar)"));
+        }
         { // vespa.dump.ignoredefaultfeatures
             EXPECT_EQ(dump::IgnoreDefaultFeatures::NAME, std::string("vespa.dump.ignoredefaultfeatures"));
             EXPECT_EQ(dump::IgnoreDefaultFeatures::DEFAULT_VALUE, "false");

--- a/searchlib/src/tests/ranksetup/ranksetup_test.cpp
+++ b/searchlib/src/tests/ranksetup/ranksetup_test.cpp
@@ -31,9 +31,11 @@
 #include <vespa/searchlib/fef/test/rankresult.h>
 #include <vespa/searchlib/fef/utils.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/stash.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 #include <iostream>
+#include <vector>
 
 using namespace search::fef;
 using namespace search::features;
@@ -496,6 +498,8 @@ TEST_F(RankSetupTest, rank_setup) {
     env.getProperties().add(match::Feature::NAME, "match_bar");
     env.getProperties().add(dump::Feature::NAME, "foo");
     env.getProperties().add(dump::Feature::NAME, "bar");
+    env.getProperties().add(sort::Feature::NAME, "value(1)");
+    env.getProperties().add(sort::Feature::NAME, "rankingExpression(foo)");
     env.getProperties().add(matching::NumThreadsPerSearch::NAME, "3");
     env.getProperties().add(matching::MinHitsPerThread::NAME, "8");
     env.getProperties().add(matchphase::DegradationAttribute::NAME, "mystaticrankattr");
@@ -544,6 +548,9 @@ TEST_F(RankSetupTest, rank_setup) {
     ASSERT_TRUE(rs.getDumpFeatures().size() == 2);
     EXPECT_EQ(rs.getDumpFeatures()[0], std::string("foo"));
     EXPECT_EQ(rs.getDumpFeatures()[1], std::string("bar"));
+    ASSERT_TRUE(rs.get_sort_features().size() == 2);
+    EXPECT_EQ(rs.get_sort_features()[0], std::string("value(1)"));
+    EXPECT_EQ(rs.get_sort_features()[1], std::string("rankingExpression(foo)"));
     EXPECT_EQ(rs.getNumThreadsPerSearch(), 3u);
     EXPECT_EQ(rs.getMinHitsPerThread(), 8u);
     EXPECT_EQ(rs.getDegradationAttribute(), "mystaticrankattr");
@@ -933,6 +940,118 @@ TEST_F(RankSetupTest, feature_normalization) {
             checkFeatures(exp, actual);
         }
     }
+}
+
+TEST_F(RankSetupTest, sort_features_compile_as_numeric_one_seed_resolvers) {
+    {
+        RankSetup rs(_factory, _indexEnv);
+        rs.setFirstPhaseRank("value(1)");
+        rs.add_sort_feature("value(2)");
+        ASSERT_TRUE(rs.compile());
+        EXPECT_TRUE(rs.has_sort_feature("value(2)"));
+        auto program = rs.create_sort_program("value(2)");
+        ASSERT_TRUE(program);
+        EXPECT_FALSE(rs.has_sort_feature("value(1)"));
+    }
+    {
+        RankSetup rs(_factory, _indexEnv);
+        rs.setFirstPhaseRank("value(1)");
+        rs.add_sort_feature("rankingExpression(\"tensor(x[3])(x)\")");
+        EXPECT_FALSE(rs.compile());
+    }
+}
+
+TEST_F(RankSetupTest, sort_features_reject_first_phase_rank_helpers) {
+    BlueprintFactory factory;
+    setup_search_features(factory);
+    {
+        RankSetup rs(factory, _indexEnv);
+        rs.setFirstPhaseRank("value(1)");
+        rs.add_sort_feature("firstPhaseRank");
+        EXPECT_FALSE(rs.compile());
+    }
+    {
+        RankSetup rs(factory, _indexEnv);
+        rs.setFirstPhaseRank("value(1)");
+        rs.add_sort_feature("firstPhaseMax");
+        EXPECT_FALSE(rs.compile());
+    }
+    {
+        RankSetup rs(factory, _indexEnv);
+        rs.setFirstPhaseRank("value(1)");
+        rs.add_sort_feature("firstPhase");
+        EXPECT_TRUE(rs.compile());
+    }
+    {
+        RankSetup rs(factory, _indexEnv);
+        rs.setFirstPhaseRank("value(1)");
+        rs.add_sort_feature("rankingExpression(\"firstPhaseRank\")");
+        EXPECT_FALSE(rs.compile());
+    }
+    {
+        RankSetup rs(factory, _indexEnv);
+        rs.setFirstPhaseRank("value(1)");
+        rs.add_sort_feature("rankingExpression(\"firstPhaseMax\")");
+        EXPECT_FALSE(rs.compile());
+    }
+}
+
+class RecordingIndexEnvironment : public search::fef::test::IndexEnvironment {
+public:
+    mutable std::vector<IIndexEnvironment::FeatureMotivation> hints;
+    FeatureMotivation getFeatureMotivation() const override {
+        return hints.empty() ? FeatureMotivation::UNKNOWN : hints.back();
+    }
+    void hintFeatureMotivation(FeatureMotivation motivation) const override { hints.push_back(motivation); }
+};
+
+TEST_F(RankSetupTest, sort_features_compile_under_rank_motivation) {
+    RecordingIndexEnvironment env;
+    RankSetup                 rs(_factory, env);
+    rs.setFirstPhaseRank("value(1)");
+    rs.add_sort_feature("value(2)");
+    ASSERT_TRUE(rs.compile());
+    ASSERT_GE(env.hints.size(), 2u);
+    EXPECT_EQ(env.hints.front(), IIndexEnvironment::RANK);
+    EXPECT_EQ(env.hints.back(), IIndexEnvironment::DUMP);
+}
+
+class CountPrepareBlueprint : public Blueprint {
+public:
+    static int prepares;
+    CountPrepareBlueprint() : Blueprint("countprepare") {}
+    void visitDumpFeatures(const IIndexEnvironment&, IDumpFeatureVisitor&) const override {}
+    Blueprint::UP createInstance() const override { return std::make_unique<CountPrepareBlueprint>(); }
+    bool setup(const IIndexEnvironment&, const StringVector&) override {
+        describeOutput("out", "dummy", FeatureType::number());
+        return true;
+    }
+    void prepareSharedState(const IQueryEnvironment&, IObjectStore&) const override { ++prepares; }
+    FeatureExecutor& createExecutor(const IQueryEnvironment&, vespalib::Stash& stash) const override {
+        return stash.create<SingleZeroValueExecutor>();
+    }
+};
+int CountPrepareBlueprint::prepares = 0;
+
+TEST_F(RankSetupTest, sort_features_prepare_only_selected_public_names) {
+    BlueprintFactory factory;
+    setup_search_features(factory);
+    factory.addPrototype(std::make_shared<CountPrepareBlueprint>());
+    CountPrepareBlueprint::prepares = 0;
+    RankSetup rs(factory, _indexEnv);
+    rs.setFirstPhaseRank("value(1)");
+    rs.add_sort_feature("countprepare");
+    rs.add_sort_feature("value(2)");
+    ASSERT_TRUE(rs.compile());
+    EXPECT_TRUE(rs.has_sort_feature("countprepare"));
+    EXPECT_TRUE(rs.has_sort_feature("value(2)"));
+    QueryEnvironment queryEnv;
+    rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"value(2)"});
+    EXPECT_EQ(0, CountPrepareBlueprint::prepares);
+    rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"countprepare"});
+    EXPECT_EQ(1, CountPrepareBlueprint::prepares);
+    rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"countprepare", "countprepare"});
+    EXPECT_EQ(2, CountPrepareBlueprint::prepares);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/sort/sort_test.cpp
+++ b/searchlib/src/tests/sort/sort_test.cpp
@@ -82,13 +82,14 @@ void PrintTo(const FieldSortSpec& spec, std::ostream* os) {
     PrintTo(spec._sort_order, os);
     *os << ", " << converter_as_string_view(spec._converter) << ", ";
     PrintTo(spec._missing_policy, os);
-    *os << ", " << std::quoted(spec._missing_value) << "}";
+    *os << ", " << std::quoted(spec._missing_value) << ", rank_feature=" << spec._is_rank_feature << "}";
 }
 
 bool operator==(const FieldSortSpec& lhs, const FieldSortSpec& rhs) {
     return lhs._field == rhs._field && lhs._sort_order == rhs._sort_order &&
            converter_as_string_view(lhs._converter) == converter_as_string_view(rhs._converter) &&
-           lhs._missing_policy == rhs._missing_policy && lhs._missing_value == rhs._missing_value;
+           lhs._missing_policy == rhs._missing_policy && lhs._missing_value == rhs._missing_value &&
+           lhs._is_rank_feature == rhs._is_rank_feature;
 }
 
 } // namespace search::common
@@ -265,6 +266,7 @@ TEST(SortTest, sortspec_missing) {
     constexpr auto      miss_first = MissingPolicy::FIRST;
     constexpr auto      miss_last = MissingPolicy::LAST;
     constexpr auto      miss_as = MissingPolicy::AS;
+    constexpr auto      miss_def = MissingPolicy::DEFAULT;
     EXPECT_EQ(FieldSortSpecVector({{"name", asc, {}, miss_first, ""}}),
               SortSpec("+missing(name,first)", ucaFactory).get_field_sort_specs());
     EXPECT_EQ(FieldSortSpecVector({{"name", asc, {}, miss_last, ""}}),
@@ -280,6 +282,20 @@ TEST(SortTest, sortspec_missing) {
                            "Expected '\\' or '\"', got 'n' at [-missing(name,as,\"bad quoting \\][n here\"]");
     EXPECT_EQ(FieldSortSpecVector({{"name", desc, lowercase, miss_last, ""}}),
               SortSpec("-missing(lowercase(name),last)", ucaFactory).get_field_sort_specs());
+    EXPECT_EQ(FieldSortSpecVector({{"foo", desc, {}, miss_def, "", true}}),
+              SortSpec("-feature(foo)", ucaFactory).get_field_sort_specs());
+    EXPECT_EQ(FieldSortSpecVector({{"foo", asc, {}, miss_def, "", true}}),
+              SortSpec("+feature(foo)", ucaFactory).get_field_sort_specs());
+    EXPECT_EQ(FieldSortSpecVector({{"foo", desc, {}, miss_def, "", true}, {"name", desc, {}, miss_def, ""}}),
+              SortSpec("-feature(foo) -name", ucaFactory).get_field_sort_specs());
+    VESPA_EXPECT_EXCEPTION(SortSpec spec("-feature(foo-bar)", ucaFactory), std::runtime_error,
+                           "Illegal feature name 'foo-bar' for sorting");
+    VESPA_EXPECT_EXCEPTION(SortSpec spec("-feature(foo$)", ucaFactory), std::runtime_error,
+                           "Illegal feature name 'foo$' for sorting");
+    VESPA_EXPECT_EXCEPTION(SortSpec spec("-missing(feature(foo),first)", ucaFactory), std::runtime_error,
+                           "Cannot use missing() with feature(...) sorting");
+    VESPA_EXPECT_EXCEPTION(SortSpec spec("-FeAtUrE(foo)", ucaFactory), std::runtime_error, "Unknown func FeAtUrE");
+    EXPECT_FALSE(SortSpec("+missing(title,as,\"feature(foo)\")", ucaFactory)[0]._is_rank_feature);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/sortspec/multilevelsort_test.cpp
+++ b/searchlib/src/tests/sortspec/multilevelsort_test.cpp
@@ -469,4 +469,77 @@ TEST(SortTest, make_sort_blob_writer_throws_when_missing_value_is_illegal) {
     verify_make_sort_blob_writer_throws(BasicType::FLOAT, CollectionType::ARRAY, true);
 }
 
+class FakeNumericSortProvider : public INumericSortValueProvider {
+public:
+    FakeNumericSortProvider(std::vector<std::string> names, std::vector<std::vector<double>> by_docid)
+        : _names(std::move(names)), _by_docid(std::move(by_docid)) {}
+
+    uint32_t seek_count() const { return _seeks; }
+    uint32_t consumed_count() const { return _consumed; }
+
+    uint32_t ordinal(std::string_view public_name) const override {
+        for (uint32_t i = 0; i < _names.size(); ++i) {
+            if (_names[i] == public_name) {
+                return i;
+            }
+        }
+        return invalid_ordinal;
+    }
+    void seek(uint32_t docid) override {
+        ++_seeks;
+        if (_started && docid < _last_seek) {
+            ADD_FAILURE() << "backwards seek " << docid << " after " << _last_seek;
+        }
+        _started = true;
+        _last_seek = docid;
+        _bound_docid = docid;
+        _bound = true;
+    }
+    double get(uint32_t ord) const override {
+        if (!_bound || _bound_docid >= _by_docid.size() || ord >= _by_docid[_bound_docid].size()) {
+            ADD_FAILURE() << "get without a valid bound seek";
+            return 0.0;
+        }
+        return _by_docid[_bound_docid][ord];
+    }
+    void consumed() override { ++_consumed; }
+
+private:
+    std::vector<std::string>         _names;
+    std::vector<std::vector<double>> _by_docid;
+    uint32_t                         _seeks = 0;
+    uint32_t                         _consumed = 0;
+    uint32_t                         _last_seek = 0;
+    uint32_t                         _bound_docid = 0;
+    bool                             _bound = false;
+    bool                             _started = false;
+};
+
+TEST(SortTest, feature_sort_binds_provider_and_seeks_each_hit_once) {
+    search::uca::UcaConverterFactory ucaFactory;
+    search::AttributeManager         mgr;
+    search::AttributeContext         ac(mgr);
+    FastS_SortSpec                   sorter("no-metastore", 7, vespalib::Doom::never(), ucaFactory);
+    ASSERT_TRUE(sorter.Init("+feature(pri) -feature(sec) +[docid]", ac));
+
+    // Hits encoded in input (docid) order. Table observes ascending pri,
+    // descending sec, and +[docid] when pri and sec both tie (docs 3 and 4).
+    std::vector<std::vector<double>> by_docid(5);
+    by_docid[1] = {1.0, 10.0};
+    by_docid[2] = {1.0, 20.0};
+    by_docid[3] = {2.0, 10.0};
+    by_docid[4] = {2.0, 10.0};
+    FakeNumericSortProvider provider({"pri", "sec"}, std::move(by_docid));
+    sorter.bind_numeric_provider(provider);
+
+    RankedHit hits[4] = {RankedHit(1, 0.0), RankedHit(2, 0.0), RankedHit(3, 0.0), RankedHit(4, 0.0)};
+    sorter.sortResults(hits, 4, 4);
+    EXPECT_EQ(2u, hits[0].getDocId());
+    EXPECT_EQ(1u, hits[1].getDocId());
+    EXPECT_EQ(3u, hits[2].getDocId());
+    EXPECT_EQ(4u, hits[3].getDocId());
+    EXPECT_EQ(4u, provider.seek_count());
+    EXPECT_EQ(1u, provider.consumed_count());
+}
+
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/common/sortresults.cpp
+++ b/searchlib/src/vespa/searchlib/common/sortresults.cpp
@@ -157,8 +157,9 @@ FastS_DefaultResultSorter FastS_DefaultResultSorter::_instance;
 //-----------------------------------------------------------------------------
 
 FastS_SortSpec::VectorRef::VectorRef(uint32_t type, const search::attribute::IAttributeVector* vector,
-                                     std::unique_ptr<search::attribute::ISortBlobWriter> writer) noexcept
-    : _type(type), _vector(vector), _writer(std::move(writer)) {
+                                     std::unique_ptr<search::attribute::ISortBlobWriter> writer,
+                                     uint32_t                                            feature_ordinal) noexcept
+    : _type(type), _vector(vector), _writer(std::move(writer)), _feature_ordinal(feature_ordinal) {
 }
 
 bool FastS_SortSpec::Add(IAttributeContext& vecMan, const FieldSortSpec& field_sort_spec) {
@@ -168,7 +169,9 @@ bool FastS_SortSpec::Add(IAttributeContext& vecMan, const FieldSortSpec& field_s
     uint32_t                type = ASC_VECTOR;
     const IAttributeVector* vector(nullptr);
 
-    if ((field_sort_spec._field.size() == 6) && (field_sort_spec._field == "[rank]")) {
+    if (field_sort_spec._is_rank_feature) {
+        type = (field_sort_spec.is_ascending()) ? ASC_FEATURE : DESC_FEATURE;
+    } else if ((field_sort_spec._field.size() == 6) && (field_sort_spec._field == "[rank]")) {
         type = (field_sort_spec.is_ascending()) ? ASC_RANK : DESC_RANK;
     } else if ((field_sort_spec._field.size() == 7) && (field_sort_spec._field == "[docid]")) {
         type = (field_sort_spec.is_ascending()) ? ASC_DOCID : DESC_DOCID;
@@ -188,7 +191,8 @@ bool FastS_SortSpec::Add(IAttributeContext& vecMan, const FieldSortSpec& field_s
         }
     }
 
-    auto sort_blob_writer = make_sort_blob_writer(vector, field_sort_spec);
+    auto sort_blob_writer = field_sort_spec._is_rank_feature ? std::unique_ptr<search::attribute::ISortBlobWriter>()
+                                                             : make_sort_blob_writer(vector, field_sort_spec);
     if (vector != nullptr && !sort_blob_writer) {
         return false;
     }
@@ -205,13 +209,25 @@ void FastS_SortSpec::initSortData(const RankedHit* hits, uint32_t n) {
     freeSortData();
     size_t fixedWidth = 0;
     size_t variableWidth = 0;
+    bool   has_feature = false;
     for (const auto& vec : _vectors) {
-        if (vec._type >= ASC_DOCID) { // doc id
+        switch (vec._type) {
+        case ASC_DOCID:
+        case DESC_DOCID:
             fixedWidth +=
                 (vec._vector != nullptr) ? vec._vector->getFixedWidth() : sizeof(uint32_t) + sizeof(uint16_t);
-        } else if (vec._type >= ASC_RANK) { // rank value
+            break;
+        case ASC_RANK:
+        case DESC_RANK:
             fixedWidth += sizeof(search::HitRank);
-        } else {
+            break;
+        case ASC_FEATURE:
+        case DESC_FEATURE:
+            fixedWidth += sizeof(double);
+            has_feature = true;
+            break;
+        case ASC_VECTOR:
+        case DESC_VECTOR: {
             size_t numBytes = vec._vector->getFixedWidth();
             if (numBytes == 0) { // string
                 variableWidth += 11;
@@ -220,6 +236,8 @@ void FastS_SortSpec::initSortData(const RankedHit* hits, uint32_t n) {
             } else {
                 fixedWidth += (1 + numBytes);
             }
+            break;
+        }
         }
     }
     _binarySortData.resize((fixedWidth + variableWidth) * n);
@@ -227,6 +245,12 @@ void FastS_SortSpec::initSortData(const RankedHit* hits, uint32_t n) {
 
     size_t offset = 0;
     for (uint32_t i(0), idx(0); (i < n) && !_doom.hard_doom(); ++i) {
+        if (has_feature) {
+            if (_numeric_provider == nullptr) {
+                abort();
+            }
+            _numeric_provider->seek(hits[i].getDocId());
+        }
         uint32_t len = 0;
         for (const auto& vec : _vectors) {
             int written = initSortData(vec, hits[i], offset);
@@ -240,6 +264,10 @@ void FastS_SortSpec::initSortData(const RankedHit* hits, uint32_t n) {
         sd._len = len;
         sd._pos = 0;
         idx += len;
+    }
+    if (_numeric_provider != nullptr) {
+        _numeric_provider->consumed();
+        _numeric_provider = nullptr;
     }
 }
 
@@ -283,6 +311,14 @@ int FastS_SortSpec::initSortData(const VectorRef& vec, const RankedHit& hit, siz
         case DESC_RANK:
             written = serializeForSort<convertForSort<search::HitRank, false>>(hit.getRank(), mySortData, available);
             break;
+        case ASC_FEATURE:
+            written = serializeForSort<convertForSort<double, true>>(_numeric_provider->get(vec._feature_ordinal),
+                                                                     mySortData, available);
+            break;
+        case DESC_FEATURE:
+            written = serializeForSort<convertForSort<double, false>>(_numeric_provider->get(vec._feature_ordinal),
+                                                                      mySortData, available);
+            break;
         case ASC_VECTOR:
             written = vec._writer->write(hit.getDocId(), mySortData, available);
             break;
@@ -304,7 +340,26 @@ FastS_SortSpec::FastS_SortSpec(std::string_view documentmetastore, uint32_t part
       _doom(doom),
       _ucaFactory(ucaFactory),
       _sortSpec(),
-      _vectors() {
+      _vectors(),
+      _numeric_provider(nullptr) {
+}
+
+void FastS_SortSpec::bind_numeric_provider(INumericSortValueProvider& provider) {
+    _numeric_provider = &provider;
+    auto spec = _sortSpec.begin();
+    for (auto& vec : _vectors) {
+        if (spec == _sortSpec.end()) {
+            abort();
+        }
+        if (spec->_is_rank_feature) {
+            uint32_t ordinal = provider.ordinal(spec->_field);
+            if (ordinal == INumericSortValueProvider::invalid_ordinal) {
+                abort();
+            }
+            vec._feature_ordinal = ordinal;
+        }
+        ++spec;
+    }
 }
 
 FastS_SortSpec::~FastS_SortSpec() {

--- a/searchlib/src/vespa/searchlib/common/sortresults.h
+++ b/searchlib/src/vespa/searchlib/common/sortresults.h
@@ -8,6 +8,8 @@
 #include <vespa/vespalib/stllike/allocator.h>
 #include <vespa/vespalib/util/doom.h>
 
+#include <string_view>
+
 #define INSERT_SORT_LEVEL 80
 
 namespace search::attribute {
@@ -57,21 +59,49 @@ public:
 
 //-----------------------------------------------------------------------------
 
+/**
+ * Supplies numeric feature keys while FastS encodes sort blobs.
+ * After binding, the provider must remain alive until consumed(). During
+ * encoding, seek() is called once per hit in non-decreasing docid order;
+ * get() reads the row bound by the most recent seek(). consumed() ends the
+ * binding and permits the provider to release its storage.
+ */
+class INumericSortValueProvider {
+public:
+    static constexpr uint32_t invalid_ordinal = ~0u;
+    virtual ~INumericSortValueProvider() = default;
+    virtual uint32_t ordinal(std::string_view public_name) const = 0;
+    virtual void seek(uint32_t docid) = 0;
+    virtual double get(uint32_t ordinal) const = 0;
+    virtual void consumed() = 0;
+};
+
 class FastS_SortSpec : public FastS_IResultSorter {
 private:
     friend class MultilevelSortTest;
 
 public:
-    enum { ASC_VECTOR = 0, DESC_VECTOR = 1, ASC_RANK = 2, DESC_RANK = 3, ASC_DOCID = 4, DESC_DOCID = 5 };
+    enum {
+        ASC_VECTOR = 0,
+        DESC_VECTOR = 1,
+        ASC_RANK = 2,
+        DESC_RANK = 3,
+        ASC_DOCID = 4,
+        DESC_DOCID = 5,
+        ASC_FEATURE = 6,
+        DESC_FEATURE = 7
+    };
 
     struct VectorRef {
         VectorRef(uint32_t type, const search::attribute::IAttributeVector* vector,
-                  std::unique_ptr<search::attribute::ISortBlobWriter> writer) noexcept;
+                  std::unique_ptr<search::attribute::ISortBlobWriter> writer,
+                  uint32_t feature_ordinal = INumericSortValueProvider::invalid_ordinal) noexcept;
         uint32_t                                            _type;
         const search::attribute::IAttributeVector*          _vector;
         std::unique_ptr<search::attribute::ISortBlobWriter> _writer;
+        uint32_t                                            _feature_ordinal;
         bool has_ascending_sort_order() const {
-            return _type == ASC_VECTOR || _type == ASC_RANK || _type == ASC_DOCID;
+            return _type == ASC_VECTOR || _type == ASC_RANK || _type == ASC_DOCID || _type == ASC_FEATURE;
         }
     };
 
@@ -87,14 +117,15 @@ private:
     using BinarySortData = std::vector<uint8_t, vespalib::allocator_large<uint8_t>>;
     using SortDataArray = std::vector<SortData, vespalib::allocator_large<SortData>>;
     using ConverterFactory = search::common::ConverterFactory;
-    std::string              _documentmetastore;
-    uint16_t                 _partitionId;
-    vespalib::Doom           _doom;
-    const ConverterFactory&  _ucaFactory;
-    search::common::SortSpec _sortSpec;
-    VectorRefList            _vectors;
-    BinarySortData           _binarySortData;
-    SortDataArray            _sortDataArray;
+    std::string                _documentmetastore;
+    uint16_t                   _partitionId;
+    vespalib::Doom             _doom;
+    const ConverterFactory&    _ucaFactory;
+    search::common::SortSpec   _sortSpec;
+    VectorRefList              _vectors;
+    BinarySortData             _binarySortData;
+    SortDataArray              _sortDataArray;
+    INumericSortValueProvider* _numeric_provider;
 
     bool Add(search::attribute::IAttributeContext& vecMan, const search::common::FieldSortSpec& field_sort_spec);
     void initSortData(const search::RankedHit* a, uint32_t n);
@@ -116,6 +147,7 @@ public:
     void copySortData(uint32_t offset, uint32_t n, uint32_t* idx, char* buf);
     void freeSortData();
     void initWithoutSorting(const search::RankedHit* hits, uint32_t hitCnt);
+    void bind_numeric_provider(INumericSortValueProvider& provider);
 };
 
 //-----------------------------------------------------------------------------

--- a/searchlib/src/vespa/searchlib/common/sortspec.cpp
+++ b/searchlib/src/vespa/searchlib/common/sortspec.cpp
@@ -41,16 +41,17 @@ ConstBufferRef LowercaseConverter::onConvert(const ConstBufferRef& src) const {
 FieldSortSpec::FieldSortSpec(std::string_view field, bool ascending,
                              std::shared_ptr<BlobConverter> converter) noexcept
     : FieldSortSpec(field, ascending ? SortOrder::ASCENDING : SortOrder::DESCENDING, std::move(converter),
-                    sortspec::MissingPolicy::DEFAULT, {}) {
+                    sortspec::MissingPolicy::DEFAULT, {}, false) {
 }
 
 FieldSortSpec::FieldSortSpec(std::string_view field, SortOrder sort_order, std::shared_ptr<BlobConverter> converter,
-                             MissingPolicy missing_policy, std::string missing_value) noexcept
+                             MissingPolicy missing_policy, std::string missing_value, bool is_rank_feature) noexcept
     : _field(field),
       _sort_order(sort_order),
       _converter(std::move(converter)),
       _missing_policy(missing_policy),
-      _missing_value(std::move(missing_value)) {
+      _missing_value(std::move(missing_value)),
+      _is_rank_feature(is_rank_feature) {
 }
 
 FieldSortSpec::~FieldSortSpec() = default;
@@ -196,6 +197,23 @@ void decode_missing(Tokenizer& tokenizer, MissingPolicy& missing_policy, std::st
     tokenizer.expect_char(')');
 }
 
+bool is_schema_identifier(std::string_view name) {
+    if (name.empty()) {
+        return false;
+    }
+    auto valid_first = [](char c) { return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_'; };
+    auto valid_rest = [&](char c) { return valid_first(c) || (c >= '0' && c <= '9'); };
+    if (!valid_first(name.front())) {
+        return false;
+    }
+    for (size_t i = 1; i < name.size(); ++i) {
+        if (!valid_rest(name[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace
 
 SortSpec::SortSpec(const std::string& spec, const ConverterFactory& ucaFactory) : _spec(spec), _field_sort_specs() {
@@ -206,6 +224,7 @@ SortSpec::SortSpec(const std::string& spec, const ConverterFactory& ucaFactory) 
         std::shared_ptr<BlobConverter> converter;
         auto                           func = tokenizer.token();
         bool                           in_missing = false;
+        bool                           is_rank_feature = false;
         if (tokenizer.peek() == '(' && func == "missing") {
             in_missing = true;
             tokenizer.step();
@@ -213,7 +232,18 @@ SortSpec::SortSpec(const std::string& spec, const ConverterFactory& ucaFactory) 
         }
         if (tokenizer.peek() == '(') {
             tokenizer.step();
-            if (func == "uca") {
+            if (func == "feature") {
+                if (in_missing) {
+                    throw std::runtime_error("Cannot use missing() with feature(...) sorting");
+                }
+                attr = tokenizer.token();
+                tokenizer.expect_char(')');
+                if (!is_schema_identifier(attr)) {
+                    throw std::runtime_error(
+                        make_string("Illegal feature name '%s' for sorting", std::string(attr).c_str()));
+                }
+                is_rank_feature = true;
+            } else if (func == "uca") {
                 attr = tokenizer.token();
                 tokenizer.expect_char(',');
                 auto             locale = tokenizer.token();
@@ -239,7 +269,8 @@ SortSpec::SortSpec(const std::string& spec, const ConverterFactory& ucaFactory) 
         if (in_missing) {
             decode_missing(tokenizer, missing_policy, missing_value);
         }
-        _field_sort_specs.emplace_back(attr, order, std::move(converter), missing_policy, std::move(missing_value));
+        _field_sort_specs.emplace_back(attr, order, std::move(converter), missing_policy, std::move(missing_value),
+                                       is_rank_feature);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/common/sortspec.h
+++ b/searchlib/src/vespa/searchlib/common/sortspec.h
@@ -28,13 +28,15 @@ enum class MissingPolicy : uint8_t {
 struct FieldSortSpec {
     FieldSortSpec(std::string_view field, bool ascending, std::shared_ptr<BlobConverter> converter) noexcept;
     FieldSortSpec(std::string_view field, sortspec::SortOrder, std::shared_ptr<BlobConverter> converter,
-                  sortspec::MissingPolicy missing_policy, std::string missing_value) noexcept;
+                  sortspec::MissingPolicy missing_policy, std::string missing_value,
+                  bool is_rank_feature = false) noexcept;
     ~FieldSortSpec();
     std::string                    _field;
     sortspec::SortOrder            _sort_order;
     std::shared_ptr<BlobConverter> _converter;
     sortspec::MissingPolicy        _missing_policy;
     std::string                    _missing_value;
+    bool                           _is_rank_feature;
     bool is_ascending() const noexcept { return _sort_order == sortspec::SortOrder::ASCENDING; }
 };
 

--- a/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
+++ b/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
@@ -256,6 +256,17 @@ std::vector<std::pair<std::string, std::string>> Rename::lookup(const Properties
 }
 } // namespace feature_rename
 
+namespace sort {
+
+const std::string              Feature::NAME("vespa.sort.feature");
+const std::vector<std::string> Feature::DEFAULT_VALUE;
+
+std::vector<std::string> Feature::lookup(const Properties& props) {
+    return lookupStringVector(props, NAME, DEFAULT_VALUE);
+}
+
+} // namespace sort
+
 namespace match {
 
 const std::string              Feature::NAME("vespa.match.feature");

--- a/searchlib/src/vespa/searchlib/fef/indexproperties.h
+++ b/searchlib/src/vespa/searchlib/fef/indexproperties.h
@@ -78,6 +78,19 @@ struct Rename {
 
 } // namespace feature_rename
 
+namespace sort {
+
+/**
+ * Property for the set of rank features that may be used as sorting keys.
+ **/
+struct Feature {
+    static const std::string              NAME;
+    static const std::vector<std::string> DEFAULT_VALUE;
+    static std::vector<std::string> lookup(const Properties& props);
+};
+
+} // namespace sort
+
 namespace match {
 
 /**

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
@@ -10,6 +10,9 @@
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
+#include <algorithm>
+#include <cstdlib>
+
 using vespalib::make_string_short::fmt;
 
 namespace {
@@ -56,6 +59,8 @@ RankSetup::RankSetup(const BlueprintFactory& factory, const IIndexEnvironment& i
       _match_features(),
       _summaryFeatures(),
       _dumpFeatures(),
+      _sort_features(),
+      _sort_resolver_by_public(),
       _warnings(),
       _feature_rename_map(),
       _sort_blueprints_by_cost(false),
@@ -102,6 +107,9 @@ void RankSetup::configure() {
     std::vector<std::string> dumpFeatures = dump::Feature::lookup(_indexEnv.getProperties());
     for (const auto& feature : dumpFeatures) {
         addDumpFeature(feature);
+    }
+    for (const auto& feature : sort::Feature::lookup(_indexEnv.getProperties())) {
+        add_sort_feature(feature);
     }
     for (const auto& rename : feature_rename::Rename::lookup(_indexEnv.getProperties())) {
         _feature_rename_map[rename.first] = rename.second;
@@ -179,6 +187,11 @@ void RankSetup::addDumpFeature(const std::string& dumpFeature) {
     _dumpFeatures.push_back(dumpFeature);
 }
 
+void RankSetup::add_sort_feature(const std::string& sort_feature) {
+    assert(!_compiled);
+    _sort_features.push_back(sort_feature);
+}
+
 void RankSetup::compileAndCheckForErrors(BlueprintResolver& bpr) {
     bool ok = bpr.compile();
     if (!ok) {
@@ -229,6 +242,49 @@ bool RankSetup::compile() {
     compileAndCheckForErrors(*_second_phase_resolver);
     compileAndCheckForErrors(*_match_resolver);
     compileAndCheckForErrors(*_summary_resolver);
+    std::map<std::string, BlueprintResolver::SP> unique_by_backend;
+    for (const auto& backend : _sort_features) {
+        auto                  existing = unique_by_backend.find(backend);
+        BlueprintResolver::SP resolver;
+        if (existing != unique_by_backend.end()) {
+            resolver = existing->second;
+        } else {
+            resolver = std::make_shared<BlueprintResolver>(_factory, _indexEnv);
+            resolver->addSeed(backend);
+            compileAndCheckForErrors(*resolver);
+            if (!_compileError) {
+                const auto& seeds = resolver->getSeedMap();
+                if (seeds.size() != 1) {
+                    _warnings.emplace_back(
+                        fmt("sort feature '%s' did not compile as a single seed", backend.c_str()));
+                    _compileError = true;
+                } else {
+                    auto        seed = seeds.begin()->second;
+                    const auto& specs = resolver->getExecutorSpecs();
+                    if (specs[seed.executor].output_types[seed.output].is_object()) {
+                        _warnings.emplace_back(
+                            fmt("sort feature '%s' must produce a double, not an object", backend.c_str()));
+                        _compileError = true;
+                    }
+                    for (const auto& spec : specs) {
+                        const auto& base = spec.blueprint->getBaseName();
+                        if (base == "firstPhaseRank" || base == "firstPhaseMax") {
+                            _warnings.emplace_back(
+                                fmt("sort feature '%s' cannot depend on %s", backend.c_str(), base.c_str()));
+                            _compileError = true;
+                        }
+                    }
+                }
+            }
+            unique_by_backend[backend] = resolver;
+        }
+        std::string public_name = backend;
+        auto        rename = _feature_rename_map.find(backend);
+        if (rename != _feature_rename_map.end()) {
+            public_name = rename->second;
+        }
+        _sort_resolver_by_public[public_name] = resolver;
+    }
     _indexEnv.hintFeatureMotivation(IIndexEnvironment::DUMP);
     compileAndCheckForErrors(*_dumpResolver);
     _compiled = true;
@@ -248,6 +304,34 @@ void RankSetup::prepareSharedState(const IQueryEnvironment& queryEnv, IObjectSto
     }
     for (const auto& spec : _summary_resolver->getExecutorSpecs()) {
         spec.blueprint->prepareSharedState(queryEnv, objectStore);
+    }
+}
+
+RankProgram::UP RankSetup::create_sort_program(const std::string& public_name) const {
+    auto it = _sort_resolver_by_public.find(public_name);
+    if (it == _sort_resolver_by_public.end() || !it->second) {
+        abort();
+    }
+    return std::make_unique<RankProgram>(it->second);
+}
+
+void RankSetup::prepare_sort_shared_state(const IQueryEnvironment& queryEnv, IObjectStore& objectStore,
+                                          const std::vector<std::string>& selected_public_names) const {
+    assert(_compiled && !_compileError);
+    std::vector<const BlueprintResolver*> prepared;
+    for (const auto& public_name : selected_public_names) {
+        auto it = _sort_resolver_by_public.find(public_name);
+        if (it == _sort_resolver_by_public.end() || !it->second) {
+            abort();
+        }
+        const BlueprintResolver* resolver = it->second.get();
+        if (std::find(prepared.begin(), prepared.end(), resolver) != prepared.end()) {
+            continue;
+        }
+        prepared.push_back(resolver);
+        for (const auto& spec : resolver->getExecutorSpecs()) {
+            spec.blueprint->prepareSharedState(queryEnv, objectStore);
+        }
     }
 }
 

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.h
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.h
@@ -11,6 +11,7 @@
 #include <vespa/searchlib/common/stringmap.h>
 #include <vespa/vespalib/fuzzy/fuzzy_matching_algorithm.h>
 
+#include <map>
 #include <optional>
 
 namespace search::fef {
@@ -39,62 +40,64 @@ public:
     };
 
 private:
-    const BlueprintFactory&          _factory;
-    const IIndexEnvironment&         _indexEnv;
-    BlueprintResolver::SP            _first_phase_resolver;
-    BlueprintResolver::SP            _second_phase_resolver;
-    BlueprintResolver::SP            _match_resolver;
-    BlueprintResolver::SP            _summary_resolver;
-    BlueprintResolver::SP            _dumpResolver;
-    std::string                      _firstPhaseRankFeature;
-    std::string                      _secondPhaseRankFeature;
-    std::string                      _degradationAttribute;
-    double                           _termwise_limit;
-    uint32_t                         _numThreads;
-    uint32_t                         _minHitsPerThread;
-    uint32_t                         _numSearchPartitions;
-    uint32_t                         _heapSize;
-    uint32_t                         _arraySize;
-    uint32_t                         _estimatePoint;
-    uint32_t                         _estimateLimit;
-    uint32_t                         _degradationMaxHits;
-    double                           _degradationMaxFilterCoverage;
-    double                           _degradationSamplePercentage;
-    double                           _degradationPostFilterMultiplier;
-    std::optional<feature_t>         _first_phase_rank_score_drop_limit;
-    std::optional<feature_t>         _second_phase_rank_score_drop_limit;
-    std::vector<std::string>         _match_features;
-    std::vector<std::string>         _summaryFeatures;
-    std::vector<std::string>         _dumpFeatures;
-    Warnings                         _warnings;
-    StringStringMap                  _feature_rename_map;
-    bool                             _sort_blueprints_by_cost;
-    bool                             _ignoreDefaultRankFeatures;
-    bool                             _compiled;
-    bool                             _compileError;
-    bool                             _degradationAscendingOrder;
-    std::string                      _diversityAttribute;
-    uint32_t                         _diversityMinGroups;
-    double                           _diversityCutoffFactor;
-    std::string                      _diversityCutoffStrategy;
-    bool                             _softTimeoutEnabled;
-    double                           _softTimeoutTailCost;
-    double                           _global_filter_lower_limit;
-    double                           _global_filter_upper_limit;
-    double                           _filter_first_upper_limit;
-    double                           _filter_first_exploration;
-    double                           _exploration_slack;
-    bool                             _prefetch_tensors;
-    double                           _target_hits_max_adjustment_factor;
-    double                           _weakand_stop_word_adjust_limit;
-    double                           _weakand_stop_word_drop_limit;
-    bool                             _weakand_allow_drop_all;
-    vespalib::FuzzyMatchingAlgorithm _fuzzy_matching_algorithm;
-    MutateOperation                  _mutateOnMatch;
-    MutateOperation                  _mutateOnFirstPhase;
-    MutateOperation                  _mutateOnSecondPhase;
-    MutateOperation                  _mutateOnSummary;
-    bool                             _mutateAllowQueryOverride;
+    const BlueprintFactory&                      _factory;
+    const IIndexEnvironment&                     _indexEnv;
+    BlueprintResolver::SP                        _first_phase_resolver;
+    BlueprintResolver::SP                        _second_phase_resolver;
+    BlueprintResolver::SP                        _match_resolver;
+    BlueprintResolver::SP                        _summary_resolver;
+    BlueprintResolver::SP                        _dumpResolver;
+    std::string                                  _firstPhaseRankFeature;
+    std::string                                  _secondPhaseRankFeature;
+    std::string                                  _degradationAttribute;
+    double                                       _termwise_limit;
+    uint32_t                                     _numThreads;
+    uint32_t                                     _minHitsPerThread;
+    uint32_t                                     _numSearchPartitions;
+    uint32_t                                     _heapSize;
+    uint32_t                                     _arraySize;
+    uint32_t                                     _estimatePoint;
+    uint32_t                                     _estimateLimit;
+    uint32_t                                     _degradationMaxHits;
+    double                                       _degradationMaxFilterCoverage;
+    double                                       _degradationSamplePercentage;
+    double                                       _degradationPostFilterMultiplier;
+    std::optional<feature_t>                     _first_phase_rank_score_drop_limit;
+    std::optional<feature_t>                     _second_phase_rank_score_drop_limit;
+    std::vector<std::string>                     _match_features;
+    std::vector<std::string>                     _summaryFeatures;
+    std::vector<std::string>                     _dumpFeatures;
+    std::vector<std::string>                     _sort_features;
+    std::map<std::string, BlueprintResolver::SP> _sort_resolver_by_public;
+    Warnings                                     _warnings;
+    StringStringMap                              _feature_rename_map;
+    bool                                         _sort_blueprints_by_cost;
+    bool                                         _ignoreDefaultRankFeatures;
+    bool                                         _compiled;
+    bool                                         _compileError;
+    bool                                         _degradationAscendingOrder;
+    std::string                                  _diversityAttribute;
+    uint32_t                                     _diversityMinGroups;
+    double                                       _diversityCutoffFactor;
+    std::string                                  _diversityCutoffStrategy;
+    bool                                         _softTimeoutEnabled;
+    double                                       _softTimeoutTailCost;
+    double                                       _global_filter_lower_limit;
+    double                                       _global_filter_upper_limit;
+    double                                       _filter_first_upper_limit;
+    double                                       _filter_first_exploration;
+    double                                       _exploration_slack;
+    bool                                         _prefetch_tensors;
+    double                                       _target_hits_max_adjustment_factor;
+    double                                       _weakand_stop_word_adjust_limit;
+    double                                       _weakand_stop_word_drop_limit;
+    bool                                         _weakand_allow_drop_all;
+    vespalib::FuzzyMatchingAlgorithm             _fuzzy_matching_algorithm;
+    MutateOperation                              _mutateOnMatch;
+    MutateOperation                              _mutateOnFirstPhase;
+    MutateOperation                              _mutateOnSecondPhase;
+    MutateOperation                              _mutateOnSummary;
+    bool                                         _mutateAllowQueryOverride;
 
     void compileAndCheckForErrors(BlueprintResolver& bp);
 
@@ -411,6 +414,13 @@ public:
      * @param dumpFeature full feature name of a dump feature
      **/
     void addDumpFeature(const std::string& dumpFeature);
+    /**
+     * Adds the backend name of a rank feature allowed as a sort key.
+     *
+     * @param sort_feature full backend feature name
+     **/
+    void add_sort_feature(const std::string& sort_feature);
+    const std::vector<std::string>& get_sort_features() const { return _sort_features; }
 
     /**
      * Returns a const view of the dump features added.
@@ -451,6 +461,17 @@ public:
     RankProgram::UP create_match_program() const { return std::make_unique<RankProgram>(_match_resolver); }
     RankProgram::UP create_summary_program() const { return std::make_unique<RankProgram>(_summary_resolver); }
     RankProgram::UP create_dump_program() const { return std::make_unique<RankProgram>(_dumpResolver); }
+
+    bool has_sort_feature(const std::string& public_name) const {
+        return _sort_resolver_by_public.contains(public_name);
+    }
+    RankProgram::UP create_sort_program(const std::string& public_name) const;
+
+    /**
+     * Prepare shared state only for the unique resolvers selected by public name.
+     **/
+    void prepare_sort_shared_state(const IQueryEnvironment& queryEnv, IObjectStore& objectStore,
+                                   const std::vector<std::string>& selected_public_names) const;
 
     /**
      * Here you can do some preprocessing. State must be stored in the IObjectStore.


### PR DESCRIPTION
Adds a `feature(...)` sort function so content nodes can sort by a rank-profile scalar, authorized by a new `sort-features` allowlist on the rank profile.

```sd
rank-profile products {
    function popularity_score() {
      expression: attribute(popularity)
    }
    function title_bm25() {
      expression: bm25(title)
    }
    sort-features {
      popularity_score
      title_bm25
    }
}
```

```text
sorting=-feature(popularity_score) +feature(title_bm25) -some_attribute_field
```

We compute the selected feature values during matching, then encode them into sort blobs the same way we encode numeric attributes.

## Notes

- **`feature` takes one bare schema identifier**, naming a numeric native feature or a zero-argument profile function. Parameterized refs (e.g. `bm25(title)`), need to be wrapped in another function.
- **Only query-selected features are prepared or instantiated.** Unused allowlist entries cost deploy-time compilation.
- **Second phase now only if needed (e.g., ask for `[rank]`).** Otherwise, an (unused) second phase could drop hits that we need. This was also a problem before (which we are fixing), but less so (e.g., NoRankingSearcher would use `unranked`)
- **Selecting a feature does not turn ranking on.** `willNeedRanking` is unchanged, so feature-sorted hits usually carry `relevance: 0`. `[rank]` stays the activator.

## Deferred for now

Can be separate PRs (trying to keep this monster in check):
- Schema language server
- Streaming search
- Shared rank-program graphs (i.e., don't duplicate rank computation for each hit, if they reuse parts of the ranking logic)
- Allocate top-K sort blobs instead of all of them, when grouping is off

We also don't support mixed-version clusters (assuming we need to completely upgrade to use this feature).

## Relevant benchmarks

Many more done and OK, omitted for brevity. 1M docs, local Podman container.

Backend `querytime`, mean of 30 after 5 warm-ups:

| case, hits=1000 | query avg |
|---|---|
| `+sort_value`, no `sort-features` declared | 36.57 ms |
| `+sort_value`, allowlist declared but unused by the query | 34.43 ms |
| `+feature(...)`, 1 key | 48.5 ms |
| `+feature(...)`, 2 keys | 59.2 ms |
| `+feature(...)`, 3 keys | 67.7 ms |
| `+feature(...)`, 1 document-dependent key (64-cell tensor × attribute) | 234.8 ms |

Released 8.738.17 sorting the same corpus by attribute is 34.97 ms, so an **unused allowlist is basically free** and **attribute sort works as before**. The wrapper anti-pattern (`+feature(f)` where `f` is `attribute(sort_value)`) costs ~13 ns/matched doc.

vespa-fbench: 8-client QPS ~0.77× attribute sort, 0 failures.

#### `RssAnon` for Proton only, restarted per variant:

Same test as above.

| case | idle | peak | peak − idle |
|---|---|---|---|
| `+sort_value`, 1 client | 177.3 MiB | 245.4 MiB | 68.0 MiB |
| `+feature(...)` 1 key, 1 client | 171.3 MiB | 253.4 MiB | 82.1 MiB |
| `+feature(...)` 3 keys, 1 client | 171.3 MiB | 293.4 MiB | 122.1 MiB |

This is close to the expected (uint32 docid + F doubles): at 1 key and 1M rows that is ~11.45 MiB, live during matching and blob construction, released before radix sort allocates its buffer.