### PR TITLE
Shutdown config servers maintainers as early as possible

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
@@ -110,11 +110,12 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
     @Override
     public void deconstruct() {
         log.log(Level.FINE, "Stopping config server");
+        configServerMaintenance.signalShutdown(); // Stop maintainers now, don't wait for RPC server draining below
         down();
         server.stop();
         log.log(Level.FINE, "RPC server stopped");
         rpcServerExecutor.shutdown();
-        configServerMaintenance.shutdown();
+        configServerMaintenance.awaitShutdown();
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
@@ -61,9 +61,19 @@ public class ConfigServerMaintenance {
         }
     }
 
-    public void shutdown() {
+    /** Signals all maintainers to stop, without waiting for them to finish. */
+    public void signalShutdown() {
         maintainers.forEach(Maintainer::shutdown);
+    }
+
+    /** Waits for all maintainers to finish shutting down, signalling shutdown first if not already done. */
+    public void awaitShutdown() {
         maintainers.forEach(Maintainer::awaitShutdown);
+    }
+
+    public void shutdown() {
+        signalShutdown();
+        awaitShutdown();
     }
 
     public List<Maintainer> maintainers() { return List.copyOf(maintainers); }


### PR DESCRIPTION
E.g. doing a deployment from a maintainer while shutting down might lead to issues, one we have seen is deploying right before shutdown, then replacing the disk (e.g. when upgrading OS), then we seem to have lost a file from the file distribution db (on disk)