### PR TITLE
Add feature flag for session timeout for Curator client in config server

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -15,6 +15,7 @@ import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.configserver.option.ConfigOptions;
 import com.yahoo.vespa.model.container.configserver.option.ConfigOptions.ConfigServer;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
@@ -24,6 +25,7 @@ import static com.yahoo.config.model.api.ModelContext.FeatureFlags;
  * Represents a config server cluster.
  *
  * @author Ulf Lilleengen
+ * @author hmusum
  */
 public class ConfigserverCluster extends TreeConfigProducer
         implements
@@ -175,6 +177,7 @@ public class ConfigserverCluster extends TreeConfigProducer
         }
         builder.zookeeperLocalhostAffinity(true);
         builder.juteMaxBuffer(options.zookeeperJuteMaxBuffer());
+        builder.zookeeperSessionTimeoutSeconds((int) (options.zookeeperSessionTimeout().orElse(Duration.ofSeconds(120)).toSeconds()));
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/ConfigOptions.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/ConfigOptions.java
@@ -32,6 +32,7 @@ public interface ConfigOptions {
     ConfigServer[] allConfigServers();
     int[] configServerZookeeperIds();
     Optional<Duration> zookeeperBarrierTimeout();
+    Optional<Duration> zookeeperSessionTimeout();
     Optional<Duration> applicationLockTimeoutSeconds();
     Optional<String> environment();
     Optional<String> region();

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/ConfigserverClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/ConfigserverClusterTest.java
@@ -21,6 +21,7 @@ import com.yahoo.vespa.model.container.configserver.option.ConfigOptions;
 import com.yahoo.vespa.model.container.xml.ConfigServerContainerModelBuilder;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -137,6 +138,13 @@ public class ConfigserverClusterTest {
         assertEquals(2181, config.server().get(0).port());
         assertEquals(120, config.zookeeperSessionTimeoutSeconds());
         assertTrue(config.zookeeperLocalhostAffinity());
+    }
+
+    @Test
+    void testCuratorConfig_zookeeperSessionTimeoutSeconds_from_config_options() {
+        TestOptions testOptions = createTestOptions(List.of(), List.of()).zookeeperSessionTimeout(Duration.ofSeconds(60));
+        CuratorConfig config = getConfig(CuratorConfig.class, testOptions);
+        assertEquals(60, config.zookeeperSessionTimeoutSeconds());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/TestOptions.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/TestOptions.java
@@ -20,6 +20,7 @@ public class TestOptions implements ConfigOptions {
     private Optional<Boolean> hostedVespa = Optional.empty();
     private static final String zooKeeperSnapshotMethod = "gz";
     private Optional<Duration> applicationLockTimeoutSeconds = Optional.empty();
+    private Optional<Duration> zookeeperSessionTimeout = Optional.empty();
 
     @Override
     public Optional<Integer> rpcPort() {
@@ -56,6 +57,9 @@ public class TestOptions implements ConfigOptions {
 
     @Override
     public Optional<Duration> zookeeperBarrierTimeout() { return Optional.empty(); }
+
+    @Override
+    public Optional<Duration> zookeeperSessionTimeout() { return zookeeperSessionTimeout; }
 
     @Override
     public Optional<Duration> applicationLockTimeoutSeconds() { return applicationLockTimeoutSeconds; }
@@ -112,5 +116,9 @@ public class TestOptions implements ConfigOptions {
         return this;
     }
 
+    public TestOptions zookeeperSessionTimeout(Duration timeout) {
+        this.zookeeperSessionTimeout = Optional.of(timeout);
+        return this;
+    }
 
 }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -264,6 +264,13 @@ public class Flags {
             INSTANCE_ID
     );
 
+    public static final UnboundIntFlag ZOOKEEPER_SESSION_TIMEOUT_SECONDS = defineIntFlag(
+            "zookeeper-session-timeout-seconds", 120,
+            List.of("hmusum"), "2026-08-24", "2027-02-13",
+            "Zookeeper session timeout in seconds for Zookeeper/Curator client running in config server",
+            "Takes effect at redeployment"
+    );
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,

--- a/standalone-container/src/main/java/com/yahoo/container/standalone/ConfigEnvironmentVariables.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/ConfigEnvironmentVariables.java
@@ -50,6 +50,13 @@ public class ConfigEnvironmentVariables implements ConfigOptions {
     }
 
     @Override
+    public Optional<Duration> zookeeperSessionTimeout() {
+        return  Optional.ofNullable(System.getenv("VESPA_ZOOKEEPER_SESSION_TIMEOUT_SECONDS"))
+                        .map(Long::parseLong)
+                        .map(Duration::ofSeconds);
+    }
+
+    @Override
     public Optional<Duration> applicationLockTimeoutSeconds() {
         return Optional.ofNullable(System.getenv("VESPA_CONFIGSERVER_APPLICATION_LOCK_TIMEOUT_SECONDS"))
                        .map(Long::parseLong)


### PR DESCRIPTION
Add feature flag for zookeeper session timeout in config server
- Add ZOOKEEPER_SESSION_TIMEOUT_SECONDS flag (will
  be used by internal component to set
  VESPA_ZOOKEEPER_SESSION_TIMEOUT_SECONDS env variable)
- Apply flag value to CuratorConfig in ConfigserverCluster