### PR TITLE
Revert "chore(deps): update dependency biz.aqute.bnd:biz.aqute.bndlib to v7.4.0"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
                         <dependency>
                             <groupId>biz.aQute.bnd</groupId>
                             <artifactId>biz.aQute.bndlib</artifactId>
-                            <version>7.4.0</version>
+                            <version>7.3.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
Reverts vespa-engine/vespa#37647

Worked locally, but failed when building on factory