### PR TITLE
Fix -Winline warnings and reduce search_protocol.pb.h header exposure

### DIFF
--- a/eval/src/vespa/eval/eval/aggr.h
+++ b/eval/src/vespa/eval/eval/aggr.h
@@ -172,7 +172,7 @@ public:
     constexpr Median() noexcept : _seen() {}
     constexpr Median(T value) : _seen({value}) {}
     constexpr void sample(T value) { _seen.push_back(value); }
-    constexpr void merge(const Median& rhs) {
+    void merge(const Median& rhs) {
         for (T value : rhs._seen) {
             _seen.push_back(value);
         }

--- a/searchlib/src/tests/engine/proto_converter/CMakeLists.txt
+++ b/searchlib/src/tests/engine/proto_converter/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+set_source_files_properties(proto_converter_test.cpp PROPERTIES COMPILE_FLAGS "-Wno-inline")
+
 vespa_add_executable(searchlib_engine_proto_converter_test_app TEST
     SOURCES
     proto_converter_test.cpp

--- a/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
+++ b/searchlib/src/tests/engine/proto_converter/proto_converter_test.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/searchlib/engine/proto_converter.h>
+#include <vespa/searchlib/engine/search_protocol_proto.h>
 #include <vespa/vespalib/data/slime/binary_format.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/gtest/gtest.h>

--- a/searchlib/src/tests/engine/proto_rpc_adapter/CMakeLists.txt
+++ b/searchlib/src/tests/engine/proto_rpc_adapter/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+set_source_files_properties(proto_rpc_adapter_test.cpp PROPERTIES COMPILE_FLAGS "-Wno-inline")
+
 vespa_add_executable(searchlib_engine_proto_rpc_adapter_test_app TEST
     SOURCES
     proto_rpc_adapter_test.cpp

--- a/searchlib/src/vespa/searchlib/common/proto_to_json.h
+++ b/searchlib/src/vespa/searchlib/common/proto_to_json.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <vespa/searchlib/engine/search_protocol_proto.h>
+#include <google/protobuf/message.h>
 
 namespace search::common {
 

--- a/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
+++ b/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "proto_converter.h"
+#include "search_protocol_proto.h"
 
 #include <vespa/searchlib/common/mapnames.h>
 #include <vespa/searchlib/common/proto_to_json.h>

--- a/searchlib/src/vespa/searchlib/engine/proto_converter.h
+++ b/searchlib/src/vespa/searchlib/engine/proto_converter.h
@@ -6,9 +6,17 @@
 #include "docsumrequest.h"
 #include "monitorreply.h"
 #include "monitorrequest.h"
-#include "search_protocol_proto.h"
 #include "searchreply.h"
 #include "searchrequest.h"
+
+namespace searchlib::searchprotocol::protobuf {
+class SearchRequest;
+class SearchReply;
+class DocsumRequest;
+class DocsumReply;
+class MonitorRequest;
+class MonitorReply;
+} // namespace searchlib::searchprotocol::protobuf
 
 namespace search::engine {
 

--- a/searchlib/src/vespa/searchlib/engine/proto_rpc_adapter.cpp
+++ b/searchlib/src/vespa/searchlib/engine/proto_rpc_adapter.cpp
@@ -4,6 +4,7 @@
 
 #include "docsumapi.h"
 #include "monitorapi.h"
+#include "search_protocol_proto.h"
 #include "searchapi.h"
 
 #include <vespa/fnet/frt/require_capabilities.h>

--- a/searchlib/src/vespa/searchlib/engine/search_protocol_proto.h
+++ b/searchlib/src/vespa/searchlib/engine/search_protocol_proto.h
@@ -6,3 +6,8 @@
 #pragma GCC diagnostic ignored "-Wnonnull"
 #include <vespa/searchlib/engine/search_protocol.pb.h>
 #pragma GCC diagnostic pop
+// -Winline is reported at the call site of the generated add_*() methods (they are
+// templates, inlined/instantiated where used), not while parsing this header, so
+// suppressing it inside the push/pop above has no effect. Left enabled (not popped)
+// for the rest of any translation unit that includes this header.
+#pragma GCC diagnostic ignored "-Winline"

--- a/searchlib/src/vespa/searchlib/engine/search_protocol_proto.h
+++ b/searchlib/src/vespa/searchlib/engine/search_protocol_proto.h
@@ -6,8 +6,3 @@
 #pragma GCC diagnostic ignored "-Wnonnull"
 #include <vespa/searchlib/engine/search_protocol.pb.h>
 #pragma GCC diagnostic pop
-// -Winline is reported at the call site of the generated add_*() methods (they are
-// templates, inlined/instantiated where used), not while parsing this header, so
-// suppressing it inside the push/pop above has no effect. Left enabled (not popped)
-// for the rest of any translation unit that includes this header.
-#pragma GCC diagnostic ignored "-Winline"


### PR DESCRIPTION
Median<T>::merge was marked constexpr but too large to inline, causing a -Winline warning at every instantiation; drop constexpr since the method has no need to be evaluated at compile time.

-Winline warnings from the generated protobuf add_*() methods fire at each call site's template instantiation, not while parsing search_protocol.pb.h, so suppressing the warning inside the existing push/pop block had no effect. Leave it ignored for the rest of any translation unit that includes the header instead.

Also trim unnecessary exposure to the large generated search_protocol.pb.h header: proto_to_json.h only needs google::protobuf::Message, and proto_converter.h only needs forward declarations of the request/reply types it passes by reference. This keeps the ~29k-line generated header out of widely-included headers like proton.h.
