### PR TITLE
Add flag to relax strictly increasing cluster state version requirement

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1461,7 +1461,8 @@
       "public boolean failWhenConfiguringIndexedMapOfArray()",
       "public boolean protonLogWarningOnDiskCapacityChange()",
       "public boolean protonResampleDiskCapacity()",
-      "public boolean fastMapSearch()"
+      "public boolean fastMapSearch()",
+      "public boolean relaxStrictlyIncreasingClusterStateVersions()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -136,6 +136,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"johsol"}, removeAfter = "8.740") default boolean protonLogWarningOnDiskCapacityChange() { return true; }
         @ModelFeatureFlag(owners = {"johsol"}, removeAfter = "8.740") default boolean protonResampleDiskCapacity() { return true; }
         @ModelFeatureFlag(owners = {"johsol", "boeker", "arnej"}) default boolean fastMapSearch() { return false; }
+        @ModelFeatureFlag(owners = {"hmusum"}) default boolean relaxStrictlyIncreasingClusterStateVersions() { return false; }
     }
 
     /** Warning: As elsewhere in this package, do not make backwards incompatible changes that will break old config models! */

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -84,6 +84,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private double searchNodeReservedMemoryFactor = 0.0;
     private boolean failWhenConfiguringIndexedMapOfArray = true;
     private boolean fastMapSearch = false;
+    private boolean relaxStrictlyIncreasingClusterStateVersions = false;
 
     @Override public ModelContext.FeatureFlags featureFlags() { return this; }
     @Override public boolean multitenant() { return multitenant; }
@@ -146,6 +147,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public double searchNodeReservedMemoryFactor() { return searchNodeReservedMemoryFactor; }
     @Override public boolean failWhenConfiguringIndexedMapOfArray() { return failWhenConfiguringIndexedMapOfArray; }
     @Override public boolean fastMapSearch() { return fastMapSearch; }
+    @Override public boolean relaxStrictlyIncreasingClusterStateVersions() { return relaxStrictlyIncreasingClusterStateVersions; }
 
 
     public TestProperties maxUnCommittedMemory(int maxUnCommittedMemory) {
@@ -374,6 +376,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties fastMapSearch(boolean value) {
         this.fastMapSearch = value;
+        return this;
+    }
+
+    public TestProperties relaxStrictlyIncreasingClusterStateVersions(boolean value) {
+        this.relaxStrictlyIncreasingClusterStateVersions = value;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -163,6 +163,7 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
         builder.root_folder("");
         builder.cluster_name(parent.getName());
         builder.is_distributor(true);
+        builder.require_strictly_increasing_cluster_state_versions(parent.requireStrictlyIncreasingClusterStateVersions());
     }
 
     public String getClusterName() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -100,6 +100,8 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
     private Integer maxNodesPerMerge;
     private final Zone zone;
     private final Optional<Integer> distributionBitsInPreviousModel;
+    private final boolean relaxStrictlyIncreasingClusterStateVersions;
+    private boolean singleClusterController = false;
 
     public enum DistributionMode { LEGACY, STRICT, LOOSE }
     private DistributionMode distributionMode;
@@ -377,6 +379,8 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
                 }
                 clusterControllers = admin.getClusterControllers();
             }
+            contentCluster.singleClusterController = clusterControllers.getContainers().size() == 1;
+
             // Update node count so we can keep track of how many content nodes there are in total
             clusterControllers.updateNodeCount(contentCluster.getNodeCount());
 
@@ -467,6 +471,7 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
         this.documentSelection = routingSelection;
         this.zone = deployState.zone();
         this.distributionBitsInPreviousModel = distributionBitsInPreviousModel(deployState, clusterId);
+        this.relaxStrictlyIncreasingClusterStateVersions = deployState.featureFlags().relaxStrictlyIncreasingClusterStateVersions();
     }
 
     public ClusterSpec.Id id() { return ClusterSpec.Id.from(clusterId); }
@@ -601,6 +606,16 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
 
     public boolean isHosted() {
         return isHosted;
+    }
+
+    /**
+     * Returns whether cluster state versions received by content nodes must be strictly increasing.
+     * This safety check can only be relaxed when the {@code relax-strictly-increasing-cluster-state-versions}
+     * feature flag is enabled AND this deployment has exactly one cluster controller configured, as the race
+     * condition it guards against requires more than one cluster controller to occur.
+     */
+    public boolean requireStrictlyIncreasingClusterStateVersions() {
+        return !(relaxStrictlyIncreasingClusterStateVersions && singleClusterController);
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
@@ -27,10 +27,11 @@ public class StorageCluster extends TreeConfigProducer<StorageNode>
         MetricsmanagerConfig.Producer
 {
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilderBase<StorageCluster> {
+
         @Override
         protected StorageCluster doBuild(DeployState deployState, TreeConfigProducer<AnyConfigProducer> ancestor, Element producerSpec) {
             ModelElement clusterElem = new ModelElement(producerSpec);
-            return new StorageCluster(ancestor,
+            return new StorageCluster((ContentCluster) ancestor,
                                       ContentCluster.getClusterId(clusterElem),
                                       new FileStorProducer.Builder().build(deployState.getProperties(), clusterElem),
                                       new StorServerProducer.Builder().build(clusterElem),
@@ -39,19 +40,21 @@ public class StorageCluster extends TreeConfigProducer<StorageNode>
         }
     }
 
+    private final ContentCluster parent;
     private final String clusterName;
     private final FileStorProducer fileStorProducer;
     private final StorServerProducer storServerProducer;
     private final StorVisitorProducer storVisitorProducer;
     private final PersistenceProducer persistenceProducer;
 
-    StorageCluster(TreeConfigProducer<?> parent,
+    StorageCluster(ContentCluster parent,
                    String clusterName,
                    FileStorProducer fileStorProducer,
                    StorServerProducer storServerProducer,
                    StorVisitorProducer storVisitorProducer,
                    PersistenceProducer persistenceProducer) {
         super(parent, "storage");
+        this.parent = parent;
         this.clusterName = clusterName;
         this.fileStorProducer = fileStorProducer;
         this.storServerProducer = storServerProducer;
@@ -83,6 +86,7 @@ public class StorageCluster extends TreeConfigProducer<StorageNode>
     @Override
     public void getConfig(StorServerConfig.Builder builder) {
         storServerProducer.getConfig(builder);
+        builder.require_strictly_increasing_cluster_state_versions(parent.requireStrictlyIncreasingClusterStateVersions());
     }
 
     @Override

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1324,9 +1324,14 @@ public class ContentClusterTest extends ContentBaseTest {
 
 
     private ContentCluster createWithZone(String clusterXml, Zone zone) throws Exception {
+        return createWithZone(clusterXml, zone, false);
+    }
+
+    private ContentCluster createWithZone(String clusterXml, Zone zone, boolean relaxStrictlyIncreasingClusterStateVersions) throws Exception {
         DeployState.Builder deployStateBuilder = new DeployState.Builder()
                 .zone(zone);
-        var properties = new TestProperties().setHostedVespa(true);
+        var properties = new TestProperties().setHostedVespa(true)
+                .relaxStrictlyIncreasingClusterStateVersions(relaxStrictlyIncreasingClusterStateVersions);
         deployStateBuilder.properties(properties);
 
         List<String> schemas = SchemaBuilder.createSchemas("test");
@@ -1698,6 +1703,78 @@ public class ContentClusterTest extends ContentBaseTest {
     @Test
     void strictly_increasing_cluster_state_versions_config() throws Exception {
         checkStrictlyIncreasingClusterStateVersionConfig(true);
+    }
+
+    private void checkStrictlyIncreasingClusterStateVersionConfigForZone(Zone zone,
+                                                                         boolean relaxStrictlyIncreasingClusterStateVersions,
+                                                                         boolean expected) throws Exception {
+        String xml = new ContentClusterBuilder().docTypes("test").getXml();
+        var cc = createWithZone(xml, zone, relaxStrictlyIncreasingClusterStateVersions);
+
+        // stor-server config should be the same for both distributors and storage nodes
+        var builder = new StorServerConfig.Builder();
+        cc.getStorageCluster().getConfig(builder);
+        var cfg = builder.build();
+        assertEquals(expected, cfg.require_strictly_increasing_cluster_state_versions());
+
+        builder = new StorServerConfig.Builder();
+        cc.getDistributorNodes().getConfig(builder);
+        cfg = builder.build();
+        assertEquals(expected, cfg.require_strictly_increasing_cluster_state_versions());
+    }
+
+    @Test
+    void strictly_increasing_cluster_state_versions_config_is_disabled_with_a_single_cluster_controller_when_flag_is_enabled() throws Exception {
+        // Dev zones get a single dedicated cluster controller, so the version check is unnecessary there,
+        // but only once the relax-strictly-increasing-cluster-state-versions feature flag is enabled.
+        checkStrictlyIncreasingClusterStateVersionConfigForZone(new Zone(Environment.dev, RegionName.from("us-east-3")), true, false);
+    }
+
+    @Test
+    void strictly_increasing_cluster_state_versions_config_stays_enabled_with_a_single_cluster_controller_when_flag_is_disabled() throws Exception {
+        // The relaxation must never happen unless explicitly enabled through the feature flag.
+        checkStrictlyIncreasingClusterStateVersionConfigForZone(new Zone(Environment.dev, RegionName.from("us-east-3")), false, true);
+    }
+
+    @Test
+    void strictly_increasing_cluster_state_versions_config_stays_enabled_with_multiple_cluster_controllers_even_when_flag_is_enabled() throws Exception {
+        // Self-hosted deployments with more than one config server get one cluster controller per config server.
+        // The version check must never be disabled when there is more than one cluster controller, regardless of the flag.
+        List<String> sds = ApplicationPackageUtils.generateSchemas("type1");
+        String xml = """
+                <services>
+                  <admin version="2.0">
+                    <adminserver hostalias="node0" />
+                    <configservers>
+                      <configserver hostalias="node0"/>
+                      <configserver hostalias="node1"/>
+                      <configserver hostalias="node2"/>
+                    </configservers>
+                  </admin>
+                  <content version="1.0" id="bar">
+                    <redundancy>1</redundancy>
+                    <documents>
+                      <document type="type1" mode="store-only"/>
+                    </documents>
+                    <group>
+                      <node hostalias="node0" distribution-key="0" />
+                    </group>
+                  </content>
+                </services>
+                """;
+        var properties = new TestProperties().relaxStrictlyIncreasingClusterStateVersions(true);
+        DeployState.Builder deployStateBuilder = new DeployState.Builder().properties(properties);
+        VespaModel model = new VespaModelCreatorWithMockPkg(null, xml, sds).create(deployStateBuilder);
+        assertTrue(model.getAdmin().getClusterControllers().getContainers().size() > 1);
+
+        ContentCluster cc = model.getContentClusters().get("bar");
+        var builder = new StorServerConfig.Builder();
+        cc.getStorageCluster().getConfig(builder);
+        assertTrue(builder.build().require_strictly_increasing_cluster_state_versions());
+
+        builder = new StorServerConfig.Builder();
+        cc.getDistributorNodes().getConfig(builder);
+        assertTrue(builder.build().require_strictly_increasing_cluster_state_versions());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1778,6 +1778,45 @@ public class ContentClusterTest extends ContentBaseTest {
     }
 
     @Test
+    void strictly_increasing_cluster_state_versions_config_is_disabled_with_a_single_config_server_when_flag_is_enabled() throws Exception {
+        // Self-hosted deployments with a single config server also get a single cluster controller,
+        // so the version check can be relaxed there once the feature flag is enabled.
+        List<String> sds = ApplicationPackageUtils.generateSchemas("type1");
+        String xml = """
+                <services>
+                  <admin version="2.0">
+                    <adminserver hostalias="node0" />
+                    <configservers>
+                      <configserver hostalias="node0"/>
+                    </configservers>
+                  </admin>
+                  <content version="1.0" id="bar">
+                    <redundancy>1</redundancy>
+                    <documents>
+                      <document type="type1" mode="store-only"/>
+                    </documents>
+                    <group>
+                      <node hostalias="node0" distribution-key="0" />
+                    </group>
+                  </content>
+                </services>
+                """;
+        var properties = new TestProperties().relaxStrictlyIncreasingClusterStateVersions(true);
+        DeployState.Builder deployStateBuilder = new DeployState.Builder().properties(properties);
+        VespaModel model = new VespaModelCreatorWithMockPkg(null, xml, sds).create(deployStateBuilder);
+        assertEquals(1, model.getAdmin().getClusterControllers().getContainers().size());
+
+        ContentCluster cc = model.getContentClusters().get("bar");
+        var builder = new StorServerConfig.Builder();
+        cc.getStorageCluster().getConfig(builder);
+        assertFalse(builder.build().require_strictly_increasing_cluster_state_versions());
+
+        builder = new StorServerConfig.Builder();
+        cc.getDistributorNodes().getConfig(builder);
+        assertFalse(builder.build().require_strictly_increasing_cluster_state_versions());
+    }
+
+    @Test
     void testResourceLimitsForSmallNodes() throws Exception {
         var services = """
                 <services>

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -263,6 +263,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean forceDisableOnnxModelOptimization() { return flag(PermanentFlags.FORCE_DISABLE_ONNX_MODEL_OPTIMIZATION).value(); }
         @Override public boolean failWhenConfiguringIndexedMapOfArray() { return flag(Flags.FAIL_WHEN_CONFIGURING_INDEXED_MAP_OF_ARRAY).value(); }
         @Override public boolean fastMapSearch() { return flag(Flags.FAST_MAP_SEARCH).value(); }
+        @Override public boolean relaxStrictlyIncreasingClusterStateVersions() { return flag(Flags.RELAX_STRICTLY_INCREASING_CLUSTER_STATE_VERSIONS).value(); }
 
         private static OptionalInt toOptionalInt(int value) {
             return value > 0 ? OptionalInt.of(value) : OptionalInt.empty();

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -266,7 +266,7 @@ public class Flags {
 
     public static final UnboundBooleanFlag RELAX_STRICTLY_INCREASING_CLUSTER_STATE_VERSIONS = defineFeatureFlag(
             "relax-strictly-increasing-cluster-state-versions", false,
-            List.of("hmusum"), "2026-08-24", "2026-12-24",
+            List.of("hmusum"), "2026-08-24", "2027-01-24",
             "Whether to allow disabling the requirement that cluster state versions are strictly " +
             "increasing when a content cluster has only a single cluster controller configured.",
             "Takes effect at redeployment",

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -264,6 +264,15 @@ public class Flags {
             INSTANCE_ID
     );
 
+    public static final UnboundBooleanFlag RELAX_STRICTLY_INCREASING_CLUSTER_STATE_VERSIONS = defineFeatureFlag(
+            "relax-strictly-increasing-cluster-state-versions", false,
+            List.of("hmusum"), "2026-08-24", "2026-12-24",
+            "Whether to allow disabling the requirement that cluster state versions are strictly " +
+            "increasing when a content cluster has only a single cluster controller configured.",
+            "Takes effect at redeployment",
+            INSTANCE_ID
+    );
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,

--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -125,4 +125,7 @@ write_pid_file_on_startup bool default=true
 ## are the leader during overlapping time intervals, as only the most recent leader
 ## is able to increment the current state version in ZooKeeper, but the old controller
 ## may still attempt to publish its old state.
+## Should be set to false when there is only one cluster controller in the system,
+## as e.g. losing cluster controller state would prevent the system from proceeding
+## if it was set to true.
 require_strictly_increasing_cluster_state_versions bool default=true


### PR DESCRIPTION
## Summary
- Adds a new feature flag `relax-strictly-increasing-cluster-state-versions` (default off) that, when enabled, allows `require_strictly_increasing_cluster_state_versions` to be disabled for a content cluster that has only a single cluster controller configured
- The requirement is never relaxed when more than one cluster controller is configured, since that's exactly the leader-race condition the check guards against — this holds regardless of the flag

---
Generated by Claude Code, with several manual changes