### PR TITLE
Wire-in string range functionality into attribute vectors

### DIFF
--- a/searchlib/src/tests/attribute/searchcontext/searchcontext_test.cpp
+++ b/searchlib/src/tests/attribute/searchcontext/searchcontext_test.cpp
@@ -173,10 +173,16 @@ protected:
     ResultSetPtr performSearch(const queryeval::ExecuteInfo& executeInfo, const V& vec, const T& term,
                                TermType termType);
     template <typename V>
+    ResultSetPtr perform_search(const queryeval::ExecuteInfo& executeInfo, const V& vec,
+                                std::unique_ptr<QueryTermSimple> term);
+    template <typename V>
     void performSearch(const V& vec, const std::string& term, const DocSet& expected, TermType termType);
     template <typename V>
     void performSearch(const queryeval::ExecuteInfo& executeInfo, const V& vec, const std::string& term,
                        const DocSet& expected, TermType termType);
+    template <typename V>
+    void perform_search(const queryeval::ExecuteInfo& executeInfo, const V& vec,
+                        std::unique_ptr<QueryTermSimple> term, const DocSet& expected);
     void checkResultSet(const ResultSet& rs, const DocSet& exp, bool bitVector);
 
     template <typename T, typename A>
@@ -240,6 +246,9 @@ protected:
     void performRangeSearch(const VectorType& vec, const std::string& term, const DocSet& expected);
     template <typename VectorType, typename ValueType>
     void testRangeSearch(const AttributePtr& ptr, uint32_t numDocs, std::vector<ValueType> values);
+
+    // test lexical range search
+    void test_lexical_range_search(const std::string& name, const Config& cfg);
 
     // test case insensitive search
     void performCaseInsensitiveSearch(const StringAttribute& vec, const std::string& term, const DocSet& expected);
@@ -471,6 +480,18 @@ ResultSetPtr SearchContextTest::performSearch(const queryeval::ExecuteInfo& exec
 }
 
 template <typename V>
+ResultSetPtr SearchContextTest::perform_search(const queryeval::ExecuteInfo& executeInfo, const V& vec,
+                                               std::unique_ptr<QueryTermSimple> term) {
+    TermFieldMatchData dummy;
+    SearchContextPtr   sc =
+        (dynamic_cast<const AttributeVector&>(vec)).getSearch(std::move(term), attribute::SearchContextParams());
+    sc->fetchPostings(executeInfo, true);
+    SearchBasePtr sb = sc->createIterator(&dummy, true);
+    ResultSetPtr  rs = performSearch(*sb, vec.getNumDocs());
+    return rs;
+}
+
+template <typename V>
 void SearchContextTest::performSearch(const queryeval::ExecuteInfo& executeInfo, const V& vec,
                                       const std::string& term, const DocSet& expected, TermType termType) {
 #if 0
@@ -483,6 +504,21 @@ void SearchContextTest::performSearch(const queryeval::ExecuteInfo& executeInfo,
         checkResultSet(*rs, expected, false);
     }
 }
+
+template <typename V>
+void SearchContextTest::perform_search(const queryeval::ExecuteInfo& executeInfo, const V& vec,
+                                       std::unique_ptr<QueryTermSimple> term, const DocSet& expected) {
+#if 0
+    std::cout << "performSearch[" << term << "]: {";
+    std::copy(expected.begin(), expected.end(), std::ostream_iterator<uint32_t>(std::cout, ", "));
+    std::cout << "}, prefix(" << (prefix ? "true" : "false") << ")" << std::endl;
+#endif
+    { // strict search iterator
+        ResultSetPtr rs = perform_search(executeInfo, vec, std::move(term));
+        checkResultSet(*rs, expected, false);
+    }
+}
+
 template <typename V>
 void SearchContextTest::performSearch(const V& vec, const std::string& term, const DocSet& expected,
                                       TermType termType) {
@@ -1260,6 +1296,110 @@ TEST_F(SearchContextTest, test_range_search) {
             AttributePtr ptr = AttributeFactory::createAttribute(cfg.first, cfg.second);
             testRangeSearch<FloatingPointAttribute, double>(ptr, numDocs, values);
         }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Test lexical range search
+//-----------------------------------------------------------------------------
+
+namespace {
+std::string to_hex(uint32_t n) {
+    return std::format("{:016X}", n);
+}
+
+std::unique_ptr<QueryTermSimple> make_string_range_query_term(uint32_t left, bool left_closed, bool left_unbounded,
+                                                              uint32_t right, bool right_closed,
+                                                              bool right_unbounded) {
+    return std::make_unique<QueryTermUCS4>(
+        QueryTermSimple::Type::WORD, std::make_unique<StringRangeSpec>(to_hex(left), left_closed, left_unbounded,
+                                                                       to_hex(right), right_closed, right_unbounded));
+}
+
+DocSet make_range_doc_set(uint32_t n, uint32_t left, bool left_closed, bool left_unbounded, uint32_t right,
+                          bool right_closed, bool right_unbounded) {
+    uint32_t from = left_unbounded ? 1 : (left_closed ? left : left + 1);
+    uint32_t to = right_unbounded ? n : (right_closed ? right : right - 1);
+    DocSet   expected;
+    for (uint32_t i = from; i <= to; ++i) {
+        expected.put(i);
+    }
+    return expected;
+}
+} // namespace
+
+void SearchContextTest::test_lexical_range_search(const std::string& name, const Config& cfg) {
+    LOG(info, "test_lexical_range_search: vector '%s'", name.c_str());
+    constexpr uint32_t n = 15;
+
+    // docid i gets hexadecimal string representation of i
+    AttributeVector::SP attr_ptr = AttributeFactory::createAttribute(name, cfg);
+    auto&               attr = dynamic_cast<StringAttribute&>(*attr_ptr);
+    attr.addReservedDoc();
+    attr.addDocs(n);
+    for (uint32_t docid = 1; docid <= n; ++docid) {
+        attr.update(docid, to_hex(docid));
+    }
+    attr.commit(CommitParam::UpdateStats::FORCE);
+
+    // test unbounded intervals
+    for (uint32_t i = 1; i <= n; ++i) {
+        // (-\infty, i]
+        // (lower bound 5 is ignored)
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(5, false, true, i, true, false),
+                       make_range_doc_set(n, 5, false, true, i, true, false));
+        // [i, \infty)
+        // (upped bound 10 is ignored)
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(i, true, false, 10, false, true),
+                       make_range_doc_set(n, i, true, false, 10, false, true));
+    }
+
+    // (-\infty, \infty)
+    // bounds 5 and 10 are ignored
+    perform_search(queryeval::ExecuteInfo::FULL, attr, make_string_range_query_term(5, false, true, 10, false, true),
+                   make_range_doc_set(n, 5, false, true, 10, false, true));
+
+    // bounded intervals
+    for (uint32_t i = 1; i <= n; ++i) {
+        for (uint32_t j = 1; j <= n; ++j) {
+            // [i, j]
+            perform_search(queryeval::ExecuteInfo::FULL, attr,
+                           make_string_range_query_term(i, true, false, j, true, false),
+                           make_range_doc_set(n, i, true, false, j, true, false));
+            // (i, j]
+            perform_search(queryeval::ExecuteInfo::FULL, attr,
+                           make_string_range_query_term(i, false, false, j, true, false),
+                           make_range_doc_set(n, i, false, false, j, true, false));
+            // [i, j)
+            perform_search(queryeval::ExecuteInfo::FULL, attr,
+                           make_string_range_query_term(i, true, false, j, false, false),
+                           make_range_doc_set(n, i, true, false, j, false, false));
+            // (i, j)
+            perform_search(queryeval::ExecuteInfo::FULL, attr,
+                           make_string_range_query_term(i, false, false, j, false, false),
+                           make_range_doc_set(n, i, false, false, j, false, false));
+        }
+    }
+
+    // Long range, cf. testPrefixSearch
+    constexpr uint32_t longrange_values =
+        search::attribute::PostingListFoldedSearchContextT<int32_t>::MAX_POSTING_INDEXES_SIZE + 100;
+    attr.addDocs(longrange_values);
+    for (uint32_t docid = n + 1; docid <= n + longrange_values; ++docid) {
+        attr.update(docid, to_hex(docid));
+    }
+    attr.commit(CommitParam::UpdateStats::FORCE);
+    // [n + 1, n + longrange_values]
+    perform_search(queryeval::ExecuteInfo::FULL, attr,
+                   make_string_range_query_term(n + 1, true, false, n + longrange_values, true, false),
+                   make_range_doc_set(n + longrange_values, n + 1, true, false, n + longrange_values, true, false));
+}
+
+TEST_F(SearchContextTest, test_lexical_range_search) {
+    for (const auto& cfg : _stringCfg) {
+        test_lexical_range_search(cfg.first, cfg.second);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
@@ -156,6 +156,7 @@ vespa_add_library(searchlib_attribute OBJECT
     string_matcher.cpp
     string_posting_search_context.cpp
     string_range_matcher.cpp
+    string_range_posting_search_context.cpp
     string_range_search_helper.cpp
     string_search_context.cpp
     string_search_helper.cpp

--- a/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringattribute.hpp
@@ -6,6 +6,7 @@
 #include "enumerated_multi_value_read_view.h"
 #include "multi_string_enum_hint_search_context.h"
 #include "multistringattribute.h"
+#include "string_range_matcher.h"
 #include "string_sort_blob_writer.h"
 
 #include <vespa/searchcommon/attribute/config.h>
@@ -46,10 +47,17 @@ MultiValueStringAttributeT<B, M>::getSearch(QueryTermSimpleUP                   
                                             const attribute::SearchContextParams& params) const {
     bool cased = this->get_match_is_cased();
     auto doc_id_limit = this->getCommittedDocIdLimit();
-    return std::make_unique<attribute::MultiStringEnumHintSearchContextT<M, attribute::StringMatcher>>(
-        attribute::StringMatcher(std::move(qTerm), cased, params.fuzzy_matching_algorithm()), *this,
-        this->_mvMapping.make_read_view(doc_id_limit), this->_enumStore, doc_id_limit,
-        this->getStatus().getNumValues());
+    if (qTerm && qTerm->get_string_range_spec()) {
+        return std::make_unique<attribute::MultiStringEnumHintSearchContextT<M, attribute::StringRangeMatcher>>(
+            attribute::StringRangeMatcher(std::move(qTerm), cased), *this,
+            this->_mvMapping.make_read_view(doc_id_limit), this->_enumStore, doc_id_limit,
+            this->getStatus().getNumValues());
+    } else {
+        return std::make_unique<attribute::MultiStringEnumHintSearchContextT<M, attribute::StringMatcher>>(
+            attribute::StringMatcher(std::move(qTerm), cased, params.fuzzy_matching_algorithm()), *this,
+            this->_mvMapping.make_read_view(doc_id_limit), this->_enumStore, doc_id_limit,
+            this->getStatus().getNumValues());
+    }
 }
 
 template <typename B, typename M>

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
@@ -6,6 +6,8 @@
 #include "multistringpostattribute.h"
 #include "string_direct_posting_store_adapter.hpp"
 #include "string_posting_search_context.hpp"
+#include "string_range_matcher.h"
+#include "string_range_posting_search_context.hpp"
 
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/query/query_term_simple.h>
@@ -83,13 +85,21 @@ template <typename B, typename T>
 std::unique_ptr<attribute::SearchContext>
 MultiValueStringPostingAttributeT<B, T>::getSearch(QueryTermSimpleUP                     qTerm,
                                                    const attribute::SearchContextParams& params) const {
-    using BaseSC = attribute::MultiStringEnumSearchContextT<T, attribute::StringMatcher>;
-    using SC = attribute::StringPostingSearchContext<BaseSC, SelfType, int32_t>;
-    bool   cased = this->get_match_is_cased();
-    auto   doc_id_limit = this->getCommittedDocIdLimit();
-    BaseSC base_sc(attribute::StringMatcher(std::move(qTerm), cased, params.fuzzy_matching_algorithm()), *this,
-                   this->_mvMapping.make_read_view(doc_id_limit), this->_enumStore);
-    return std::make_unique<SC>(std::move(base_sc), params.useBitVector(), *this);
+    bool cased = this->get_match_is_cased();
+    auto doc_id_limit = this->getCommittedDocIdLimit();
+    if (qTerm && qTerm->get_string_range_spec()) {
+        using BaseSC = attribute::MultiStringEnumSearchContextT<T, attribute::StringRangeMatcher>;
+        using SC = attribute::StringRangePostingSearchContext<BaseSC, SelfType, int32_t>;
+        BaseSC base_sc(attribute::StringRangeMatcher(std::move(qTerm), cased), *this,
+                       this->_mvMapping.make_read_view(doc_id_limit), this->_enumStore);
+        return std::make_unique<SC>(std::move(base_sc), params.useBitVector(), *this);
+    } else {
+        using BaseSC = attribute::MultiStringEnumSearchContextT<T, attribute::StringMatcher>;
+        using SC = attribute::StringPostingSearchContext<BaseSC, SelfType, int32_t>;
+        BaseSC base_sc(attribute::StringMatcher(std::move(qTerm), cased, params.fuzzy_matching_algorithm()), *this,
+                       this->_mvMapping.make_read_view(doc_id_limit), this->_enumStore);
+        return std::make_unique<SC>(std::move(base_sc), params.useBitVector(), *this);
+    }
 }
 
 template <typename B, typename T>

--- a/searchlib/src/vespa/searchlib/attribute/singlestringattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringattribute.hpp
@@ -6,6 +6,7 @@
 #include "single_string_enum_hint_search_context.h"
 #include "singleenumattribute.hpp"
 #include "singlestringattribute.h"
+#include "string_range_matcher.h"
 
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/query/query_term_ucs4.h>
@@ -41,9 +42,15 @@ SingleValueStringAttributeT<B>::getSearch(QueryTermSimpleUP                     
                                           const attribute::SearchContextParams& params) const {
     bool cased = this->get_match_is_cased();
     auto docid_limit = this->getCommittedDocIdLimit();
-    return std::make_unique<attribute::SingleStringEnumHintSearchContextT<attribute::StringMatcher>>(
-        attribute::StringMatcher(std::move(qTerm), cased, params.fuzzy_matching_algorithm()), *this,
-        this->_enumIndices.make_read_view(docid_limit), this->_enumStore, this->getStatus().getNumValues());
+    if (qTerm && qTerm->get_string_range_spec()) {
+        return std::make_unique<attribute::SingleStringEnumHintSearchContextT<attribute::StringRangeMatcher>>(
+            attribute::StringRangeMatcher(std::move(qTerm), cased), *this,
+            this->_enumIndices.make_read_view(docid_limit), this->_enumStore, this->getStatus().getNumValues());
+    } else {
+        return std::make_unique<attribute::SingleStringEnumHintSearchContextT<attribute::StringMatcher>>(
+            attribute::StringMatcher(std::move(qTerm), cased, params.fuzzy_matching_algorithm()), *this,
+            this->_enumIndices.make_read_view(docid_limit), this->_enumStore, this->getStatus().getNumValues());
+    }
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.hpp
@@ -6,6 +6,9 @@
 #include "singlestringpostattribute.h"
 #include "string_direct_posting_store_adapter.hpp"
 #include "string_posting_search_context.hpp"
+#include "string_range_matcher.h"
+#include "string_range_posting_search_context.h"
+#include "string_range_posting_search_context.hpp"
 
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/query/query_term_ucs4.h>
@@ -122,13 +125,22 @@ template <typename B>
 std::unique_ptr<attribute::SearchContext>
 SingleValueStringPostingAttributeT<B>::getSearch(QueryTermSimpleUP                     qTerm,
                                                  const attribute::SearchContextParams& params) const {
-    using BaseSC = attribute::SingleStringEnumSearchContextT<attribute::StringMatcher>;
-    using SC = attribute::StringPostingSearchContext<BaseSC, SelfType, vespalib::btree::BTreeNoLeafData>;
-    bool   cased = this->get_match_is_cased();
-    auto   docid_limit = this->getCommittedDocIdLimit();
-    BaseSC base_sc(attribute::StringMatcher(std::move(qTerm), cased, params.fuzzy_matching_algorithm()), *this,
-                   this->_enumIndices.make_read_view(docid_limit), this->_enumStore);
-    return std::make_unique<SC>(std::move(base_sc), params.useBitVector(), *this);
+    bool cased = this->get_match_is_cased();
+    auto docid_limit = this->getCommittedDocIdLimit();
+    if (qTerm && qTerm->get_string_range_spec()) {
+        using BaseSC = attribute::SingleStringEnumSearchContextT<attribute::StringRangeMatcher>;
+        using SC = attribute::StringRangePostingSearchContext<BaseSC, SelfType, vespalib::btree::BTreeNoLeafData>;
+        BaseSC base_sc(attribute::StringRangeMatcher(std::move(qTerm), cased), *this,
+                       this->_enumIndices.make_read_view(docid_limit), this->_enumStore);
+        return std::make_unique<SC>(std::move(base_sc), params.useBitVector(), *this);
+
+    } else {
+        using BaseSC = attribute::SingleStringEnumSearchContextT<attribute::StringMatcher>;
+        using SC = attribute::StringPostingSearchContext<BaseSC, SelfType, vespalib::btree::BTreeNoLeafData>;
+        BaseSC base_sc(attribute::StringMatcher(std::move(qTerm), cased, params.fuzzy_matching_algorithm()), *this,
+                       this->_enumIndices.make_read_view(docid_limit), this->_enumStore);
+        return std::make_unique<SC>(std::move(base_sc), params.useBitVector(), *this);
+    }
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/string_range_matcher.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_matcher.cpp
@@ -6,6 +6,7 @@
 #include "enumstore.h"
 
 #include <vespa/searchlib/query/query_term_ucs4.h>
+#include <vespa/vespalib/datastore/infinity_unique_store_string_comparator.h>
 
 namespace search::attribute {
 
@@ -22,10 +23,33 @@ void StringRangeMatcher::setup_enum_hint_sc(const EnumStoreT<const char*>& enum_
                                             EnumHintSearchContext&         enum_hint_sc) {
     if (_helper.is_valid()) {
         auto* range_spec = _helper.get_string_range_spec();
-        // TODO respect unbounded ranges and test
-        auto comp_left = enum_store.make_folded_comparator(range_spec->left.c_str());
-        auto comp_right = enum_store.make_folded_comparator(range_spec->right.c_str());
-        enum_hint_sc.lookupRange(comp_left, comp_right);
+        // This is used to eliminate searches that do not yield any results.
+        // We do not use the possible (half-)openness of the range here: If we do not get any result here,
+        // we do not have any results for the closed range and, hence, also not any hits if the range is (half-)open.
+
+        if (!range_spec->left_unbounded && !range_spec->right_unbounded) {
+            enum_hint_sc.lookupRange(enum_store.make_folded_comparator(range_spec->left.c_str()),
+                                     enum_store.make_folded_comparator(range_spec->right.c_str()));
+
+        } else if (!range_spec->left_unbounded) {
+            enum_hint_sc.lookupRange(
+                enum_store.make_folded_comparator(range_spec->left.c_str()),
+                vespalib::datastore::PositiveInfinityUniqueStoreStringComparator<IEnumStore::InternalIndex>(
+                    enum_store.get_data_store()));
+
+        } else if (!range_spec->right_unbounded) {
+            enum_hint_sc.lookupRange(
+                vespalib::datastore::NegativeInfinityUniqueStoreStringComparator<IEnumStore::InternalIndex>(
+                    enum_store.get_data_store()),
+                enum_store.make_folded_comparator(range_spec->right.c_str()));
+
+        } else {
+            enum_hint_sc.lookupRange(
+                vespalib::datastore::NegativeInfinityUniqueStoreStringComparator<IEnumStore::InternalIndex>(
+                    enum_store.get_data_store()),
+                vespalib::datastore::PositiveInfinityUniqueStoreStringComparator<IEnumStore::InternalIndex>(
+                    enum_store.get_data_store()));
+        }
     }
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.cpp
@@ -1,0 +1,9 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "string_range_posting_search_context.hpp"
+
+namespace search::attribute {
+
+// no code here yet
+
+} // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.h
@@ -1,0 +1,35 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "posting_list_folded_search_context.h"
+#include "postinglistsearchcontext.h"
+
+namespace search::attribute {
+
+/*
+ * A variant of the StringPostingSearchContext for use with a base search context that uses the StringRangeMatcher.
+ */
+template <typename BaseSC, typename AttrT, typename DataT>
+class StringRangePostingSearchContext
+    : public PostingSearchContext<BaseSC, PostingListFoldedSearchContextT<DataT>, AttrT> {
+private:
+    using ExecuteInfo = queryeval::ExecuteInfo;
+    using Parent = PostingSearchContext<BaseSC, PostingListFoldedSearchContextT<DataT>, AttrT>;
+    using Parent::_enumStore;
+
+    const StringRangeSpec* _range_spec;
+
+    // Note: Steps iterator one or more steps when not using dictionary entry
+    bool use_dictionary_entry(PostingListSearchContext::DictionaryConstIterator& it) const override;
+    // Note: Uses copy of dictionary iterator to avoid stepping original.
+    bool use_single_dictionary_entry(PostingListSearchContext::DictionaryConstIterator it) const {
+        return use_dictionary_entry(it);
+    }
+    bool use_posting_lists_when_non_strict(const ExecuteInfo& info) const override;
+
+public:
+    StringRangePostingSearchContext(BaseSC&& base_sc, bool use_bit_vector, const AttrT& to_be_searched);
+};
+
+} // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.hpp
@@ -5,6 +5,8 @@
 #include "posting_list_folded_search_context.hpp"
 #include "string_range_posting_search_context.h"
 
+#include <vespa/vespalib/datastore/infinity_unique_store_string_comparator.h>
+
 namespace search::attribute {
 
 template <typename BaseSC, typename AttrT, typename DataT>
@@ -13,11 +15,29 @@ StringRangePostingSearchContext<BaseSC, AttrT, DataT>::StringRangePostingSearchC
                                                                                        const AttrT& to_be_searched)
     : Parent(std::move(base_sc), use_bit_vector, to_be_searched), _range_spec(this->get_string_range_spec()) {
     if (this->valid() && _range_spec) {
-        const std::string& left = _range_spec->left;
-        const std::string& right = _range_spec->right;
-        auto               comp_left = _enumStore.make_folded_comparator(left.c_str());
-        auto               comp_right = _enumStore.make_folded_comparator(right.c_str());
-        this->lookupRange(comp_left, comp_right);
+        if (!_range_spec->left_unbounded && !_range_spec->right_unbounded) {
+            this->lookupRange(_enumStore.make_folded_comparator(_range_spec->left.c_str()),
+                              _enumStore.make_folded_comparator(_range_spec->right.c_str()));
+
+        } else if (!_range_spec->left_unbounded) {
+            this->lookupRange(
+                _enumStore.make_folded_comparator(_range_spec->left.c_str()),
+                vespalib::datastore::PositiveInfinityUniqueStoreStringComparator<IEnumStore::InternalIndex>(
+                    _enumStore.get_data_store()));
+
+        } else if (!_range_spec->right_unbounded) {
+            this->lookupRange(
+                vespalib::datastore::NegativeInfinityUniqueStoreStringComparator<IEnumStore::InternalIndex>(
+                    _enumStore.get_data_store()),
+                _enumStore.make_folded_comparator(_range_spec->right.c_str()));
+
+        } else {
+            this->lookupRange(
+                vespalib::datastore::NegativeInfinityUniqueStoreStringComparator<IEnumStore::InternalIndex>(
+                    _enumStore.get_data_store()),
+                vespalib::datastore::PositiveInfinityUniqueStoreStringComparator<IEnumStore::InternalIndex>(
+                    _enumStore.get_data_store()));
+        }
         if (this->_uniqueValues == 1u) {
             if (!this->_lowerDictItr.valid() || use_single_dictionary_entry(this->_lowerDictItr)) {
                 this->lookupSingle();

--- a/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.hpp
@@ -1,0 +1,47 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "posting_list_folded_search_context.hpp"
+#include "string_range_posting_search_context.h"
+
+namespace search::attribute {
+
+template <typename BaseSC, typename AttrT, typename DataT>
+StringRangePostingSearchContext<BaseSC, AttrT, DataT>::StringRangePostingSearchContext(BaseSC&&     base_sc,
+                                                                                       bool         use_bit_vector,
+                                                                                       const AttrT& to_be_searched)
+    : Parent(std::move(base_sc), use_bit_vector, to_be_searched), _range_spec(this->get_string_range_spec()) {
+    if (this->valid() && _range_spec) {
+        const std::string& left = _range_spec->left;
+        const std::string& right = _range_spec->right;
+        auto               comp_left = _enumStore.make_folded_comparator(left.c_str());
+        auto               comp_right = _enumStore.make_folded_comparator(right.c_str());
+        this->lookupRange(comp_left, comp_right);
+        if (this->_uniqueValues == 1u) {
+            if (!this->_lowerDictItr.valid() || use_single_dictionary_entry(this->_lowerDictItr)) {
+                this->lookupSingle();
+            } else {
+                this->_uniqueValues = 0;
+            }
+        }
+    }
+}
+
+template <typename BaseSC, typename AttrT, typename DataT>
+bool StringRangePostingSearchContext<BaseSC, AttrT, DataT>::use_dictionary_entry(
+    PostingListSearchContext::DictionaryConstIterator& it) const {
+    if (this->match(_enumStore.get_value(it.getKey().load_acquire()))) {
+        return true;
+    }
+    ++it;
+    return false;
+}
+
+template <typename BaseSC, typename AttrT, typename DataT>
+bool StringRangePostingSearchContext<BaseSC, AttrT, DataT>::use_posting_lists_when_non_strict(
+    const ExecuteInfo& /*info*/) const {
+    return false;
+}
+
+} // namespace search::attribute

--- a/vespalib/src/vespa/vespalib/datastore/infinity_unique_store_string_comparator.h
+++ b/vespalib/src/vespa/vespalib/datastore/infinity_unique_store_string_comparator.h
@@ -1,0 +1,58 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "unique_store_string_comparator.h"
+
+namespace vespalib::datastore {
+
+/**
+ * Compare two strings based on entry refs.
+ *
+ * Valid entry ref is mapped to a string in a data store.
+ * Invalid entry ref is mapped to negative infinity.
+ */
+template <typename RefT> class NegativeInfinityUniqueStoreStringComparator
+    : public UniqueStoreStringComparator<RefT> {
+public:
+    NegativeInfinityUniqueStoreStringComparator(
+        const typename UniqueStoreStringComparator<RefT>::DataStoreType& store) noexcept
+        : UniqueStoreStringComparator<RefT>(store) {}
+    bool less(const EntryRef lhs, const EntryRef rhs) const noexcept override {
+        bool lhs_neg_infty = !lhs.valid();
+        bool rhs_neg_infty = !rhs.valid();
+        return !rhs_neg_infty && (lhs_neg_infty || (strcmp(this->get(lhs), this->get(rhs)) < 0));
+    }
+    bool equal(const EntryRef lhs, const EntryRef rhs) const noexcept override {
+        bool lhs_neg_infty = !lhs.valid();
+        bool rhs_neg_infty = !rhs.valid();
+        return (lhs_neg_infty && rhs_neg_infty) ||
+               (!lhs_neg_infty && !rhs_neg_infty && (strcmp(this->get(lhs), this->get(rhs)) == 0));
+    }
+};
+
+/**
+ * Compare two strings based on entry refs.
+ *
+ * Valid entry ref is mapped to a string in a data store.
+ * Invalid entry ref is mapped to positive infinity.
+ */
+template <typename RefT> class PositiveInfinityUniqueStoreStringComparator
+    : public UniqueStoreStringComparator<RefT> {
+public:
+    PositiveInfinityUniqueStoreStringComparator(
+        const typename UniqueStoreStringComparator<RefT>::DataStoreType& store) noexcept
+        : UniqueStoreStringComparator<RefT>(store) {}
+    bool less(const EntryRef lhs, const EntryRef rhs) const noexcept override {
+        bool lhs_pos_infty = !lhs.valid();
+        bool rhs_pos_infty = !rhs.valid();
+        return !lhs_pos_infty && (rhs_pos_infty || (strcmp(this->get(lhs), this->get(rhs)) < 0));
+    }
+    bool equal(const EntryRef lhs, const EntryRef rhs) const noexcept override {
+        bool lhs_pos_infty = !lhs.valid();
+        bool rhs_pos_infty = !rhs.valid();
+        return (lhs_pos_infty && rhs_pos_infty) ||
+               (!lhs_pos_infty && !rhs_pos_infty && (strcmp(this->get(lhs), this->get(rhs)) == 0));
+    }
+};
+
+} // namespace vespalib::datastore


### PR DESCRIPTION
Adds a `StringRangePostingSearchContext` and wires the (posting and non-posting) search contexts for string ranges into the corresponding string attribute vectors. Adds unit tests to `SearchContextTest`.

Fixes the behavior for unbounded ranges with new comparators `NegativeInfinityUniqueStoreStringComparator` and `PositiveInfinityUniqueStoreStringComparator`. Not sure if we already have something like that.

No way to use this yet, so functionality should be unchanged.

@johansolbakken fyi