### PR TITLE
skip validate name for fast map search

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/IndexFieldNames.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/IndexFieldNames.java
@@ -27,9 +27,7 @@ public class IndexFieldNames extends Processor {
         if ( ! validate) return;
 
         for (SDField field : schema.allConcreteFields()) {
-            // extra field is set by fields created by processors: e.g. CreatePositionZCurve
-            // and CreateFastMapSearch.
-            if (field.isExtraField()) {
+            if (field.hasFastMapSearch()) {
                 continue;
             }
             if ( ! field.getName().matches(FIELD_NAME_REGEXP) &&  ! legalDottedPositionField(field)) {

--- a/config-model/src/main/java/com/yahoo/schema/processing/IndexFieldNames.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/IndexFieldNames.java
@@ -27,6 +27,11 @@ public class IndexFieldNames extends Processor {
         if ( ! validate) return;
 
         for (SDField field : schema.allConcreteFields()) {
+            // extra field is set by fields created by processors: e.g. CreatePositionZCurve
+            // and CreateFastMapSearch.
+            if (field.isExtraField()) {
+                continue;
+            }
             if ( ! field.getName().matches(FIELD_NAME_REGEXP) &&  ! legalDottedPositionField(field)) {
                 fail(schema, field, " Not a legal field name. Legal expression: " + FIELD_NAME_REGEXP);
             }


### PR DESCRIPTION
With schema inheritance, this check runs for fields defined by the parent. With fast map search, the parent generates `foo$keyvalue`, which fails this check for the child. Extra fields are fields that aren't document fields.

@arnej27959, please review: is this the right approach?