### PR TITLE
move CountAggregationResult implementation into own file

### DIFF
--- a/searchlib/src/vespa/searchlib/aggregation/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/aggregation/CMakeLists.txt
@@ -2,6 +2,7 @@
 vespa_add_library(searchlib_aggregation OBJECT
     SOURCES
     aggregation.cpp
+    countaggregationresult.cpp
     fs4hit.cpp
     group.cpp
     grouping.cpp

--- a/searchlib/src/vespa/searchlib/aggregation/aggregation.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/aggregation.cpp
@@ -165,6 +165,10 @@ void SumAggregationResult::onAggregate(const ResultNode& result) {
     }
 }
 
+void SumAggregationResult::onReset() {
+    _sum.reset(static_cast<NumericResultNode*>(_sum->getClass().create()));
+}
+
 void MaxAggregationResult::onMerge(const AggregationResult& b) {
     _max->max(*static_cast<const MaxAggregationResult&>(b)._max);
 }

--- a/searchlib/src/vespa/searchlib/aggregation/aggregation.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/aggregation.cpp
@@ -7,6 +7,7 @@
 #include <vespa/document/fieldvalue/document.h>
 #include <vespa/searchlib/expression/resultvector.h>
 
+#include <vespa/searchlib/aggregation/aggregation.hpp>
 #include <vespa/vespalib/objects/visit.hpp>
 
 #include <xxhash.h>
@@ -38,12 +39,7 @@ std::unique_ptr<Wanted> createAndEnsureWanted(const ResultNode& result) {
 using vespalib::Deserializer;
 using vespalib::Serializer;
 
-#define IMPLEMENT_ABSTRACT_AGGREGATIONRESULT(cclass, base)                 \
-    IMPLEMENT_IDENTIFIABLE_ABSTRACT_NS2(search, aggregation, cclass, base)
-#define IMPLEMENT_AGGREGATIONRESULT(cclass, base) IMPLEMENT_IDENTIFIABLE_NS2(search, aggregation, cclass, base)
-
 IMPLEMENT_ABSTRACT_AGGREGATIONRESULT(AggregationResult, ExpressionNode);
-IMPLEMENT_AGGREGATIONRESULT(CountAggregationResult, AggregationResult);
 IMPLEMENT_AGGREGATIONRESULT(SumAggregationResult, AggregationResult);
 IMPLEMENT_AGGREGATIONRESULT(MaxAggregationResult, AggregationResult);
 IMPLEMENT_AGGREGATIONRESULT(MinAggregationResult, AggregationResult);
@@ -83,13 +79,6 @@ AggregationResult& AggregationResult::setExpression(ExpressionNode::UP expr) {
     _expressionTree = std::make_shared<ExpressionTree>(std::move(expr));
     prepare(_expressionTree->getResult());
     return *this;
-}
-
-void CountAggregationResult::onPrepare(const ResultNode&) {
-}
-
-void CountAggregationResult::initForUnitTest(const ResultNode& result) {
-    _count.set(result);
 }
 
 void SumAggregationResult::onPrepare(const ResultNode& result) {
@@ -174,26 +163,6 @@ void SumAggregationResult::onAggregate(const ResultNode& result) {
     } else {
         _sum->add(result);
     }
-}
-
-void SumAggregationResult::onReset() {
-    _sum.reset(static_cast<NumericResultNode*>(_sum->getClass().create()));
-}
-
-void CountAggregationResult::onMerge(const AggregationResult& b) {
-    _count.add(static_cast<const CountAggregationResult&>(b)._count);
-}
-
-void CountAggregationResult::onAggregate(const ResultNode& result) {
-    if (result.isMultiValue()) {
-        _count += static_cast<const ResultNodeVector&>(result).size();
-    } else {
-        ++_count;
-    }
-}
-
-void CountAggregationResult::onReset() {
-    setCount(0);
 }
 
 void MaxAggregationResult::onMerge(const AggregationResult& b) {
@@ -299,21 +268,6 @@ void AggregationResult::visitMembers(vespalib::ObjectVisitor& visitor) const {
 void AggregationResult::selectMembers(const vespalib::ObjectPredicate& predicate,
                                       vespalib::ObjectOperation&       operation) {
     _expressionTree->select(predicate, operation);
-}
-
-Serializer& CountAggregationResult::onSerialize(Serializer& os) const {
-    AggregationResult::onSerialize(os);
-    return _count.serialize(os);
-}
-
-Deserializer& CountAggregationResult::onDeserialize(Deserializer& is) {
-    AggregationResult::onDeserialize(is);
-    return _count.deserialize(is);
-}
-
-void CountAggregationResult::visitMembers(vespalib::ObjectVisitor& visitor) const {
-    AggregationResult::visitMembers(visitor);
-    visit(visitor, "count", _count);
 }
 
 Serializer& SumAggregationResult::onSerialize(Serializer& os) const {

--- a/searchlib/src/vespa/searchlib/aggregation/aggregation.hpp
+++ b/searchlib/src/vespa/searchlib/aggregation/aggregation.hpp
@@ -1,0 +1,29 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/searchlib/expression/resultnode.h>
+
+#include <memory>
+
+namespace search::aggregation {
+
+#define IMPLEMENT_ABSTRACT_AGGREGATIONRESULT(cclass, base)                 \
+    IMPLEMENT_IDENTIFIABLE_ABSTRACT_NS2(search, aggregation, cclass, base)
+
+#define IMPLEMENT_AGGREGATIONRESULT(cclass, base) IMPLEMENT_IDENTIFIABLE_NS2(search, aggregation, cclass, base)
+
+inline bool is_ready(const expression::ResultNode* my_result, const expression::ResultNode& ref) {
+    return (my_result != nullptr && my_result->getClass().id() == ref.getClass().id());
+}
+
+template <typename Wanted, typename Fallback>
+std::unique_ptr<Wanted> create_and_ensure_wanted(const expression::ResultNode& result) {
+    std::unique_ptr<expression::ResultNode> tmp = result.createBaseType();
+    if (dynamic_cast<Wanted*>(tmp.get()) != nullptr) {
+        return std::unique_ptr<Wanted>(static_cast<Wanted*>(tmp.release()));
+    } else {
+        return std::make_unique<Fallback>();
+    }
+}
+
+} // namespace search::aggregation

--- a/searchlib/src/vespa/searchlib/aggregation/countaggregationresult.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/countaggregationresult.cpp
@@ -1,0 +1,64 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "aggregation.h"
+
+#include <vespa/document/fieldvalue/document.h>
+#include <vespa/searchlib/expression/resultvector.h>
+
+#include <vespa/searchlib/aggregation/aggregation.hpp>
+#include <vespa/vespalib/objects/visit.hpp>
+
+using search::expression::ResultNodeVector;
+using vespalib::Deserializer;
+using vespalib::Serializer;
+
+namespace search::aggregation {
+
+IMPLEMENT_AGGREGATIONRESULT(CountAggregationResult, AggregationResult);
+
+CountAggregationResult::CountAggregationResult(uint64_t count) : AggregationResult(), _count(count) {
+}
+
+void CountAggregationResult::initForUnitTest(const ResultNode& result) {
+    _count.set(result);
+}
+
+void CountAggregationResult::onPrepare(const ResultNode&) {
+}
+
+void CountAggregationResult::onReset() {
+    setCount(0);
+}
+
+void SumAggregationResult::onReset() {
+    _sum.reset(static_cast<NumericResultNode*>(_sum->getClass().create()));
+}
+
+void CountAggregationResult::onMerge(const AggregationResult& b) {
+    _count.add(static_cast<const CountAggregationResult&>(b)._count);
+}
+
+void CountAggregationResult::onAggregate(const ResultNode& result) {
+    if (result.isMultiValue()) {
+        _count += static_cast<const ResultNodeVector&>(result).size();
+    } else {
+        ++_count;
+    }
+}
+
+Serializer& CountAggregationResult::onSerialize(Serializer& os) const {
+    AggregationResult::onSerialize(os);
+    return _count.serialize(os);
+}
+
+Deserializer& CountAggregationResult::onDeserialize(Deserializer& is) {
+    AggregationResult::onDeserialize(is);
+    return _count.deserialize(is);
+}
+
+void CountAggregationResult::visitMembers(vespalib::ObjectVisitor& visitor) const {
+    AggregationResult::visitMembers(visitor);
+    visit(visitor, "count", _count);
+}
+
+} // namespace search::aggregation

--- a/searchlib/src/vespa/searchlib/aggregation/countaggregationresult.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/countaggregationresult.cpp
@@ -30,10 +30,6 @@ void CountAggregationResult::onReset() {
     setCount(0);
 }
 
-void SumAggregationResult::onReset() {
-    _sum.reset(static_cast<NumericResultNode*>(_sum->getClass().create()));
-}
-
 void CountAggregationResult::onMerge(const AggregationResult& b) {
     _count.add(static_cast<const CountAggregationResult&>(b)._count);
 }

--- a/searchlib/src/vespa/searchlib/aggregation/countaggregationresult.h
+++ b/searchlib/src/vespa/searchlib/aggregation/countaggregationresult.h
@@ -7,22 +7,27 @@
 
 namespace search::aggregation {
 
+/**
+ * Counting aggregator that counts every single-value hit as 1, and every
+ * multi-value hit as its size.
+ */
 class CountAggregationResult : public AggregationResult {
+    expression::Int64ResultNode _count;
+
 public:
     DECLARE_AGGREGATIONRESULT(CountAggregationResult);
-    CountAggregationResult(uint64_t count = 0) : AggregationResult(), _count(count) {}
+    CountAggregationResult(uint64_t count = 0);
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
-    uint64_t getCount() const { return _count.get(); }
+    [[nodiscard]] uint64_t getCount() const { return _count.get(); }
     CountAggregationResult& setCount(uint64_t c) {
         _count = c;
         return *this;
     }
 
 private:
-    const ResultNode& onGetRank() const override { return _count; }
+    [[nodiscard]] const ResultNode& onGetRank() const override { return _count; }
     void onPrepare(const ResultNode& result) override;
     void initForUnitTest(const ResultNode& result) override;
-    expression::Int64ResultNode _count;
 };
 
 } // namespace search::aggregation

--- a/searchlib/src/vespa/searchlib/aggregation/quantile_aggregation_result.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/quantile_aggregation_result.cpp
@@ -3,6 +3,7 @@
 
 #include <vespa/searchlib/expression/resultvector.h>
 
+#include <vespa/searchlib/aggregation/aggregation.hpp>
 #include <vespa/vespalib/objects/deserializer.hpp>
 #include <vespa/vespalib/objects/serializer.hpp>
 
@@ -17,7 +18,7 @@ using expression::ResultNodeVector;
 using vespalib::Deserializer;
 using vespalib::Serializer;
 
-IMPLEMENT_IDENTIFIABLE_NS2(search, aggregation, QuantileAggregationResult, AggregationResult);
+IMPLEMENT_AGGREGATIONRESULT(QuantileAggregationResult, AggregationResult);
 
 QuantileAggregationResult::QuantileAggregationResult() {
     _no_rank.reset(new FloatResultNode(0));


### PR DESCRIPTION
**aggregation.hpp:** moved macros and made `is_ready` and `create_and_ensure_wanted` copies in it.

Then use aggregation.hpp in the quantiles implementation.

And move only countaggregationresult into its own file.

@arnej27959 ptal