### PR TITLE
Add FastMapSearcher

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
@@ -1,0 +1,123 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.querytransform;
+
+import com.yahoo.component.chain.dependencies.After;
+import com.yahoo.component.chain.dependencies.Before;
+import com.yahoo.prelude.query.CompositeItem;
+import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.QueryCanonicalizer;
+import com.yahoo.prelude.query.SameElementItem;
+import com.yahoo.prelude.query.WordItem;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.schema.FieldInfo;
+import com.yahoo.search.schema.SchemaInfo;
+import com.yahoo.search.searchchain.Execution;
+import com.yahoo.search.searchchain.PhaseNames;
+import com.yahoo.searchlib.document.FastMapSearch;
+
+/**
+ * When a field has fast map search enabled, this class transforms queries on
+ * that field to target the fast map attribute.
+ *
+ * @author johsol
+ */
+@Before(QueryCanonicalizer.queryCanonicalization)
+@After(PhaseNames.TRANSFORMED_QUERY)
+public class FastMapSearcher extends Searcher {
+
+    @Override
+    public Result search(Query query, Execution execution) {
+        var schemaInfo = execution.context().schemaInfo();
+        var session = schemaInfo.newSession(query);
+        rewriteFastMapSearch(query, session);
+        return execution.search(query);
+    }
+
+    private void rewriteFastMapSearch(Query query, SchemaInfo.Session session) {
+        Item root = query.getModel().getQueryTree().getRoot();
+        Item possibleNewRoot = rewriteFastMapSearchVisit(root, session);
+        if (root != possibleNewRoot) {
+            query.getModel().getQueryTree().setRoot(possibleNewRoot);
+            query.trace("rewrote sameElement to fast-map lookup", true, 2);
+        }
+    }
+
+    /**
+     * Rewrite sameElement for fast map search.
+     *
+     * Package-private for unit testing.
+     */
+    Item rewriteFastMapSearchVisit(Item item, SchemaInfo.Session session) {
+        if (item == null) {
+            return null;
+        }
+
+        // handle sameelement rewrite
+        if (item instanceof SameElementItem sameElementItem) {
+            String fieldName = sameElementItem.getIndexName();
+            if (isFastMapSearch(fieldName, session)) {
+                var kv = KeyValue.parse(sameElementItem);
+                if (kv.hasKeyValue) {
+                    return makeFastMapSearchWordItem(kv.key, kv.value, fieldName);
+                }
+            }
+        }
+
+        // recursively try rewrite children.
+        if (item instanceof CompositeItem composite) {
+            for (int i = 0; i < composite.getItemCount(); i++) {
+                Item child = composite.getItem(i);
+                Item newChild = rewriteFastMapSearchVisit(child, session);
+                if (newChild != child) {
+                    composite.setItem(i, newChild);
+                }
+            }
+        }
+
+        return item;
+    }
+
+    /**
+     * Parses key and value to string form.
+     */
+    private record KeyValue(boolean hasKeyValue, String key, String value) {
+
+        /**
+         * Recognizes that same element has two elements called key and value, and
+         * that they are string items.
+         * TODO: extend to handle IntItem
+         */
+        static KeyValue parse(SameElementItem sameElementItem) {
+            if (sameElementItem.getItemCount() == 2) {
+                if (sameElementItem.getItem(0) instanceof WordItem item1
+                    && sameElementItem.getItem(1) instanceof WordItem item2) {
+                    if (isKeyValue(item1, item2)) {
+                        return new KeyValue(true, item1.getWord(), item2.getWord());
+                    } else if (isKeyValue(item2, item1)) {
+                        return new KeyValue(true,  item2.getWord(), item1.getWord());
+                    }
+                }
+            }
+
+            return new KeyValue(false, null, null);
+        }
+
+        static boolean isKeyValue(WordItem key, WordItem value) {
+            return "key".equals(key.getIndexName()) && "value".equals(value.getIndexName());
+        }
+    }
+
+    /** Package-private for unit testing. */
+    WordItem makeFastMapSearchWordItem(String key, String value, String fieldName) {
+        return new WordItem(key + FastMapSearch.keyValueSeparator() + value,
+                FastMapSearch.toKeyValueFieldName(fieldName), false);
+    }
+
+    /** Returns whether the given field has fast map search enabled. */
+    private boolean isFastMapSearch(String fieldName, SchemaInfo.Session session) {
+        return session.fieldInfo(fieldName).map(FieldInfo::hasFastMapSearch).orElse(false);
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/LocalProviderSpec.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/LocalProviderSpec.java
@@ -28,6 +28,7 @@ public class LocalProviderSpec {
                             com.yahoo.search.querytransform.VespaLowercasingSearcher.class,
                             com.yahoo.search.querytransform.DefaultPositionSearcher.class,
                             com.yahoo.search.querytransform.RangeQueryOptimizer.class,
+                            com.yahoo.search.querytransform.FastMapSearcher.class,
                             com.yahoo.search.querytransform.SortingDegrader.class,
                             com.yahoo.prelude.searcher.ValidateSortingSearcher.class,
                             com.yahoo.search.searchers.QueryValidator.class,

--- a/container-search/src/test/java/com/yahoo/search/querytransform/FastMapSearcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/FastMapSearcherTest.java
@@ -1,0 +1,87 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.querytransform;
+
+import com.yahoo.prelude.query.AndItem;
+import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.SameElementItem;
+import com.yahoo.prelude.query.WordItem;
+import com.yahoo.search.Query;
+import com.yahoo.search.schema.Field;
+import com.yahoo.search.schema.Schema;
+import com.yahoo.search.schema.SchemaInfo;
+import com.yahoo.search.searchchain.Execution;
+import com.yahoo.searchlib.document.FastMapSearch;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link FastMapSearcher}
+ */
+public class FastMapSearcherTest {
+
+    @Test
+    public void requireWordItemMadeCorrectly() {
+        FastMapSearcher searcher = new FastMapSearcher();
+        var word = searcher.makeFastMapSearchWordItem("foo", "bar", "baz");
+
+        var arr = word.getWord().toCharArray();
+        assertEquals('f', arr[0]);
+        assertEquals('o', arr[1]);
+        assertEquals('o', arr[2]);
+        assertEquals((char)0x7F, arr[3]);
+        assertEquals('b', arr[4]);
+        assertEquals('a', arr[5]);
+        assertEquals('r', arr[6]);
+
+        assertEquals("baz$keyvalue", word.getIndexName());
+    }
+
+    @Test
+    public void requireSameElementRewrittenForFastMapField() {
+        var schema = new Schema.Builder("test")
+                .add(new Field.Builder("mymap", "map<string,string>").setFastMapSearch(true).build())
+                .add(new Field.Builder("othermap", "map<string,string>").build())
+                .build();
+        var schemaInfo = new SchemaInfo(List.of(schema), List.of());
+        var execution = new Execution(Execution.Context.createContextStub(schemaInfo));
+
+        String expectedWord = "mymap$keyvalue:foo" + FastMapSearch.keyValueSeparator() + "bar";
+
+        // Rewritten at the root
+        Query query = queryWith(sameElement("mymap"));
+        new FastMapSearcher().search(query, execution);
+        assertEquals(expectedWord, query.getModel().getQueryTree().getRoot().toString());
+
+        // Rewritten below a composite
+        AndItem and = new AndItem();
+        and.addItem(sameElement("mymap"));
+        and.addItem(new WordItem("other", "title"));
+        query = queryWith(and);
+        new FastMapSearcher().search(query, execution);
+        assertEquals("AND " + expectedWord + " title:other",
+                query.getModel().getQueryTree().getRoot().toString());
+
+        // Untouched when the field does not have fast map search
+        query = queryWith(sameElement("othermap"));
+        new FastMapSearcher().search(query, execution);
+        assertEquals("othermap:{key:foo value:bar}",
+                query.getModel().getQueryTree().getRoot().toString());
+    }
+
+    private static SameElementItem sameElement(String field) {
+        SameElementItem sameElement = new SameElementItem(field);
+        sameElement.addItem(new WordItem("foo", "key"));
+        sameElement.addItem(new WordItem("bar", "value"));
+        return sameElement;
+    }
+
+    private static Query queryWith(Item root) {
+        Query query = new Query();
+        query.getModel().getQueryTree().setRoot(root);
+        return query;
+    }
+
+}


### PR DESCRIPTION
Can now round-trip fast map search. For `map<string,string>` we now recognize the form:

```
field contains sameElement(key contains "foo", value contains "bar")
```

and if `field` has fast map search enabled, we rewrite it to:

```
WordItem("foo DEL bar", field$keyvalue)
```

Tested with trace level 2, and it outputs:

```
rewrote sameElement to fast-map lookup: [select foo from sources * where foo$keyvalue contains ({implicitTransforms: false}\"baz\\u007Fbar\") timeout 9997]
```

@arnej27959 please review
@boeker fyi