### PR TITLE
Add dequantized tensor docsum field rendering

### DIFF
--- a/searchsummary/src/tests/docsummary/attributedfw/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/attributedfw/CMakeLists.txt
@@ -5,6 +5,7 @@ vespa_add_executable(searchsummary_attributedfw_test_app TEST
     DEPENDS
     vespa_searchsummary
     searchsummary_test
+    searchlib_test
     GTest::gtest
 )
 vespa_add_test(NAME searchsummary_attributedfw_test_app COMMAND searchsummary_attributedfw_test_app)

--- a/searchsummary/src/tests/docsummary/attributedfw/attributedfw_test.cpp
+++ b/searchsummary/src/tests/docsummary/attributedfw/attributedfw_test.cpp
@@ -1,12 +1,19 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/eval/eval/fast_value.h>
+#include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/test/value_compare.h>
+#include <vespa/eval/eval/value_codec.h>
 #include <vespa/searchlib/common/matching_elements_fields.h>
+#include <vespa/searchlib/tensor/tensor_attribute.h>
+#include <vespa/searchlib/test/tensor_divergence.h>
 #include <vespa/searchsummary/docsummary/attributedfw.h>
 #include <vespa/searchsummary/docsummary/summary_elements_selector.h>
 #include <vespa/searchsummary/test/mock_attribute_manager.h>
 #include <vespa/searchsummary/test/mock_state_callback.h>
 #include <vespa/searchsummary/test/slime_value.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/objects/nbostream.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("attributedfw_test");
@@ -22,11 +29,25 @@ using search::docsummary::SummaryElementsSelector;
 using search::docsummary::test::MockAttributeManager;
 using search::docsummary::test::MockStateCallback;
 using search::docsummary::test::SlimeValue;
+using search::test::compute_tensor_nrmse;
+using vespalib::eval::FastValueBuilderFactory;
+using vespalib::eval::TensorSpec;
+using vespalib::eval::Value;
 
 using ElementVector = std::vector<uint32_t>;
 
 std::vector<char> as_vector(std::string_view value) {
     return {value.data(), value.data() + value.size()};
+}
+
+const std::string dense_tensor_spec = "tensor(x[4])";
+
+[[nodiscard]] std::unique_ptr<Value> tensor_from_spec(const TensorSpec& spec) {
+    return value_from_spec(spec, FastValueBuilderFactory::get());
+}
+
+[[nodiscard]] std::unique_ptr<Value> make_tensor(const double x1, const double x3) {
+    return tensor_from_spec(TensorSpec(dense_tensor_spec).add({{"x", 1}}, x1).add({{"x", 3}}, x3));
 }
 
 class AttributeDFWTest : public ::testing::Test {
@@ -59,6 +80,13 @@ public:
 
         _attrs.build_string_attribute("single_str", {{"world"}, {}}, CollectionType::SINGLE);
         _attrs.build_raw_attribute("single_raw", {{as_vector("hello")}, {}});
+
+        std::vector<std::unique_ptr<Value>> tensors;
+        tensors.emplace_back(make_tensor(4, 2));
+        tensors.emplace_back(make_tensor(10, 20));
+
+        _attrs.build_tensor_attribute("dense_tensor", dense_tensor_spec, false, tensors);
+        _attrs.build_tensor_attribute("quantized_dense_tensor", dense_tensor_spec, true, tensors);
         _state._attrCtx = _attrs.mgr().createContext();
         _state._matching_elements_fields = _matching_elements_fields;
     }
@@ -74,7 +102,7 @@ public:
         _writer = AttributeDFWFactory::create(_attrs.mgr(), field_name);
         _writer->setIndex(0);
         auto attr = _state._attrCtx->getAttribute(field_name);
-        if (attr->hasMultiValue()) {
+        if (attr->hasMultiValue() || (attr->getBasicType() == BasicType::TENSOR)) {
             EXPECT_TRUE(_writer->setFieldWriterStateIndex(0));
             _state._fieldWriterStates.resize(1);
         } else {
@@ -85,15 +113,25 @@ public:
         _state._attributes[0] = attr;
     }
 
-    void expect_field(const std::string& exp_slime_as_json, uint32_t docid) {
+    [[nodiscard]] vespalib::Slime field_to_slime(uint32_t docid) {
         vespalib::Slime                act;
         vespalib::slime::SlimeInserter inserter(act);
         if (!_writer->isDefaultValue(docid, _state)) {
             _writer->insert_field(docid, nullptr, _state, _elements_selector->get_selected_elements(docid, _state),
                                   inserter);
         }
+        return act;
+    }
 
-        SlimeValue exp(exp_slime_as_json);
+    [[nodiscard]] static std::unique_ptr<Value> decode_slime_to_tensor(const vespalib::Slime& obj) {
+        auto                buf = obj.get().asData();
+        vespalib::nbostream in_stream(buf.data, buf.size);
+        return vespalib::eval::decode_value(in_stream, FastValueBuilderFactory::get());
+    }
+
+    void expect_field(const std::string& exp_slime_as_json, uint32_t docid) {
+        vespalib::Slime act = field_to_slime(docid);
+        SlimeValue      exp(exp_slime_as_json);
         EXPECT_EQ(exp.slime, act);
     }
 
@@ -192,6 +230,29 @@ TEST_F(AttributeDFWTest, single_value_raw) {
     setup("single_raw", false);
     expect_field("x68656C6C6F", 1);
     expect_field("null", 2);
+}
+
+TEST_F(AttributeDFWTest, tensors_are_rendered_as_encoded_data_field) {
+    setup("dense_tensor", false);
+    // To be able to actually compare the rendered tensors, we have to decode the output
+    const auto t1 = decode_slime_to_tensor(field_to_slime(1));
+    EXPECT_EQ(*t1, *make_tensor(4, 2));
+    const auto t2 = decode_slime_to_tensor(field_to_slime(2));
+    EXPECT_EQ(*t2, *make_tensor(10, 20));
+}
+
+TEST_F(AttributeDFWTest, quantized_tensor_cells_are_dequantized_and_rendered_as_encoded_data_field) {
+    setup("quantized_dense_tensor", false);
+    // Quantized tensors are approximations, so we have to compare within a max error bound
+    constexpr double max_error = 0.0125;
+
+    const auto t1 = decode_slime_to_tensor(field_to_slime(1));
+    const auto expected_t1 = make_tensor(4, 2);
+    EXPECT_LE(compute_tensor_nrmse(*expected_t1, *t1), max_error);
+
+    const auto t2 = decode_slime_to_tensor(field_to_slime(2));
+    const auto expected_t2 = make_tensor(10, 20);
+    EXPECT_LE(compute_tensor_nrmse(*expected_t2, *t2), max_error);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchsummary/src/vespa/searchsummary/docsummary/attributedfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/attributedfw.cpp
@@ -17,6 +17,7 @@
 #include <vespa/searchlib/common/matching_elements.h>
 #include <vespa/searchlib/common/matching_elements_fields.h>
 #include <vespa/searchlib/tensor/i_tensor_attribute.h>
+#include <vespa/searchlib/tensor/tensor_quantization.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/objects/nbostream.h>
 #include <vespa/vespalib/util/issue.h>
@@ -25,13 +26,13 @@
 LOG_SETUP(".searchlib.docsummary.attributedfw");
 
 using namespace search;
-using search::attribute::BasicType;
-using search::attribute::IArrayBoolReadView;
-using search::attribute::IAttributeContext;
-using search::attribute::IAttributeVector;
-using search::attribute::IMultiValueAttribute;
-using search::attribute::IMultiValueReadView;
-using search::common::ElementIds;
+using attribute::BasicType;
+using attribute::IArrayBoolReadView;
+using attribute::IAttributeContext;
+using attribute::IAttributeVector;
+using attribute::IMultiValueAttribute;
+using attribute::IMultiValueReadView;
+using common::ElementIds;
 using vespalib::Issue;
 using vespalib::Memory;
 using vespalib::eval::Value;
@@ -44,7 +45,7 @@ namespace search::docsummary {
 AttrDFW::AttrDFW(const std::string& attrName) : _attrName(attrName) {
 }
 
-const attribute::IAttributeVector& AttrDFW::get_attribute(const GetDocsumsState& s) const {
+const IAttributeVector& AttrDFW::get_attribute(const GetDocsumsState& s) const {
     return *s.getAttribute(getIndex());
 }
 
@@ -86,24 +87,16 @@ void SingleAttrDFW::insert_field(uint32_t docid, const IDocsumStoreDocument*, Ge
         break;
     }
     case BasicType::Type::TENSOR: {
-        const tensor::ITensorAttribute* tv = v.asTensorAttribute();
-        assert(tv != nullptr);
-        const auto tensor = tv->getTensor(docid);
-        if (tensor) {
-            vespalib::nbostream str;
-            encode_value(*tensor, str);
-            target.insertData(vespalib::Memory(str.peek(), str.size()));
-        }
-        break;
+        break; // Not handled by this field writer
     }
     case BasicType::STRING: {
         auto s = v.get_raw(docid);
-        target.insertString(vespalib::Memory(s.data(), s.size()));
+        target.insertString(Memory(s.data(), s.size()));
         break;
     }
     case BasicType::RAW: {
         auto s = v.get_raw(docid);
-        target.insertData(vespalib::Memory(s.data(), s.size()));
+        target.insertData(Memory(s.data(), s.size()));
         break;
     }
     case BasicType::REFERENCE:
@@ -112,7 +105,61 @@ void SingleAttrDFW::insert_field(uint32_t docid, const IDocsumStoreDocument*, Ge
     default:
         break; // Unknown type
     }
-    return;
+}
+
+//-----------------------------------------------------------------------------
+
+class TensorAttrDFW : public AttrDFW {
+    uint32_t _state_index; // index into _fieldWriterStates in GetDocsumsState
+
+public:
+    TensorAttrDFW(const std::string& attr_name) : AttrDFW(attr_name), _state_index(0) {}
+    bool setFieldWriterStateIndex(uint32_t field_writer_state_index) override {
+        _state_index = field_writer_state_index;
+        return true;
+    }
+    void insert_field(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState& state,
+                      ElementIds selected_elements, Inserter& target) const override;
+};
+
+class TensorAttrDFWState : public DocsumFieldWriterState {
+    const tensor::ITensorAttribute&            _tensor_attr;
+    std::unique_ptr<tensor::TensorDequantizer> _dequantizer;
+
+public:
+    explicit TensorAttrDFWState(const tensor::ITensorAttribute& attr);
+    ~TensorAttrDFWState() override;
+    void insertField(uint32_t docid, ElementIds selected_elements, Inserter& target) override;
+};
+
+TensorAttrDFWState::TensorAttrDFWState(const tensor::ITensorAttribute& attr)
+    : _tensor_attr(attr),
+      _dequantizer(attr.is_quantized() ? attr.make_dequantizer() : std::unique_ptr<tensor::TensorDequantizer>()) {
+}
+
+TensorAttrDFWState::~TensorAttrDFWState() = default;
+
+void TensorAttrDFWState::insertField(uint32_t docid, ElementIds, Inserter& target) {
+    if (auto tensor = _tensor_attr.getTensor(docid)) {
+        if (_dequantizer) {
+            tensor = _dequantizer->dequantize(*tensor);
+        }
+        vespalib::nbostream str;
+        encode_value(*tensor, str);
+        target.insertData(Memory(str.peek(), str.size()));
+    }
+}
+
+void TensorAttrDFW::insert_field(uint32_t docid, const IDocsumStoreDocument*, GetDocsumsState& state,
+                                 ElementIds selected_elements, Inserter& target) const {
+    auto& field_writer_state = state._fieldWriterStates[_state_index];
+    if (!field_writer_state) {
+        const auto& attr = get_attribute(state);
+        const auto* as_tensor_attr = attr.asTensorAttribute();
+        assert(as_tensor_attr != nullptr);
+        field_writer_state = &state.get_stash().create<TensorAttrDFWState>(*as_tensor_attr);
+    }
+    field_writer_state->insertField(docid, selected_elements, target);
 }
 
 //-----------------------------------------------------------------------------
@@ -258,7 +305,6 @@ void MultiAttrDFWStateBool::insertField(uint32_t docid, ElementIds selected_elem
 }
 
 class MultiAttrDFW : public AttrDFW {
-private:
     uint32_t _state_index; // index into _fieldWriterStates in GetDocsumsState
 
 public:
@@ -350,6 +396,8 @@ std::unique_ptr<DocsumFieldWriter> AttributeDFWFactory::create(const IAttributeM
     }
     if (attr->hasMultiValue()) {
         return create_multi_writer(*attr);
+    } else if (attr->getBasicType() == BasicType::TENSOR) {
+        return std::make_unique<TensorAttrDFW>(attr->getName());
     } else {
         return std::make_unique<SingleAttrDFW>(attr->getName());
     }

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsum_field_writer_state.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsum_field_writer_state.h
@@ -19,7 +19,7 @@ namespace search::docsummary {
  */
 class DocsumFieldWriterState {
 public:
-    virtual void insertField(uint32_t docId, search::common::ElementIds selected_elements,
+    virtual void insertField(uint32_t docId, common::ElementIds selected_elements,
                              vespalib::slime::Inserter& target) = 0;
     virtual ~DocsumFieldWriterState() = default;
 };

--- a/searchsummary/src/vespa/searchsummary/test/mock_attribute_manager.cpp
+++ b/searchsummary/src/vespa/searchsummary/test/mock_attribute_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "mock_attribute_manager.h"
 
+#include <vespa/eval/eval/tensor_spec.h>
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/attribute/array_bool_attribute.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
@@ -9,15 +10,33 @@
 #include <vespa/searchlib/attribute/integerbase.h>
 #include <vespa/searchlib/attribute/single_raw_attribute.h>
 #include <vespa/searchlib/attribute/stringbase.h>
+#include <vespa/searchlib/tensor/tensor_attribute.h>
+#include <vespa/searchlib/test/test_quantization_params.h>
 
 #include <cassert>
 
 using search::attribute::BasicType;
 using search::attribute::CollectionType;
 using search::attribute::Config;
+using search::attribute::QuantizationParams;
 using search::attribute::SingleRawAttribute;
+using vespalib::eval::TensorSpec;
+using vespalib::eval::Value;
+using vespalib::eval::ValueType;
 
 namespace search::docsummary::test {
+
+template <typename AttributeType>
+std::shared_ptr<AttributeType> MockAttributeManager::create_and_register_attribute(const std::string&       name,
+                                                                                   const attribute::Config& cfg) {
+    auto attr_base = AttributeFactory::createAttribute(name, cfg);
+    assert(attr_base);
+    auto attr = std::dynamic_pointer_cast<AttributeType>(attr_base);
+    assert(attr);
+    attr->addReservedDoc();
+    _mgr.add(attr);
+    return attr;
+}
 
 template <typename AttributeType, typename ValueType>
 void MockAttributeManager::build_attribute(const std::string& name, BasicType type, CollectionType col_type,
@@ -27,11 +46,7 @@ void MockAttributeManager::build_attribute(const std::string& name, BasicType ty
     if (uncased.has_value()) {
         cfg.set_match(uncased.value() ? Config::Match::UNCASED : Config::Match::CASED);
     }
-    auto attr_base = AttributeFactory::createAttribute(name, cfg);
-    assert(attr_base);
-    auto attr = std::dynamic_pointer_cast<AttributeType>(attr_base);
-    assert(attr);
-    attr->addReservedDoc();
+    auto attr = create_and_register_attribute<AttributeType>(name, cfg);
     for (const auto& docValues : values) {
         uint32_t docId = 0;
         attr->addDoc(docId);
@@ -46,12 +61,9 @@ void MockAttributeManager::build_attribute(const std::string& name, BasicType ty
         }
         attr->commit();
     }
-    _mgr.add(attr);
 }
 
-MockAttributeManager::MockAttributeManager() : _mgr() {
-}
-
+MockAttributeManager::MockAttributeManager() = default;
 MockAttributeManager::~MockAttributeManager() = default;
 
 void MockAttributeManager::build_string_attribute(const std::string&                           name,
@@ -81,19 +93,38 @@ void MockAttributeManager::build_raw_attribute(const std::string&               
 void MockAttributeManager::build_bool_attribute(const std::string&                      name,
                                                 const std::vector<std::vector<int8_t>>& values) {
     Config cfg(BasicType::BOOL, CollectionType::ARRAY);
-    auto   attr_base = AttributeFactory::createAttribute(name, cfg);
-    assert(attr_base);
-    auto& bool_attr = dynamic_cast<search::attribute::ArrayBoolAttribute&>(*attr_base);
-    attr_base->addReservedDoc();
+    auto   bool_attr = create_and_register_attribute<attribute::ArrayBoolAttribute>(name, cfg);
     for (const auto& doc_values : values) {
         uint32_t docId = 0;
-        attr_base->addDoc(docId);
+        bool_attr->addDoc(docId);
         if (!doc_values.empty()) {
-            bool_attr.set_bools(docId, doc_values);
+            bool_attr->set_bools(docId, doc_values);
         }
-        attr_base->commit();
+        bool_attr->commit();
     }
-    _mgr.add(attr_base);
+}
+
+void MockAttributeManager::build_tensor_attribute(const std::string& name, const std::string& tensor_spec,
+                                                  bool                                       quantized,
+                                                  const std::vector<std::unique_ptr<Value>>& tensors) {
+    Config cfg(BasicType::TENSOR, CollectionType::SINGLE);
+    if (!quantized) {
+        cfg.setTensorType(ValueType::from_spec(tensor_spec));
+    } else {
+        cfg.set_tensor_type_with_quantization(ValueType::from_spec(tensor_spec),
+                                              ::search::test::mse_4bit_quantization_params());
+    }
+    auto attr = create_and_register_attribute<tensor::TensorAttribute>(name, cfg);
+    for (const auto& t : tensors) {
+        uint32_t doc_id = 0;
+        attr->addDoc(doc_id);
+        if (!quantized) {
+            attr->setTensor(doc_id, *t);
+        } else {
+            attr->setTensor(doc_id, *attr->make_quantizer()->quantize(*t));
+        }
+        attr->commit();
+    }
 }
 
 } // namespace search::docsummary::test

--- a/searchsummary/src/vespa/searchsummary/test/mock_attribute_manager.h
+++ b/searchsummary/src/vespa/searchsummary/test/mock_attribute_manager.h
@@ -1,5 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#pragma once
+
+#include <vespa/eval/eval/value.h>
 #include <vespa/searchcommon/attribute/basictype.h>
 #include <vespa/searchlib/attribute/attributemanager.h>
 
@@ -11,12 +14,14 @@ namespace search::docsummary::test {
  * Class used to build attributes and populate a manager for testing.
  */
 class MockAttributeManager {
-private:
     AttributeManager _mgr;
 
+    template <typename AttributeType>
+    std::shared_ptr<AttributeType> create_and_register_attribute(const std::string&       name,
+                                                                 const attribute::Config& cfg);
+
     template <typename AttributeType, typename ValueType>
-    void build_attribute(const std::string& name, search::attribute::BasicType type,
-                         search::attribute::CollectionType          col_type,
+    void build_attribute(const std::string& name, attribute::BasicType type, attribute::CollectionType col_type,
                          const std::vector<std::vector<ValueType>>& values, std::optional<bool> uncased);
 
 public:
@@ -25,15 +30,17 @@ public:
     AttributeManager& mgr() { return _mgr; }
 
     void build_string_attribute(const std::string& name, const std::vector<std::vector<std::string>>& values,
-                                search::attribute::CollectionType col_type = search::attribute::CollectionType::ARRAY,
-                                std::optional<bool>               uncased = std::nullopt);
+                                attribute::CollectionType col_type = attribute::CollectionType::ARRAY,
+                                std::optional<bool>       uncased = std::nullopt);
     void build_float_attribute(const std::string& name, const std::vector<std::vector<double>>& values,
-                               search::attribute::CollectionType col_type = search::attribute::CollectionType::ARRAY);
-    void build_int_attribute(const std::string& name, search::attribute::BasicType type,
+                               attribute::CollectionType col_type = attribute::CollectionType::ARRAY);
+    void build_int_attribute(const std::string& name, attribute::BasicType type,
                              const std::vector<std::vector<int64_t>>& values,
-                             search::attribute::CollectionType col_type = search::attribute::CollectionType::ARRAY);
+                             attribute::CollectionType                col_type = attribute::CollectionType::ARRAY);
     void build_raw_attribute(const std::string& name, const std::vector<std::vector<std::vector<char>>>& values);
     void build_bool_attribute(const std::string& name, const std::vector<std::vector<int8_t>>& values);
+    void build_tensor_attribute(const std::string& name, const std::string& tensor_spec, bool quantized,
+                                const std::vector<std::unique_ptr<vespalib::eval::Value>>& tensors);
 };
 
 } // namespace search::docsummary::test


### PR DESCRIPTION
@arnej27959 @toregge please review

This adds a dedicated tensor docsum field writer which caches and reuses the associated `TensorDequantizer` instance (if any).

It is currently not possible to fetch docsums for quantized tensors from the source of truth document store; the attribute is always used. As far as I know there is no existing config setting that naturally maps to this (since attributes have generally been authoritative), so we'd have to extend this at a later point if we want to fetch from the doc store instead.

Also add tests for existing tensor attribute docsum field rendering, which were missing for some reason.

