### PR TITLE
fast map search: include dollar in synthetic field name

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
@@ -24,7 +24,7 @@ import com.yahoo.vespa.model.container.search.QueryProfiles;
 
 
 /**
- * Adds a "_fieldName_keyvalue" attribute to maps with fast-search enabled.
+ * Adds a "fieldName$keyvalue" attribute to maps with fast-search enabled.
  *
  * The attribute holds one string per map entry, on the form key + separator + value,
  * so that a key-value pair can be matched with a single lexical lookup.

--- a/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
@@ -91,7 +91,7 @@ public class CreateFastMapSearch extends Processor {
      * impossible to declare in a schema while still being a legal identifier in the indexing language.
      */
     static String keyValueFieldName(String fieldName) {
-        return "_" + fieldName + "_keyvalue";
+        return fieldName + "$keyvalue";
     }
 
     /** Builds "input mapField | for_each { get_field $key . separator . get_field $value } | attribute". */

--- a/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests the synthetic key-value attribute created for map fields with 'map: fast-search'.
@@ -27,7 +28,7 @@ public class CreateFastMapSearchTest {
     void requireKeyValueFieldIsCreatedForFastSearchMap() throws ParseException {
         var schema = build(fastSearchMap("map<string, string>"));
 
-        SDField field = schema.getConcreteField("_foo_keyvalue");
+        SDField field = schema.getConcreteField("foo$keyvalue");
         assertNotNull(field, "Expected a synthetic key-value field");
         assertEquals(DataType.getArray(DataType.STRING), field.getDataType());
     }
@@ -36,7 +37,7 @@ public class CreateFastMapSearchTest {
     void requireKeyValueAttributeIsAFastSearchStringArray() throws ParseException {
         var schema = build(fastSearchMap("map<string, string>"));
 
-        Attribute attribute = schema.getConcreteField("_foo_keyvalue").getAttributes().get("_foo_keyvalue");
+        Attribute attribute = schema.getConcreteField("foo$keyvalue").getAttributes().get("foo$keyvalue");
         assertNotNull(attribute);
         assertEquals(Attribute.Type.STRING, attribute.getType());
         assertEquals(Attribute.CollectionType.ARRAY, attribute.getCollectionType());
@@ -47,7 +48,7 @@ public class CreateFastMapSearchTest {
     void requireKeyValueFieldIsCreatedForIntKeysAndValues() throws ParseException {
         for (String type : new String[] { "map<int, string>", "map<string, int>", "map<int, int>" }) {
             var schema = build(fastSearchMap(type));
-            assertNotNull(schema.getConcreteField("_foo_keyvalue"), "Expected key-value field for " + type);
+            assertNotNull(schema.getConcreteField("foo$keyvalue"), "Expected key-value field for " + type);
         }
     }
 
@@ -57,8 +58,8 @@ public class CreateFastMapSearchTest {
 
         var internal = schema.fieldSets().builtInFieldSets().get(BuiltInFieldSets.INTERNAL_FIELDSET_NAME);
         assertNotNull(internal);
-        assertTrue(internal.getFieldNames().contains("_foo_keyvalue"),
-                   "Expected _foo_keyvalue in " + internal.getFieldNames());
+        assertTrue(internal.getFieldNames().contains("foo$keyvalue"),
+                   "Expected foo$keyvalue in " + internal.getFieldNames());
     }
 
     @Test
@@ -67,7 +68,7 @@ public class CreateFastMapSearchTest {
                                      "  indexing: summary",
                                      "}"));
 
-        assertNull(schema.getConcreteField("_foo_keyvalue"));
+        assertNull(schema.getConcreteField("foo$keyvalue"));
     }
 
     @Test
@@ -76,7 +77,7 @@ public class CreateFastMapSearchTest {
                                      "  indexing: summary",
                                      "}"));
 
-        assertNull(schema.getConcreteField("_foo_keyvalue"));
+        assertNull(schema.getConcreteField("foo$keyvalue"));
     }
 
     @Test
@@ -93,9 +94,9 @@ public class CreateFastMapSearchTest {
                                      "  indexing: summary",
                                      "}"));
 
-        assertNotNull(schema.getConcreteField("_foo_keyvalue"));
-        assertNotNull(schema.getConcreteField("_bar_keyvalue"));
-        assertNull(schema.getConcreteField("_baz_keyvalue"));
+        assertNotNull(schema.getConcreteField("foo$keyvalue"));
+        assertNotNull(schema.getConcreteField("bar$keyvalue"));
+        assertNull(schema.getConcreteField("baz$keyvalue"));
     }
 
     /**
@@ -103,17 +104,10 @@ public class CreateFastMapSearchTest {
      * so that a user cannot declare a field colliding with it.
      */
     @Test
-    void requireUsersCannotDeclareTheKeyValueFieldName() {
-        try {
-            build(joinLines("field _foo_keyvalue type array<string> {",
-                            "  indexing: attribute",
-                            "}"));
-            throw new AssertionError("Expected exception");
-        }
-        catch (IllegalArgumentException | ParseException e) {
-            assertTrue(e.getMessage().contains("Not a legal field name"),
-                       "Unexpected message: " + e.getMessage());
-        }
+void requireUsersCannotDeclareTheKeyValueFieldName() {
+        assertThrows(ParseException.class, () -> build(joinLines("field foo$keyvalue type array<string> {",
+                        "  indexing: attribute",
+                        "}")));
     }
 
     private static String fastSearchMap(String type) {

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/OutputExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/OutputExpression.java
@@ -2,17 +2,22 @@
 package com.yahoo.vespa.indexinglanguage.expressions;
 
 import com.yahoo.document.DataType;
+import com.yahoo.text.StringUtilities;
 import com.yahoo.vespa.objects.ObjectOperation;
 import com.yahoo.vespa.objects.ObjectPredicate;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * @author Simon Thoresen Hult
  */
 public abstract class OutputExpression extends Expression {
+
+    /** Field names expressible without quotes: dot-joined indexing language identifiers. */
+    private static final Pattern identifierFieldName = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_-]*(\\.[a-zA-Z_][a-zA-Z0-9_-]*)*");
 
     private final String image;
     private final String fieldName;
@@ -50,7 +55,15 @@ public abstract class OutputExpression extends Expression {
 
     @Override
     public String toString() {
-        return image + (fieldName != null ? " " + fieldName : "");
+        return image + (fieldName != null ? " " + fieldNameImage(fieldName) : "");
+    }
+
+    /** Returns the field name in a form the indexing language parser accepts: verbatim, or quoted if necessary. */
+    private static String fieldNameImage(String fieldName) {
+        if (identifierFieldName.matcher(fieldName).matches()) {
+            return fieldName;
+        }
+        return "\"" + StringUtilities.escape(fieldName, '"') + "\"";
     }
 
     @Override

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/parser/FieldNameTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/parser/FieldNameTestCase.java
@@ -32,4 +32,21 @@ public class FieldNameTestCase {
         assertEquals(new CatExpression(new InputExpression("foo"), new ConstantExpression(new StringFieldValue("bar"))),
                      Expression.fromString("input foo . 'bar'"));
     }
+
+    @Test
+    public void requireThatNonIdentifierOutputFieldNamesRoundTripThroughQuoting() throws ParseException {
+        // Names containing characters outside the identifier charset, such as the synthetic
+        // 'mymap$keyvalue' attribute, must be quoted when serialized to be re-parseable.
+        assertEquals("attribute \"mymap$keyvalue\"", new AttributeExpression("mymap$keyvalue").toString());
+        assertEquals(new AttributeExpression("mymap$keyvalue"), Expression.fromString("attribute \"mymap$keyvalue\""));
+        assertEquals(new AttributeExpression("mymap$keyvalue"),
+                     Expression.fromString(new AttributeExpression("mymap$keyvalue").toString()));
+        assertEquals(new IndexExpression("mymap$keyvalue"),
+                     Expression.fromString(new IndexExpression("mymap$keyvalue").toString()));
+        assertEquals(new SummaryExpression("mymap$keyvalue"),
+                     Expression.fromString(new SummaryExpression("mymap$keyvalue").toString()));
+        // Identifier and dotted names must stay unquoted, so existing configs serialize unchanged.
+        assertEquals("attribute foo", new AttributeExpression("foo").toString());
+        assertEquals("attribute foo.bar", new AttributeExpression("foo.bar").toString());
+    }
 }


### PR DESCRIPTION
#### Indexing language

Adds quotes to output expressions that are not an identifier (or `ident.ident`). For instance: `foo$keyvalue` becomes `"foo$keyvalue"`, but `foo.bar` stays `foo.bar` unquoted. Aligned with the IndexingParser.jj.

This was needed because the indexing script makes a round trip through text form, and $ is not part of an identifier, so we had to quote it.

#### CreateFastMapSearch
Change the name of the synthetic field from `_fieldName_keyvalue` to `fieldName$keyvalue`.

I verified this by deploying an app with fast map search, dumping the live fields (confirming the synthetic field was present), and checking the synthetic attribute's content.

@arnej27959 please review
@boeker fyi

