### PR TITLE
add cmake function to simplify source-file-specific compiler flags

### DIFF
--- a/defaults/src/apps/printdefault/CMakeLists.txt
+++ b/defaults/src/apps/printdefault/CMakeLists.txt
@@ -7,4 +7,4 @@ vespa_add_executable(defaults_vespa-print-default_app
     DEPENDS
     vespadefaults
 )
-set_source_files_properties(printdefault.cpp PROPERTIES COMPILE_FLAGS "${VTAG_DEFINES}")
+vespa_compile_flag_for(printdefault.cpp "${VTAG_DEFINES}")

--- a/documentapi/src/vespa/documentapi/messagebus/CMakeLists.txt
+++ b/documentapi/src/vespa/documentapi/messagebus/CMakeLists.txt
@@ -17,7 +17,7 @@ vespa_suppress_warnings_for_protobuf_sources(SOURCES ${documentapi_messagebus_PR
 
 # protoc explicitly annotates methods with inline, which triggers -Werror=inline when
 # the header file grows over a certain size.
-set_source_files_properties(routable_factories_8.cpp PROPERTIES COMPILE_FLAGS "-Wno-inline")
+vespa_compile_flag_for(routable_factories_8.cpp "-Wno-inline")
 
 vespa_add_library(documentapi_documentapimessagebus OBJECT
     SOURCES

--- a/functions.cmake
+++ b/functions.cmake
@@ -250,7 +250,7 @@ function(__install_header_files)
             get_filename_component(RELDIR ${HEADER} DIRECTORY)
             install(FILES ${RELATIVE_TO}/${HEADER} DESTINATION include/vespa/${RELDIR})
         endforeach()
-   endif()   
+   endif()
 endfunction()
 
 function(vespa_add_executable TARGET)
@@ -461,7 +461,7 @@ function(vespa_add_test)
     if (ARG_COST)
         set_tests_properties(${ARG_NAME} PROPERTIES COST ${ARG_COST})
     endif()
-    
+
     if(ARG_RUN_SERIAL)
         set_tests_properties(${ARG_NAME} PROPERTIES RUN_SERIAL TRUE)
     endif()
@@ -505,6 +505,10 @@ function(vespa_workaround_gcc_bug_67055 SOURCE_FILE)
             set_source_files_properties(${SOURCE_FILE} PROPERTIES COMPILE_FLAGS -fno-ipa-icf)
         endif()
     endif()
+endfunction()
+
+function(vespa_compile_flag_for SOURCE_FILE COMPILE_FLAG)
+    set_source_files_properties(${SOURCE_FILE} PROPERTIES COMPILE_FLAGS ${COMPILE_FLAG})
 endfunction()
 
 macro(__initialize_module)

--- a/searchlib/src/tests/engine/proto_converter/CMakeLists.txt
+++ b/searchlib/src/tests/engine/proto_converter/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-set_source_files_properties(proto_converter_test.cpp PROPERTIES COMPILE_FLAGS "-Wno-inline")
+vespa_compile_flag_for(proto_converter_test.cpp "-Wno-inline")
 
 vespa_add_executable(searchlib_engine_proto_converter_test_app TEST
     SOURCES

--- a/searchlib/src/tests/engine/proto_rpc_adapter/CMakeLists.txt
+++ b/searchlib/src/tests/engine/proto_rpc_adapter/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-set_source_files_properties(proto_rpc_adapter_test.cpp PROPERTIES COMPILE_FLAGS "-Wno-inline")
+vespa_compile_flag_for(proto_rpc_adapter_test.cpp "-Wno-inline")
 
 vespa_add_executable(searchlib_engine_proto_rpc_adapter_test_app TEST
     SOURCES

--- a/storage/src/vespa/storageapi/mbusprot/CMakeLists.txt
+++ b/storage/src/vespa/storageapi/mbusprot/CMakeLists.txt
@@ -14,7 +14,7 @@ vespa_suppress_warnings_for_protobuf_sources(SOURCES ${storageapi_PROTOBUF_SRCS}
 
 # protoc explicitly annotates methods with inline, which triggers -Werror=inline when
 # the header file grows over a certain size.
-set_source_files_properties(protocolserialization7.cpp PROPERTIES COMPILE_FLAGS "-Wno-inline")
+vespa_compile_flag_for(protocolserialization7.cpp "-Wno-inline")
 
 vespa_add_library(storageapi_mbusprot OBJECT
     SOURCES

--- a/vespalib/src/vespa/vespalib/component/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/component/CMakeLists.txt
@@ -6,4 +6,4 @@ vespa_add_library(vespalib_vespalib_component OBJECT
     vtag.cpp
     DEPENDS
 )
-set_source_files_properties(vtag.cpp PROPERTIES COMPILE_FLAGS "${VTAG_DEFINES}")
+vespa_compile_flag_for(vtag.cpp "${VTAG_DEFINES}")

--- a/vespalib/src/vespa/vespalib/hwaccelerated/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/CMakeLists.txt
@@ -19,14 +19,14 @@ vespa_add_library(vespa_hwaccelerated
     DEPENDS
     INSTALL lib64
 )
-set_source_files_properties(avx2.cpp              PROPERTIES COMPILE_FLAGS "-O3 -march=haswell")
-set_source_files_properties(avx3.cpp              PROPERTIES COMPILE_FLAGS "-O3 -march=skylake-avx512 -mprefer-vector-width=512")
-set_source_files_properties(avx3_dl.cpp           PROPERTIES COMPILE_FLAGS "-O3 -march=icelake-server -mprefer-vector-width=512")
+vespa_compile_flag_for(avx2.cpp              "-O3 -march=haswell")
+vespa_compile_flag_for(avx3.cpp              "-O3 -march=skylake-avx512 -mprefer-vector-width=512")
+vespa_compile_flag_for(avx3_dl.cpp           "-O3 -march=icelake-server -mprefer-vector-width=512")
 
-set_source_files_properties(neon.cpp              PROPERTIES COMPILE_FLAGS "-O3 -march=armv8.2-a")
-set_source_files_properties(neon_fp16_dotprod.cpp PROPERTIES COMPILE_FLAGS "-O3 -march=armv8.2-a+fp16+dotprod+crypto -mtune=neoverse-n1")
-set_source_files_properties(sve.cpp               PROPERTIES COMPILE_FLAGS "-O3 -march=armv8.2-a+sve -mtune=neoverse-n1")
-set_source_files_properties(sve2.cpp              PROPERTIES COMPILE_FLAGS "-O3 -march=armv8.2-a+sve2 -mtune=neoverse-n1")
+vespa_compile_flag_for(neon.cpp              "-O3 -march=armv8.2-a")
+vespa_compile_flag_for(neon_fp16_dotprod.cpp "-O3 -march=armv8.2-a+fp16+dotprod+crypto -mtune=neoverse-n1")
+vespa_compile_flag_for(sve.cpp               "-O3 -march=armv8.2-a+sve -mtune=neoverse-n1")
+vespa_compile_flag_for(sve2.cpp              "-O3 -march=armv8.2-a+sve2 -mtune=neoverse-n1")
 
 set(BLA_VENDOR OpenBLAS)
 vespa_add_target_package_dependency(vespa_hwaccelerated BLAS)


### PR DESCRIPTION
Several CMakeLists.txt files repeated the same
set_source_files_properties(... PROPERTIES COMPILE_FLAGS ...) pattern to set per-file compile flags. Introduce a cmake function vespa_compile_flag_for(SOURCE_FILE COMPILE_FLAG) in functions.cmake to wrap this and use it at existing call sites.
