### PR TITLE
Allows disabling model optimization in triton

### DIFF
--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -265,6 +265,16 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
             configBuilder.setDynamicBatching(dynamicBatchingBuilder.build());
         }
 
+        // Triton's ONNX Runtime backend enables all optimizations when the graph optimization level is unspecified,
+        // and maps level 2 to disabling all optimizations (ORT_DISABLE_ALL).
+        if (!options.optimizeModel()) {
+            configBuilder.setOptimization(ModelConfigOuterClass.ModelOptimizationPolicy.newBuilder()
+                    .setGraph(ModelConfigOuterClass.ModelOptimizationPolicy.Graph.newBuilder()
+                            .setLevel(2)
+                            .build())
+                    .build());
+        }
+
         return configBuilder.build().toString();
     }
 

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
@@ -37,7 +37,8 @@ import org.junit.jupiter.api.function.ThrowingSupplier;
 class TritonOnnxRuntimeTest {
 
     private static TritonServerContainer tritonContainer;
-    private final OnnxEvaluatorOptions.Builder optsBuilder = new OnnxEvaluatorOptions.Builder(8);
+    private final OnnxEvaluatorOptions.Builder optsBuilder =
+            new OnnxEvaluatorOptions.Builder(8).setOptimizeModel(true);
 
     // Used by most of the test. Some use their own.
     @BeforeAll
@@ -63,6 +64,12 @@ class TritonOnnxRuntimeTest {
     void load_model_with_execution_mode() throws IOException {
         var opts = optsBuilder.setExecutionMode(OnnxEvaluatorOptions.ExecutionMode.PARALLEL).build();
         assertLoadModel("src/test/triton/config_with_execution_mode.pbtxt", opts);
+    }
+
+    @Test
+    void load_model_without_optimization() throws IOException {
+        var opts = optsBuilder.setOptimizeModel(false).build();
+        assertLoadModel("src/test/triton/config_without_optimization.pbtxt", opts);
     }
 
     @Test

--- a/model-integration/src/test/triton/config_without_optimization.pbtxt
+++ b/model-integration/src/test/triton/config_without_optimization.pbtxt
@@ -1,0 +1,42 @@
+name: "dummy_transformer_42577fdcb5dd44d6"
+platform: "onnxruntime_onnx"
+max_batch_size: 1
+instance_group {
+  count: 1
+  kind: KIND_CPU
+}
+optimization {
+  graph {
+    level: 2
+  }
+}
+parameters {
+  key: "enable_mem_arena"
+  value {
+    string_value: "0"
+  }
+}
+parameters {
+  key: "enable_mem_pattern"
+  value {
+    string_value: "0"
+  }
+}
+parameters {
+  key: "execution_mode"
+  value {
+    string_value: "0"
+  }
+}
+parameters {
+  key: "inter_op_thread_count"
+  value {
+    string_value: "2"
+  }
+}
+parameters {
+  key: "intra_op_thread_count"
+  value {
+    string_value: "8"
+  }
+}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This seems necessary for some fp16 models, e.g. [fp16 version of mxbai model](https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1/blob/main/onnx/model_fp16.onnx)