### PR TITLE
Resolve connections through a per-generation snapshot of the node set

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -266,7 +266,11 @@ public class Dispatcher extends AbstractComponent {
         return new VolatileItems(new LoadBalancer(searchCluster.groupList().groups(),
                                                   toLoadBalancerPolicy(dispatchConfig.distributionPolicy()),
                                                   localAvailabilityZone),
-                                 invokerFactories.create(rpcResourcePool, searchCluster.groupList(), dispatchConfig, qrSearchersConfig));
+                                 // Invokers of this generation resolve connections through a snapshot of the node set,
+                                 // so nodes removed by a later reconfiguration stay resolvable until this generation drains.
+                                 // The pool is null in some tests, which use invoker factories that don't need it.
+                                 invokerFactories.create(rpcResourcePool == null ? null : rpcResourcePool.snapshot(),
+                                                         searchCluster.groupList(), dispatchConfig, qrSearchersConfig));
     }
 
     private void initialWarmup(double warmupTime) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcConnectionPool.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcConnectionPool.java
@@ -16,6 +16,14 @@ public interface RpcConnectionPool extends AutoCloseable {
     /** Returns a connection to the given node id. */
     Client.NodeConnection getConnection(int nodeId);
 
+    /**
+     * Returns an immutable view of the current node set, for use by a single generation of invokers.
+     * Resolving connections through such a view keeps nodes removed by a later node set update
+     * resolvable until the generation's queries have drained, while the underlying connections
+     * are kept open by the delayed close of updateNodes.
+     */
+    default RpcConnectionPool snapshot() { return this; }
+
     /** Will return a list of items that need a delayed close when updating node set. */
     default Collection<? extends AutoCloseable> updateNodes(DispatchNodesConfig nodesConfig) { return List.of(); }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcResourcePool.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcResourcePool.java
@@ -77,6 +77,46 @@ public class RpcResourcePool implements RpcConnectionPool {
     }
 
     @Override
+    public RpcConnectionPool snapshot() {
+        return new View(nodeConnectionPools);
+    }
+
+    /**
+     * An immutable view of one generation of the node set. Queries of a generation resolve
+     * connections through this, so a node removed by a later node set update stays resolvable
+     * to them: updateNodes leaves its connections open until the generation has drained.
+     */
+    private static class View implements RpcConnectionPool {
+
+        private final Map<Integer, NodeConnectionPool> pools;
+
+        View(Map<Integer, NodeConnectionPool> pools) { this.pools = Map.copyOf(pools); }
+
+        @Override
+        public NodeConnection getConnection(int nodeId) {
+            var pool = pools.get(nodeId);
+            return pool == null ? null : pool.nextConnection();
+        }
+
+        @Override
+        public Collection<Integer> knownNodeIds() { return pools.keySet(); }
+
+        @Override
+        public RpcConnectionPool snapshot() { return this; }
+
+        @Override
+        public Collection<? extends AutoCloseable> updateNodes(DispatchNodesConfig nodesConfig) {
+            throw new UnsupportedOperationException("Immutable view of the node set");
+        }
+
+        @Override
+        public void close() {
+            throw new UnsupportedOperationException("Views do not own the connections");
+        }
+
+    }
+
+    @Override
     public void close() {
         nodeConnectionPools.values().forEach(NodeConnectionPool::close);
         if (rpcClient != null) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcResourcePoolTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcResourcePoolTest.java
@@ -1,0 +1,83 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.rpc;
+
+import com.yahoo.search.dispatch.rpc.RpcClient.RpcNodeConnection;
+import com.yahoo.vespa.config.search.DispatchConfig;
+import com.yahoo.vespa.config.search.DispatchNodesConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author andreer
+ */
+public class RpcResourcePoolTest {
+
+    @Test
+    void snapshotKeepsRemovedNodesResolvableWhileItsGenerationDrains() {
+        var pool = new RpcResourcePool(dispatchConfig(), nodesConfig(0, 1));
+        var oldGeneration = pool.snapshot();
+
+        pool.updateNodes(nodesConfig(0)); // Node 1 removed; its connections stay open for delayed close
+
+        // Queries in flight against the old topology must still be able to reach node 1,
+        // which is still up: only the config no longer includes it.
+        assertNotNull(oldGeneration.getConnection(1));
+        // New generations must not see it.
+        assertNull(pool.snapshot().getConnection(1));
+        assertEquals(Set.of(0), Set.copyOf(pool.snapshot().knownNodeIds()));
+        pool.close();
+    }
+
+    @Test
+    void reAddedNodeGetsFreshConnectionsIndependentOfTheOldGeneration() {
+        var pool = new RpcResourcePool(dispatchConfig(), nodesConfig(0, 1));
+        var oldGeneration = pool.snapshot();
+        var oldConnection = oldGeneration.getConnection(1);
+
+        pool.updateNodes(nodesConfig(0));    // remove node 1
+        pool.updateNodes(nodesConfig(0, 1)); // then add it back
+
+        var newConnection = pool.snapshot().getConnection(1);
+        assertNotNull(newConnection);
+        assertNotSame(oldConnection, newConnection);
+        assertNotNull(oldGeneration.getConnection(1), "the old generation keeps its own view");
+        pool.close();
+    }
+
+    @Test
+    void nodeChangingAddressIsReplacedInNewSnapshotsOnly() {
+        var pool = new RpcResourcePool(dispatchConfig(), nodesConfig(0, 1));
+        var oldGeneration = pool.snapshot();
+
+        pool.updateNodes(new DispatchNodesConfig.Builder()
+                                 .node(node(0))
+                                 .node(new DispatchNodesConfig.Node.Builder()
+                                               .key(1).host("host-b1").port(19101).group(0))
+                                 .build());
+
+        assertEquals("host-b1", ((RpcNodeConnection) pool.snapshot().getConnection(1)).getHostname());
+        assertEquals("host1", ((RpcNodeConnection) oldGeneration.getConnection(1)).getHostname());
+        pool.close();
+    }
+
+    private DispatchConfig dispatchConfig() {
+        return new DispatchConfig.Builder().numJrtConnectionsPerNode(1).numJrtTransportThreads(1).build();
+    }
+
+    private DispatchNodesConfig nodesConfig(int... keys) {
+        var builder = new DispatchNodesConfig.Builder();
+        for (int key : keys) builder.node(node(key));
+        return builder.build();
+    }
+
+    private DispatchNodesConfig.Node.Builder node(int key) {
+        return new DispatchNodesConfig.Node.Builder().key(key).host("host" + key).port(19100 + key).group(0);
+    }
+
+}


### PR DESCRIPTION
@arnej27959 I'm in over my head on this so please help me figure out if this makes sense, or if it'd be better for me to submit this is a ticket/issue, with details of the observed failures 🙂

Here's the theory: Dispatcher reconfiguration delays closing connections of removed nodes until queries in flight against the old topology have completed, but the invokers look up connections in the shared, mutable RpcResourcePool, which drops removed nodes from its map immediately. Queries running against the old topology then fail with 'Could not send search to unknown node N' (or the fill variant) even though the node is still up and its connections still open. Observed as bursts of a few hundred code-10 errors per node removed when scaling down.

Give each generation of invokers an immutable snapshot of the node set instead, created together with the invoker factory it belongs to. The connections of removed nodes are kept open by the existing delayed close, so the last generation referencing them can use them until it has drained.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
