### PR TITLE
Factor out tensor divergence/error calculations to its own file

### DIFF
--- a/searchlib/src/tests/attribute/tensorattribute/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/tensorattribute/CMakeLists.txt
@@ -5,6 +5,7 @@ vespa_add_executable(searchlib_tensorattribute_test_app TEST
     tensorattribute_test.cpp
     DEPENDS
     vespa_searchlib
+    searchlib_test
     GTest::gmock_main
 )
 vespa_add_test(NAME searchlib_tensorattribute_test_app COMMAND searchlib_tensorattribute_test_app)

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -28,6 +28,7 @@
 #include <vespa/searchlib/tensor/tensor_attribute.h>
 #include <vespa/searchlib/tensor/tensor_attribute_flags.h>
 #include <vespa/searchlib/test/directory_handler.h>
+#include <vespa/searchlib/test/tensor_divergence.h>
 #include <vespa/searchlib/util/bufferwriter.h>
 #include <vespa/searchlib/util/fileutil.h>
 #include <vespa/vespalib/data/fileheader.h>
@@ -465,17 +466,11 @@ void PrintTo(const WrapValue& value, std::ostream* os) {
 /*
  * Checks if two tensors are approximately equal to each other, where the max divergence is
  * given by the `max_nrmse` (maximum normalized root mean squared error) argument.
- * NRMSE isn't necessarily the most intuitive error metric, but unlike other metrics (MAPE,
- * SMAPE etc.) it is well-defined for values of (or close to) zero, and it compensates for
- * different vector norms. The latter is very useful since vector dequantization precision
- * is directly affected by the norm due to the scaling factor used during reconstruction.
  *
  * If `max_nrmse` is zero, this will fall back to eval::Value operator== for equality testing,
  * as it transparently handles floating point precision issues.
  *
  * `arg` is expected to be a WrapValue instance.
- *
- * TODO move this out since it's useful for other quantization tests.
  */
 MATCHER_P2(TensorApproxEquals, exp_spec, max_nrmse, "") {
     using vespalib::eval::Aggr;
@@ -483,29 +478,8 @@ MATCHER_P2(TensorApproxEquals, exp_spec, max_nrmse, "") {
     if (max_nrmse == 0) {
         return ExplainMatchResult(Eq(exp_spec), arg, result_listener);
     }
-    auto arg_spec = TensorSpec::from_value(*arg._value); // WrapValue arg
-    if (exp_spec.type() != arg_spec.type()) {
-        *result_listener << "tensors have mismatching types";
-        return false;
-    }
-    // Root mean squared error (RMSE)
-    // For simplicity, compute across all subspaces. Quantization works on a per
-    // dense subspace basis, so we may want to change this to be subspace-aware.
-    // We also casually assume tensors have at least 1 dimension.
-    const double n = ReferenceOperations::reduce(exp_spec, Aggr::COUNT, {}).as_double();
-    auto         err_sq = ReferenceOperations::merge(exp_spec, arg_spec, [](double a, double b) noexcept {
-        const double diff = a - b;
-        return diff * diff;
-    });
-    const double sum_err_sq = ReferenceOperations::reduce(err_sq, Aggr::SUM, {}).as_double();
-    const double mse = sum_err_sq / n;
-    const double rmse = std::sqrt(mse);
-    // Normalized root mean squared error (NRSME)
-    // We choose to normalize based on the max observed cell value in the expected tensor
-    // Ref: https://en.wikipedia.org/wiki/Root_mean_square_deviation#Normalization
-    const double exp_max = ReferenceOperations::reduce(exp_spec, Aggr::MAX, {}).as_double();
-    const double nrmse = (exp_max != 0) ? (rmse / exp_max) : rmse;
-
+    const auto   exp_value = WrapValue(exp_spec);
+    const double nrmse = search::test::compute_tensor_nrmse(*exp_value._value, *arg._value);
     if (nrmse > max_nrmse) {
         *result_listener << "expected NRMSE between tensors to be <= " << max_nrmse << ", was " << nrmse;
         return false;

--- a/searchlib/src/vespa/searchlib/test/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/test/CMakeLists.txt
@@ -14,6 +14,7 @@ vespa_add_library(searchlib_test
     searchiteratorverifier.cpp
     schema_builder.cpp
     string_field_builder.cpp
+    tensor_divergence.cpp
     test_features.cpp
     vector_buffer_writer.cpp
     weightedchildrenverifiers.cpp

--- a/searchlib/src/vespa/searchlib/test/tensor_divergence.cpp
+++ b/searchlib/src/vespa/searchlib/test/tensor_divergence.cpp
@@ -1,0 +1,42 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/test/reference_operations.h>
+#include <vespa/eval/eval/value.h>
+#include <vespa/vespalib/util/exceptions.h>
+
+using vespalib::IllegalArgumentException;
+using vespalib::eval::Aggr;
+using vespalib::eval::ReferenceOperations;
+using vespalib::eval::TensorSpec;
+using vespalib::eval::Value;
+
+namespace search::test {
+
+double compute_tensor_nrmse(const Value& expected, const Value& actual) {
+    const auto exp_spec = TensorSpec::from_value(expected);
+    const auto arg_spec = TensorSpec::from_value(actual);
+    if (exp_spec.type() != arg_spec.type()) [[unlikely]] {
+        throw IllegalArgumentException("Can't compute NRMSE between tensors; types do not match");
+    }
+    // Root mean squared error (RMSE)
+    // For simplicity, compute across all subspaces. Quantization works on a per
+    // dense subspace basis, so we may want to change this to be subspace-aware.
+    // We also casually assume tensors have at least 1 dimension.
+    const double n = ReferenceOperations::reduce(exp_spec, Aggr::COUNT, {}).as_double();
+    auto         err_sq = ReferenceOperations::merge(exp_spec, arg_spec, [](double a, double b) noexcept {
+        const double diff = a - b;
+        return diff * diff;
+    });
+    const double sum_err_sq = ReferenceOperations::reduce(err_sq, Aggr::SUM, {}).as_double();
+    const double mse = sum_err_sq / n;
+    const double rmse = std::sqrt(mse);
+    // Normalized root mean squared error (NRSME)
+    // We choose to normalize based on the max observed cell value in the expected tensor
+    // Ref: https://en.wikipedia.org/wiki/Root_mean_square_deviation#Normalization
+    const double exp_max = ReferenceOperations::reduce(exp_spec, Aggr::MAX, {}).as_double();
+    const double nrmse = (exp_max != 0) ? (rmse / exp_max) : rmse;
+    return nrmse;
+}
+
+} // namespace search::test

--- a/searchlib/src/vespa/searchlib/test/tensor_divergence.h
+++ b/searchlib/src/vespa/searchlib/test/tensor_divergence.h
@@ -1,0 +1,26 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace vespalib::eval {
+struct Value;
+}
+
+namespace search::test {
+
+/*
+ * Computes the normalized root mean squared error (NRMSE) between the tensors `expected`
+ * and `actual`, which are expected to have the same type. The error is computed across all
+ * subspaces.
+ *
+ * NRMSE isn't necessarily the most intuitive error metric, but unlike other metrics (MAPE,
+ * SMAPE etc.) it is well-defined for values of (or close to) zero, and it compensates for
+ * different vector norms. The latter is very useful since vector dequantization precision
+ * is directly affected by the norm due to the scaling factor used during reconstruction.
+ *
+ * Throws vespalib::IllegalArgumentException if the tensor types of `expected` and `actual`
+ * are different.
+ */
+[[nodiscard]] double compute_tensor_nrmse(const vespalib::eval::Value& expected, const vespalib::eval::Value& actual);
+
+} // namespace search::test

--- a/searchlib/src/vespa/searchlib/test/test_quantization_params.h
+++ b/searchlib/src/vespa/searchlib/test/test_quantization_params.h
@@ -1,0 +1,15 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchcommon/attribute/quantization_params.h>
+
+namespace search::test {
+
+[[nodiscard]] constexpr attribute::QuantizationParams mse_4bit_quantization_params() noexcept {
+    constexpr uint64_t seed = 0x12345678;
+    constexpr auto     mode = attribute::QuantizationParams::QuantizationMode::MSE;
+    return {seed, mode, 4};
+}
+
+} // namespace search::test


### PR DESCRIPTION
@arnej27959 please review

Also add utility for creating 4-bit quantization params with a fixed seed for unit tests.

These will be used by various unit tests in upcoming changes.
