### PR TITLE
Wire string ranges through Proton query stack 

### DIFF
--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -237,6 +237,7 @@ public:
     void visit(ProtonLocationTerm& n) override { checkNode(n, 0, true); }
     void visit(ProtonPrefixTerm& n) override { checkNode(n, 1, false); }
     void visit(ProtonRangeTerm& n) override { checkNode(n, 2, false); }
+    void visit(ProtonStringRangeTerm&) override {}
     void visit(ProtonStringTerm& n) override { checkNode(n, 2, false); }
     void visit(ProtonSubstringTerm& n) override { checkNode(n, 0, true); }
     void visit(ProtonSuffixTerm& n) override { checkNode(n, 2, false); }
@@ -355,6 +356,7 @@ public:
     void visit(ProtonLocationTerm&) override {}
     void visit(ProtonPrefixTerm&) override {}
     void visit(ProtonRangeTerm&) override {}
+    void visit(ProtonStringRangeTerm&) override {}
 
     void visit(ProtonStringTerm& n) override {
         const ITermData& term_data = n;

--- a/searchcore/src/tests/proton/matching/unpacking_iterators_optimizer/unpacking_iterators_optimizer_test.cpp
+++ b/searchcore/src/tests/proton/matching/unpacking_iterators_optimizer/unpacking_iterators_optimizer_test.cpp
@@ -52,6 +52,7 @@ struct DumpQuery : QueryVisitor {
     }
     void visit(PrefixTerm&) override {}
     void visit(RangeTerm&) override {}
+    void visit(StringRangeTerm&) override {}
     void visit(Rank&) override {}
     void visit(LabelWrapper&) override {}
     void visit(StringTerm& n) override {

--- a/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.cpp
@@ -218,6 +218,7 @@ protected:
     void visit(ProtonLocationTerm& n) override { buildTerm(n); }
     void visit(ProtonPrefixTerm& n) override { buildTerm(n); }
     void visit(ProtonRangeTerm& n) override { buildTerm(n); }
+    void visit(ProtonStringRangeTerm& n) override { buildTerm(n); }
     void visit(ProtonStringTerm& n) override { buildTerm(n); }
     void visit(ProtonSubstringTerm& n) override { buildTerm(n); }
     void visit(ProtonSuffixTerm& n) override { buildTerm(n); }

--- a/searchcore/src/vespa/searchcore/proton/matching/querynodes.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/querynodes.cpp
@@ -146,6 +146,7 @@ template struct ProtonTerm<search::query::NumberTerm>;
 template struct ProtonTerm<search::query::Phrase>;
 template struct ProtonTerm<search::query::PrefixTerm>;
 template struct ProtonTerm<search::query::RangeTerm>;
+template struct ProtonTerm<search::query::StringRangeTerm>;
 template struct ProtonTerm<search::query::StringTerm>;
 template struct ProtonTerm<search::query::SubstringTerm>;
 template struct ProtonTerm<search::query::SuffixTerm>;

--- a/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
@@ -177,6 +177,7 @@ using ProtonPhrase = ProtonTerm<search::query::Phrase>;
 
 using ProtonPrefixTerm = ProtonTerm<search::query::PrefixTerm>;
 using ProtonRangeTerm = ProtonTerm<search::query::RangeTerm>;
+using ProtonStringRangeTerm = ProtonTerm<search::query::StringRangeTerm>;
 using ProtonStringTerm = ProtonTerm<search::query::StringTerm>;
 using ProtonSubstringTerm = ProtonTerm<search::query::SubstringTerm>;
 using ProtonSuffixTerm = ProtonTerm<search::query::SuffixTerm>;
@@ -212,6 +213,7 @@ struct ProtonNodeTypes {
     using SameElement = ProtonSameElement;
     using PrefixTerm = ProtonPrefixTerm;
     using RangeTerm = ProtonRangeTerm;
+    using StringRangeTerm = ProtonStringRangeTerm;
     using Rank = ProtonRank;
     using LabelWrapper = ProtonLabelWrapper;
     using StringTerm = ProtonStringTerm;
@@ -236,6 +238,7 @@ extern template struct ProtonTerm<search::query::NumberTerm>;
 extern template struct ProtonTerm<search::query::Phrase>;
 extern template struct ProtonTerm<search::query::PrefixTerm>;
 extern template struct ProtonTerm<search::query::RangeTerm>;
+extern template struct ProtonTerm<search::query::StringRangeTerm>;
 extern template struct ProtonTerm<search::query::StringTerm>;
 extern template struct ProtonTerm<search::query::SubstringTerm>;
 extern template struct ProtonTerm<search::query::SuffixTerm>;

--- a/searchcore/src/vespa/searchcore/proton/matching/termdatafromnode.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/termdatafromnode.cpp
@@ -37,6 +37,7 @@ struct TermDataFromTermVisitor : public search::query::CustomTypeVisitor<ProtonN
     void visit(ProtonLocationTerm& n) override { visitTerm(n); }
     void visit(ProtonPrefixTerm& n) override { visitTerm(n); }
     void visit(ProtonRangeTerm& n) override { visitTerm(n); }
+    void visit(ProtonStringRangeTerm& n) override { visitTerm(n); }
     void visit(ProtonStringTerm& n) override { visitTerm(n); }
     void visit(ProtonSubstringTerm& n) override { visitTerm(n); }
     void visit(ProtonSuffixTerm& n) override { visitTerm(n); }

--- a/searchcore/src/vespa/searchcore/proton/matching/unpacking_iterators_optimizer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/unpacking_iterators_optimizer.cpp
@@ -47,6 +47,7 @@ struct TermExpander : QueryVisitor {
     }
     void visit(PrefixTerm&) override {}
     void visit(RangeTerm&) override {}
+    void visit(StringRangeTerm&) override {}
     void visit(Rank&) override {}
     void visit(LabelWrapper&) override {}
     void visit(StringTerm&) override {}

--- a/searchcore/src/vespa/searchcorespi/index/indexcollection.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/indexcollection.cpp
@@ -171,6 +171,7 @@ private:
     void visit(LocationTerm& n) override { visitTerm(n); }
     void visit(PrefixTerm& n) override { visitTerm(n); }
     void visit(RangeTerm& n) override { visitTerm(n); }
+    void visit(StringRangeTerm& n) override { visitTerm(n); }
     void visit(StringTerm& n) override { visitTerm(n); }
     void visit(SubstringTerm& n) override { visitTerm(n); }
     void visit(SuffixTerm& n) override { visitTerm(n); }

--- a/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
@@ -303,7 +303,7 @@ template <typename T> MyAttributeManager makeAttributeManager(T value) {
     return MyAttributeManager(attr);
 }
 
-MyAttributeManager makeFastSearchStringAttributeManager(const string& value) {
+MyAttributeManager make_fast_search_string_attribute_manager(const string& value) {
     Config cfg(BasicType::STRING, CollectionType::SINGLE);
     cfg.setFastSearch(true);
     AttributeVector::SP attr_ptr = AttributeFactory::createAttribute(field, cfg);
@@ -314,18 +314,11 @@ MyAttributeManager makeFastSearchStringAttributeManager(const string& value) {
     return MyAttributeManager(attr_ptr);
 }
 
-SimpleStringRangeTerm make_string_range_term(const string& lower, bool lower_inclusive, const string& upper,
-                                             bool upper_inclusive) {
-    auto spec = std::make_unique<search::StringRangeSpec>(lower, lower_inclusive, lower.empty(), upper,
-                                                          upper_inclusive, upper.empty());
+SimpleStringRangeTerm make_string_range_term(const string& left, bool left_closed, bool left_unbounded,
+                                             const string& right, bool right_closed, bool right_unbounded) {
+    auto spec = std::make_unique<search::StringRangeSpec>(left, left_closed, left_unbounded, right, right_closed,
+                                                          right_unbounded);
     return {StringRange(std::move(spec)), field, 0, Weight(0)};
-}
-
-bool string_range_search(IAttributeManager& attribute_manager, const string& lower, bool lower_inclusive,
-                         const string& upper, bool upper_inclusive) {
-    auto   node = make_string_range_term(lower, lower_inclusive, upper, upper_inclusive);
-    Result result = do_search(attribute_manager, node, true);
-    return (result.hits.size() == 1) && (result.hits[0].docid == (num_docs - 1));
 }
 
 MyAttributeManager makeFastSearchLongAttributeManager(int64_t value) {
@@ -361,45 +354,29 @@ TEST(AttributeSearchableAdapterTest, requireThatRangeTermsWorkToo) {
 
 TEST(AttributeSearchableAdapterTest, require_that_string_range_terms_work) {
     for (bool fast_search : {false, true}) {
-        SCOPED_TRACE(fast_search ? "fast-search" : "no fast-search");
         MyAttributeManager attribute_manager =
-            fast_search ? makeFastSearchStringAttributeManager("foo") : makeAttributeManager("foo");
+            fast_search ? make_fast_search_string_attribute_manager("foo") : makeAttributeManager("foo");
 
-        EXPECT_TRUE(string_range_search(attribute_manager, "bar", true, "fox", true));
-        EXPECT_TRUE(string_range_search(attribute_manager, "foo", true, "foo", true));
-        EXPECT_TRUE(string_range_search(attribute_manager, "bar", true, "", true));
+        // Contained in range
+        EXPECT_TRUE(search(make_string_range_term("bar", true, false, "fox", true, false), attribute_manager,
+                           fast_search, true, false));
+        EXPECT_TRUE(search(make_string_range_term("foo", true, false, "foo", true, false), attribute_manager,
+                           fast_search, true, false));
+        EXPECT_TRUE(search(make_string_range_term("bar", true, false, "", false, true), attribute_manager,
+                           fast_search, true, false));
         // matching is uncased by default
-        EXPECT_TRUE(string_range_search(attribute_manager, "BAR", true, "FOX", true));
+        EXPECT_TRUE(search(make_string_range_term("BAR", true, false, "FOX", true, false), attribute_manager,
+                           fast_search, true, false));
 
-        EXPECT_FALSE(string_range_search(attribute_manager, "bar", true, "fon", true));
-        EXPECT_FALSE(string_range_search(attribute_manager, "foo", false, "fox", true));
-        EXPECT_FALSE(string_range_search(attribute_manager, "bar", true, "foo", false));
+        // Not contained in range
+        EXPECT_FALSE(search(make_string_range_term("bar", true, false, "fon", true, false), attribute_manager,
+                            fast_search, true, true));
+        // The following two cannot be expected to be empty since the closed range contains foo
+        EXPECT_FALSE(search(make_string_range_term("foo", false, false, "fox", true, false), attribute_manager,
+                            fast_search, true, false));
+        EXPECT_FALSE(search(make_string_range_term("bar", true, false, "foo", false, false), attribute_manager,
+                            fast_search, true, false));
     }
-}
-
-TEST(AttributeSearchableAdapterTest, require_that_string_range_term_uses_enum_hint) {
-    MyAttributeManager attribute_manager = makeAttributeManager("foo");
-
-    // A range containing an enum store value cannot be eliminated up front.
-    auto   node = make_string_range_term("bar", true, "fox", true);
-    Result result = do_search(attribute_manager, node, true);
-    EXPECT_FALSE(result.est_empty);
-    EXPECT_EQ(num_docs, result.est_hits);
-
-    // A range without any enum store value is known to be empty.
-    node = make_string_range_term("aaa", true, "abb", true);
-    result = do_search(attribute_manager, node, true);
-    EXPECT_TRUE(result.est_empty);
-    EXPECT_EQ(0u, result.est_hits);
-}
-
-TEST(AttributeSearchableAdapterTest, require_that_string_range_on_numeric_attribute_produces_empty_search) {
-    MyAttributeManager attribute_manager = makeAttributeManager(int64_t(42));
-
-    auto   node = make_string_range_term("bar", true, "fox", true);
-    Result result = do_search(attribute_manager, node, true);
-    EXPECT_TRUE(result.est_empty);
-    EXPECT_TRUE(result.hits.empty());
 }
 
 TEST(AttributeSearchableAdapterTest, requireThatPrefixTermsWork) {

--- a/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
@@ -53,11 +53,13 @@ using search::query::SimpleLocationTerm;
 using search::query::SimplePredicateQuery;
 using search::query::SimplePrefixTerm;
 using search::query::SimpleRangeTerm;
+using search::query::SimpleStringRangeTerm;
 using search::query::SimpleStringTerm;
 using search::query::SimpleSubstringTerm;
 using search::query::SimpleSuffixTerm;
 using search::query::SimpleWandTerm;
 using search::query::SimpleWeightedSetTerm;
+using search::query::StringRange;
 using search::query::StringTermVector;
 using search::query::Weight;
 using search::queryeval::Blueprint;
@@ -301,6 +303,31 @@ template <typename T> MyAttributeManager makeAttributeManager(T value) {
     return MyAttributeManager(attr);
 }
 
+MyAttributeManager makeFastSearchStringAttributeManager(const string& value) {
+    Config cfg(BasicType::STRING, CollectionType::SINGLE);
+    cfg.setFastSearch(true);
+    AttributeVector::SP attr_ptr = AttributeFactory::createAttribute(field, cfg);
+    auto*               attr = static_cast<search::StringAttribute*>(attr_ptr.get());
+    add_docs(attr, num_docs);
+    attr->update(num_docs - 1, value);
+    attr->commit();
+    return MyAttributeManager(attr_ptr);
+}
+
+SimpleStringRangeTerm make_string_range_term(const string& lower, bool lower_inclusive, const string& upper,
+                                             bool upper_inclusive) {
+    auto spec = std::make_unique<search::StringRangeSpec>(lower, lower_inclusive, lower.empty(), upper,
+                                                          upper_inclusive, upper.empty());
+    return {StringRange(std::move(spec)), field, 0, Weight(0)};
+}
+
+bool string_range_search(IAttributeManager& attribute_manager, const string& lower, bool lower_inclusive,
+                         const string& upper, bool upper_inclusive) {
+    auto   node = make_string_range_term(lower, lower_inclusive, upper, upper_inclusive);
+    Result result = do_search(attribute_manager, node, true);
+    return (result.hits.size() == 1) && (result.hits[0].docid == (num_docs - 1));
+}
+
 MyAttributeManager makeFastSearchLongAttributeManager(int64_t value) {
     Config cfg(BasicType::INT64, CollectionType::SINGLE);
     cfg.setFastSearch(true);
@@ -330,6 +357,49 @@ TEST(AttributeSearchableAdapterTest, requireThatRangeTermsWorkToo) {
     EXPECT_TRUE(!search("[10;23]", attribute_manager));
     EXPECT_TRUE(!search(">43", attribute_manager));
     EXPECT_TRUE(search("[10;]", attribute_manager));
+}
+
+TEST(AttributeSearchableAdapterTest, require_that_string_range_terms_work) {
+    for (bool fast_search : {false, true}) {
+        SCOPED_TRACE(fast_search ? "fast-search" : "no fast-search");
+        MyAttributeManager attribute_manager =
+            fast_search ? makeFastSearchStringAttributeManager("foo") : makeAttributeManager("foo");
+
+        EXPECT_TRUE(string_range_search(attribute_manager, "bar", true, "fox", true));
+        EXPECT_TRUE(string_range_search(attribute_manager, "foo", true, "foo", true));
+        EXPECT_TRUE(string_range_search(attribute_manager, "bar", true, "", true));
+        // matching is uncased by default
+        EXPECT_TRUE(string_range_search(attribute_manager, "BAR", true, "FOX", true));
+
+        EXPECT_FALSE(string_range_search(attribute_manager, "bar", true, "fon", true));
+        EXPECT_FALSE(string_range_search(attribute_manager, "foo", false, "fox", true));
+        EXPECT_FALSE(string_range_search(attribute_manager, "bar", true, "foo", false));
+    }
+}
+
+TEST(AttributeSearchableAdapterTest, require_that_string_range_term_uses_enum_hint) {
+    MyAttributeManager attribute_manager = makeAttributeManager("foo");
+
+    // A range containing an enum store value cannot be eliminated up front.
+    auto   node = make_string_range_term("bar", true, "fox", true);
+    Result result = do_search(attribute_manager, node, true);
+    EXPECT_FALSE(result.est_empty);
+    EXPECT_EQ(num_docs, result.est_hits);
+
+    // A range without any enum store value is known to be empty.
+    node = make_string_range_term("aaa", true, "abb", true);
+    result = do_search(attribute_manager, node, true);
+    EXPECT_TRUE(result.est_empty);
+    EXPECT_EQ(0u, result.est_hits);
+}
+
+TEST(AttributeSearchableAdapterTest, require_that_string_range_on_numeric_attribute_produces_empty_search) {
+    MyAttributeManager attribute_manager = makeAttributeManager(int64_t(42));
+
+    auto   node = make_string_range_term("bar", true, "fox", true);
+    Result result = do_search(attribute_manager, node, true);
+    EXPECT_TRUE(result.est_empty);
+    EXPECT_TRUE(result.hits.empty());
 }
 
 TEST(AttributeSearchableAdapterTest, requireThatPrefixTermsWork) {

--- a/searchlib/src/tests/query/customtypevisitor_test.cpp
+++ b/searchlib/src/tests/query/customtypevisitor_test.cpp
@@ -81,6 +81,10 @@ struct MyRangeTerm : InitTerm<RangeTerm> {
     ~MyRangeTerm() override;
 };
 
+struct MyStringRangeTerm : InitTerm<StringRangeTerm> {
+    ~MyStringRangeTerm() override;
+};
+
 struct MyStringTerm : InitTerm<StringTerm> {
     ~MyStringTerm() override;
 };
@@ -183,6 +187,7 @@ MyLocationTerm::~MyLocationTerm() = default;
 MyPrefixTerm::~MyPrefixTerm() = default;
 
 MyRangeTerm::~MyRangeTerm() = default;
+MyStringRangeTerm::~MyStringRangeTerm() = default;
 
 MyStringTerm::~MyStringTerm() = default;
 
@@ -227,6 +232,7 @@ struct MyQueryNodeTypes {
     using SameElement = MySameElement;
     using PrefixTerm = MyPrefixTerm;
     using RangeTerm = MyRangeTerm;
+    using StringRangeTerm = MyStringRangeTerm;
     using Rank = MyRank;
     using LabelWrapper = MyLabelWrapper;
     using StringTerm = MyStringTerm;
@@ -267,6 +273,7 @@ public:
     void visit(MySameElement&) override { setVisited<MySameElement>(); }
     void visit(MyPrefixTerm&) override { setVisited<MyPrefixTerm>(); }
     void visit(MyRangeTerm&) override { setVisited<MyRangeTerm>(); }
+    void visit(MyStringRangeTerm&) override { setVisited<MyStringRangeTerm>(); }
     void visit(MyRank&) override { setVisited<MyRank>(); }
     void visit(MyLabelWrapper&) override { setVisited<MyLabelWrapper>(); }
     void visit(MyStringTerm&) override { setVisited<MyStringTerm>(); }
@@ -304,6 +311,7 @@ TEST(CustomTypeVisitorTest, all_query_nodes_are_visited) {
     requireThatNodeIsVisited<MyPhrase>();
     requireThatNodeIsVisited<MySameElement>();
     requireThatNodeIsVisited<MyRangeTerm>();
+    requireThatNodeIsVisited<MyStringRangeTerm>();
     requireThatNodeIsVisited<MyRank>();
     requireThatNodeIsVisited<MyLabelWrapper>();
     requireThatNodeIsVisited<MyNumberTerm>();

--- a/searchlib/src/tests/query/query_visitor_test.cpp
+++ b/searchlib/src/tests/query/query_visitor_test.cpp
@@ -35,6 +35,7 @@ public:
     void visit(SameElement&) override { isVisited<SameElement>() = true; }
     void visit(PrefixTerm&) override { isVisited<PrefixTerm>() = true; }
     void visit(RangeTerm&) override { isVisited<RangeTerm>() = true; }
+    void visit(StringRangeTerm&) override { isVisited<StringRangeTerm>() = true; }
     void visit(Rank&) override { isVisited<Rank>() = true; }
     void visit(LabelWrapper&) override { isVisited<LabelWrapper>() = true; }
     void visit(StringTerm&) override { isVisited<StringTerm>() = true; }
@@ -80,6 +81,8 @@ TEST(QueryVisitorTest, requireThatAllNodesCanBeVisited) {
     checkVisit<LocationTerm>(new SimpleLocationTerm(location, "field", 0, Weight(0)));
     checkVisit<PrefixTerm>(new SimplePrefixTerm("t", "field", 0, Weight(0)));
     checkVisit<RangeTerm>(new SimpleRangeTerm(Range(0, 1), "field", 0, Weight(0)));
+    checkVisit<StringRangeTerm>(
+        new SimpleStringRangeTerm(StringRange(std::make_unique<search::StringRangeSpec>()), "field", 0, Weight(0)));
     checkVisit<StringTerm>(new SimpleStringTerm("t", "field", 0, Weight(0)));
     checkVisit<SubstringTerm>(new SimpleSubstringTerm("t", "field", 0, Weight(0)));
     checkVisit<SuffixTerm>(new SimpleSuffixTerm("t", "field", 0, Weight(0)));

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -42,6 +42,12 @@ const int      max_distance = 20;
 const uint32_t x_aspect = 0;
 const Location location(position, max_distance, x_aspect);
 
+StringRange make_string_range(std::string left, bool left_closed, bool left_unbounded, std::string right,
+                              bool right_closed, bool right_unbounded) {
+    return StringRange(std::make_unique<search::StringRangeSpec>(std::move(left), left_closed, left_unbounded,
+                                                                 std::move(right), right_closed, right_unbounded));
+}
+
 PredicateQueryTerm::UP getPredicateQueryTerm() {
     auto pqt = std::make_unique<PredicateQueryTerm>();
     pqt->addFeature("key", "value");
@@ -356,6 +362,7 @@ struct AbstractTypes {
     using Phrase = search::query::Phrase;
     using PrefixTerm = search::query::PrefixTerm;
     using RangeTerm = search::query::RangeTerm;
+    using StringRangeTerm = search::query::StringRangeTerm;
     using Rank = search::query::Rank;
     using StringTerm = search::query::StringTerm;
     using SubstringTerm = search::query::SubstringTerm;
@@ -475,6 +482,11 @@ struct MyRangeTerm : RangeTerm {
     ~MyRangeTerm() override;
 };
 
+struct MyStringRangeTerm : StringRangeTerm {
+    MyStringRangeTerm(const Type& t, const string& f, int32_t i, Weight w) : StringRangeTerm(t, f, i, w) {}
+    ~MyStringRangeTerm() override;
+};
+
 struct MyStringTerm : StringTerm {
     MyStringTerm(const Type& t, const string& f, int32_t i, Weight w) : StringTerm(t, f, i, w) {}
     ~MyStringTerm() override;
@@ -568,6 +580,8 @@ MyPrefixTerm::~MyPrefixTerm() = default;
 
 MyRangeTerm::~MyRangeTerm() = default;
 
+MyStringRangeTerm::~MyStringRangeTerm() = default;
+
 MyStringTerm::~MyStringTerm() = default;
 
 MySubstringTerm::~MySubstringTerm() = default;
@@ -603,6 +617,7 @@ struct MyQueryNodeTypes {
     using SameElement = MySameElement;
     using PrefixTerm = MyPrefixTerm;
     using RangeTerm = MyRangeTerm;
+    using StringRangeTerm = MyStringRangeTerm;
     using Rank = MyRank;
     using LabelWrapper = MyLabelWrapper;
     using StringTerm = MyStringTerm;
@@ -849,6 +864,40 @@ TEST(QueryBuilderTest, label_wrapper_node_survives_protobuf_round_trip) {
     EXPECT_EQ(2.5, wrapper->getLabelScore());
     ASSERT_EQ(1u, wrapper->getChildren().size());
     EXPECT_TRUE(checkTerm(as_node<StringTerm>(wrapper->getChildren()[0]), str[0], view[0], id[0], weight[0]));
+}
+
+std::vector<StringRange> string_ranges() {
+    return {make_string_range("abba", true, false, "zztop", false, false),
+            make_string_range("", true, true, "zztop", true, false),
+            make_string_range("abba", false, false, "", false, true),
+            make_string_range("", false, true, "", false, true)};
+}
+
+TEST(QueryBuilderTest, string_range_node_survives_protobuf_round_trip) {
+    for (const auto& expected : string_ranges()) {
+        QueryBuilder<SimpleQueryNodeTypes> builder;
+        builder.add_string_range_term(expected, view[9], id[9], weight[9]);
+        Node::UP node = builder.build();
+
+        QueryToProtobuf converter;
+        auto            protoQueryTree = converter.serialize(*node);
+        auto            serializedQueryTree =
+            SerializedQueryTree::fromProtobuf(std::make_unique<decltype(protoQueryTree)>(protoQueryTree));
+
+        auto new_node = serializedQueryTree->apply(QueryTreeCreator<SimpleQueryNodeTypes>());
+        EXPECT_TRUE(checkTerm(as_node<StringRangeTerm>(new_node.get()), expected, view[9], id[9], weight[9]));
+    }
+}
+
+TEST(QueryBuilderTest, string_range_node_can_be_replicated) {
+    for (const auto& expected : string_ranges()) {
+        QueryBuilder<SimpleQueryNodeTypes> builder;
+        builder.add_string_range_term(expected, view[9], id[9], weight[9]);
+        Node::UP node = builder.build();
+
+        Node::UP new_node = QueryTreeCreator<MyQueryNodeTypes>::replicate(*node);
+        EXPECT_TRUE(checkTerm(as_node<MyStringRangeTerm>(new_node.get()), expected, view[9], id[9], weight[9]));
+    }
 }
 
 TEST(QueryBuilderTest, require_that_empty_intermediate_node_can_be_added) {

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -42,10 +42,11 @@ const int      max_distance = 20;
 const uint32_t x_aspect = 0;
 const Location location(position, max_distance, x_aspect);
 
-StringRange make_string_range(std::string left, bool left_closed, bool left_unbounded, std::string right,
-                              bool right_closed, bool right_unbounded) {
-    return StringRange(std::make_unique<search::StringRangeSpec>(std::move(left), left_closed, left_unbounded,
-                                                                 std::move(right), right_closed, right_unbounded));
+std::vector<StringRange> string_ranges() {
+    return {StringRange(std::make_unique<search::StringRangeSpec>("aaa", true, false, "zzz", false, false)),
+            StringRange(std::make_unique<search::StringRangeSpec>("", true, true, "zzz", true, false)),
+            StringRange(std::make_unique<search::StringRangeSpec>("aaa", false, false, "", false, true)),
+            StringRange(std::make_unique<search::StringRangeSpec>("", false, true, "", false, true))};
 }
 
 PredicateQueryTerm::UP getPredicateQueryTerm() {
@@ -866,13 +867,6 @@ TEST(QueryBuilderTest, label_wrapper_node_survives_protobuf_round_trip) {
     EXPECT_TRUE(checkTerm(as_node<StringTerm>(wrapper->getChildren()[0]), str[0], view[0], id[0], weight[0]));
 }
 
-std::vector<StringRange> string_ranges() {
-    return {make_string_range("abba", true, false, "zztop", false, false),
-            make_string_range("", true, true, "zztop", true, false),
-            make_string_range("abba", false, false, "", false, true),
-            make_string_range("", false, true, "", false, true)};
-}
-
 TEST(QueryBuilderTest, string_range_node_survives_protobuf_round_trip) {
     for (const auto& expected : string_ranges()) {
         QueryBuilder<SimpleQueryNodeTypes> builder;
@@ -880,11 +874,11 @@ TEST(QueryBuilderTest, string_range_node_survives_protobuf_round_trip) {
         Node::UP node = builder.build();
 
         QueryToProtobuf converter;
-        auto            protoQueryTree = converter.serialize(*node);
-        auto            serializedQueryTree =
-            SerializedQueryTree::fromProtobuf(std::make_unique<decltype(protoQueryTree)>(protoQueryTree));
+        auto            proto_query_tree = converter.serialize(*node);
+        auto            serialized_query_tree =
+            SerializedQueryTree::fromProtobuf(std::make_unique<decltype(proto_query_tree)>(proto_query_tree));
 
-        auto new_node = serializedQueryTree->apply(QueryTreeCreator<SimpleQueryNodeTypes>());
+        auto new_node = serialized_query_tree->apply(QueryTreeCreator<SimpleQueryNodeTypes>());
         EXPECT_TRUE(checkTerm(as_node<StringRangeTerm>(new_node.get()), expected, view[9], id[9], weight[9]));
     }
 }

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -74,6 +74,7 @@ using search::query::PrefixTerm;
 using search::query::RangeTerm;
 using search::query::RegExpTerm;
 using search::query::StackDumpCreator;
+using search::query::StringRangeTerm;
 using search::query::StringTerm;
 using search::query::SubstringTerm;
 using search::query::SuffixTerm;
@@ -657,6 +658,20 @@ public:
         auto range_spec = spec ? std::make_unique<NumericRangeSpec>(*spec) : std::make_unique<NumericRangeSpec>();
         auto term = std::make_unique<streaming::QueryTerm>(QueryTermSimple::Type::WORD, "", std::move(range_spec));
         setResult(std::make_unique<AttributeFieldBlueprint>(_field, _attr, std::move(term), scParams));
+    }
+
+    void visit(StringRangeTerm& n) override {
+        const StringRangeSpec* spec = n.getTerm().getSpec();
+        if (spec == nullptr || !_attr.isStringType()) {
+            Issue::report("Trying to apply a string range to the non-string attribute vector '%s'.",
+                          _attr.getName().c_str());
+            setResult(std::make_unique<queryeval::EmptyBlueprint>(_field));
+            return;
+        }
+        auto term =
+            std::make_unique<QueryTermUCS4>(QueryTermSimple::Type::WORD, std::make_unique<StringRangeSpec>(*spec));
+        setResult(std::make_unique<AttributeFieldBlueprint>(_field, _attr, std::move(term),
+                                                            createContextParams(_field.isFilter())));
     }
 
     void visit(StringTerm& n) override { visitTerm(n); }

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -661,15 +661,9 @@ public:
     }
 
     void visit(StringRangeTerm& n) override {
-        const StringRangeSpec* spec = n.getTerm().getSpec();
-        if (spec == nullptr || !_attr.isStringType()) {
-            Issue::report("Trying to apply a string range to the non-string attribute vector '%s'.",
-                          _attr.getName().c_str());
-            setResult(std::make_unique<queryeval::EmptyBlueprint>(_field));
-            return;
-        }
-        auto term =
-            std::make_unique<QueryTermUCS4>(QueryTermSimple::Type::WORD, std::make_unique<StringRangeSpec>(*spec));
+        const StringRangeSpec* spec = n.getTerm().get_spec();
+        auto spec_for_term = spec ? std::make_unique<StringRangeSpec>(*spec) : std::make_unique<StringRangeSpec>();
+        auto term = std::make_unique<streaming::QueryTerm>(QueryTermSimple::Type::WORD, "", std::move(spec_for_term));
         setResult(std::make_unique<AttributeFieldBlueprint>(_field, _attr, std::move(term),
                                                             createContextParams(_field.isFilter())));
     }

--- a/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
@@ -198,6 +198,7 @@ public:
     void visit(LocationTerm& n) override { visitTerm(n); }
     void visit(PrefixTerm& n) override { visitTerm(n); }
     void visit(RangeTerm& n) override { visitTerm(n); }
+    void visit(StringRangeTerm& n) override { not_supported(n); }
     void visit(StringTerm& n) override { visitTerm(n); }
     void visit(SubstringTerm& n) override { visitTerm(n); }
     void visit(SuffixTerm& n) override { visitTerm(n); }

--- a/searchlib/src/vespa/searchlib/memoryindex/memory_index.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/memory_index.cpp
@@ -41,6 +41,7 @@ using query::PredicateQuery;
 using query::PrefixTerm;
 using query::RangeTerm;
 using query::RegExpTerm;
+using query::StringRangeTerm;
 using query::StringTerm;
 using query::SubstringTerm;
 using query::SuffixTerm;
@@ -154,6 +155,7 @@ public:
     void visit(LocationTerm& n) override { visitTerm(n); }
     void visit(PrefixTerm& n) override { visitTerm(n); }
     void visit(RangeTerm& n) override { visitTerm(n); }
+    void visit(StringRangeTerm& n) override { not_supported(n); }
     void visit(StringTerm& n) override { visitTerm(n); }
     void visit(SubstringTerm& n) override { visitTerm(n); }
     void visit(SuffixTerm& n) override { visitTerm(n); }

--- a/searchlib/src/vespa/searchlib/parsequery/parse.h
+++ b/searchlib/src/vespa/searchlib/parsequery/parse.h
@@ -65,8 +65,9 @@ public:
         ITEM_STRING_IN = 31,
         ITEM_NUMERIC_IN = 32,
         ITEM_LABEL_WRAPPER = 33,
+        ITEM_STRING_RANGE_TERM = 34,
         // sentinel, kept last: it moves up as item types are added
-        ITEM_UNDEF = 34,
+        ITEM_UNDEF = 35,
     };
 
     /*

--- a/searchlib/src/vespa/searchlib/query/proto_tree_converter.hpp
+++ b/searchlib/src/vespa/searchlib/query/proto_tree_converter.hpp
@@ -392,8 +392,22 @@ public:
         return true;
     }
 
-    bool handle(const ItemStringRangeTerm& /*item*/) {
-        // TODO
+    bool handle(const ItemStringRangeTerm& item) {
+        auto d = fillTermProperties(item.properties());
+        auto spec = std::make_unique<StringRangeSpec>();
+        spec->left_unbounded = !item.has_lower_limit();
+        spec->left = item.lower_limit();
+        spec->left_closed = item.lower_inclusive();
+        spec->right_unbounded = !item.has_upper_limit();
+        spec->right = item.upper_limit();
+        spec->right_closed = item.upper_inclusive();
+
+        query::StringRange range(std::move(spec));
+        auto&              term = _builder.add_string_range_term(range, d.index_view, d.uniqueId, d.weight);
+        if (d.noRankFlag)
+            term.setRanked(false);
+        if (d.noPositionDataFlag)
+            term.setPositionData(false);
         return true;
     }
 

--- a/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
@@ -284,8 +284,11 @@ bool handle(const ItemFloatingPointRangeTerm& item, QueryStackIterator::Data& _d
     _d.term_view = tmp;
     return true;
 }
-bool handle(const ItemStringRangeTerm& /*item*/, QueryStackIterator::Data& /*_d*/, std::string& /*tmp*/) {
-    // TODO
+bool handle(const ItemStringRangeTerm& item, QueryStackIterator::Data& _d) {
+    // The range itself is not exposed here, as the query stack is only used by consumers
+    // that do not support string ranges.
+    fillTermProperties(item.properties(), _d);
+    _d.itemType = ParseItem::ItemType::ITEM_STRING_RANGE_TERM;
     return true;
 }
 
@@ -530,7 +533,7 @@ bool ProtoTreeIterator::handle_item(const QueryTreeItem& qsi) {
     case IC::kItemFloatingPointRangeTerm:
         return handle(qsi.item_floating_point_range_term(), _d, _serialized_term);
     case IC::kItemStringRangeTerm:
-        return handle(qsi.item_string_range_term(), _d, _serialized_term);
+        return handle(qsi.item_string_range_term(), _d);
 
     case IC::kItemWeightedSetOfString:
         return handle(qsi.item_weighted_set_of_string(), _d);

--- a/searchlib/src/vespa/searchlib/query/streaming/query_builder.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/query_builder.cpp
@@ -20,6 +20,7 @@
 #include <vespa/searchlib/query/streaming/weighted_set_term.h>
 #include <vespa/searchlib/query/tree/term_vector.h>
 #include <vespa/searchlib/queryeval/split_float.h>
+#include <vespa/vespalib/util/issue.h>
 
 #include <charconv>
 
@@ -261,6 +262,10 @@ std::unique_ptr<QueryNode> QueryBuilder::build(const QueryNode* parent, const Qu
         break;
     case ParseItem::ITEM_SAME_ELEMENT:
         qn = build_same_element_term(factory, queryRep);
+        break;
+    case ParseItem::ITEM_STRING_RANGE_TERM:
+        // Lexical ranges are only implemented for attribute vectors, i.e. for indexed search.
+        vespalib::Issue::report("string range terms are not supported in streaming search");
         break;
     default:
         skip_unknown(queryRep);

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
@@ -83,6 +83,19 @@ QueryTerm::QueryTerm(Type type, string index, std::unique_ptr<NumericRangeSpec> 
       _fieldInfo() {
 }
 
+QueryTerm::QueryTerm(Type type, string index, std::unique_ptr<StringRangeSpec> string_range)
+    : QueryTermUCS4(type, std::move(string_range)),
+      _hitList(),
+      _index(std::move(index)),
+      _result(),
+      _encoding(0x01),
+      _isRanked(false),
+      _filter(true),
+      _weight(100),
+      _uniqueId(0),
+      _fieldInfo() {
+}
+
 QueryTerm::QueryTerm(std::unique_ptr<QueryNodeResultBase> org, string_view termS, string indexS, Type type,
                      Normalizing normalizing)
     : QueryTermUCS4(QueryNormalization::optional_fold(termS, type, normalizing), type),

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
@@ -74,6 +74,7 @@ public:
         : QueryTerm(std::move(resultBase), term, std::move(index), type,
                     (type == Type::EXACTSTRINGTERM) ? Normalizing::LOWERCASE : Normalizing::LOWERCASE_AND_FOLD) {}
     QueryTerm(Type type, string index, std::unique_ptr<NumericRangeSpec> range);
+    QueryTerm(Type type, string index, std::unique_ptr<StringRangeSpec> range);
     QueryTerm(std::unique_ptr<QueryNodeResultBase> resultBase, string_view term, string index, Type type,
               Normalizing normalizing);
     QueryTerm(const QueryTerm&) = delete;

--- a/searchlib/src/vespa/searchlib/query/tree/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/query/tree/CMakeLists.txt
@@ -12,6 +12,7 @@ vespa_add_library(searchlib_query_tree OBJECT
     simplequery.cpp
     stackdumpcreator.cpp
     stackdumpquerycreator.cpp
+    string_range.cpp
     string_term_vector.cpp
     term.cpp
     termnodes.cpp

--- a/searchlib/src/vespa/searchlib/query/tree/customtypevisitor.h
+++ b/searchlib/src/vespa/searchlib/query/tree/customtypevisitor.h
@@ -13,7 +13,7 @@ namespace search::query {
  *
  * The traits class must define the following types:
  * And, AndNot, Equiv, NumberTerm, Near, ONear, Or,
- * Phrase, PrefixTerm, RangeTerm, Rank, LabelWrapper, StringTerm, SubstringTerm,
+ * Phrase, PrefixTerm, RangeTerm, StringRangeTerm, Rank, LabelWrapper, StringTerm, SubstringTerm,
  * SuffixTerm, WeakAnd, WeightedSetTerm, DotProduct, RegExpTerm
  *
  * See customtypevisitor_test.cpp for an example.
@@ -38,6 +38,7 @@ public:
     virtual void visit(typename NodeTypes::SameElement&) = 0;
     virtual void visit(typename NodeTypes::PrefixTerm&) = 0;
     virtual void visit(typename NodeTypes::RangeTerm&) = 0;
+    virtual void visit(typename NodeTypes::StringRangeTerm&) = 0;
     virtual void visit(typename NodeTypes::Rank&) = 0;
     virtual void visit(typename NodeTypes::LabelWrapper&) = 0;
     virtual void visit(typename NodeTypes::StringTerm&) = 0;
@@ -71,6 +72,7 @@ private:
     using TSameElement = typename NodeTypes::SameElement;
     using TPrefixTerm = typename NodeTypes::PrefixTerm;
     using TRangeTerm = typename NodeTypes::RangeTerm;
+    using TStringRangeTerm = typename NodeTypes::StringRangeTerm;
     using TRank = typename NodeTypes::Rank;
     using TLabelWrapper = typename NodeTypes::LabelWrapper;
     using TStringTerm = typename NodeTypes::StringTerm;
@@ -101,6 +103,7 @@ private:
     void visit(SameElement& n) override { visit(static_cast<TSameElement&>(n)); }
     void visit(PrefixTerm& n) override { visit(static_cast<TPrefixTerm&>(n)); }
     void visit(RangeTerm& n) override { visit(static_cast<TRangeTerm&>(n)); }
+    void visit(StringRangeTerm& n) override { visit(static_cast<TStringRangeTerm&>(n)); }
     void visit(Rank& n) override { visit(static_cast<TRank&>(n)); }
     void visit(LabelWrapper& n) override { visit(static_cast<TLabelWrapper&>(n)); }
     void visit(StringTerm& n) override { visit(static_cast<TStringTerm&>(n)); }

--- a/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
+++ b/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
@@ -349,7 +349,7 @@ private:
     }
 
     void visit(StringRangeTerm& node) override {
-        const auto* spec = node.getTerm().getSpec();
+        const auto* spec = node.getTerm().get_spec();
         if (spec == nullptr) {
             return;
         }

--- a/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
+++ b/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
@@ -348,6 +348,23 @@ private:
         }
     }
 
+    void visit(StringRangeTerm& node) override {
+        const auto* spec = node.getTerm().getSpec();
+        if (spec == nullptr) {
+            return;
+        }
+        auto* item = _item_stack.back()->mutable_item_string_range_term();
+        copyTermState(node, item->mutable_properties());
+        if (!spec->left_unbounded) {
+            item->set_lower_limit(spec->left);
+        }
+        if (!spec->right_unbounded) {
+            item->set_upper_limit(spec->right);
+        }
+        item->set_lower_inclusive(spec->left_closed);
+        item->set_upper_inclusive(spec->right_closed);
+    }
+
     void visit(StringTerm& node) override {
         auto* item = _item_stack.back()->mutable_item_word_term();
         copyTermState(node, item->mutable_properties());

--- a/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
+++ b/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
@@ -185,6 +185,11 @@ typename NodeTypes::RangeTerm* createRangeTerm(const Range& term, const std::str
     return new typename NodeTypes::RangeTerm(term, view, id, weight);
 }
 template <class NodeTypes>
+typename NodeTypes::StringRangeTerm* createStringRangeTerm(const StringRange& term, const std::string& view,
+                                                           int32_t id, Weight weight) {
+    return new typename NodeTypes::StringRangeTerm(term, view, id, weight);
+}
+template <class NodeTypes>
 typename NodeTypes::StringTerm* createStringTerm(const std::string& term, const std::string& view, int32_t id,
                                                  Weight weight) {
     return new typename NodeTypes::StringTerm(term, view, id, weight);
@@ -369,6 +374,11 @@ public:
     typename NodeTypes::RangeTerm& addRangeTerm(const Range& range, const string& view, int32_t id, Weight weight) {
         adjustWeight(weight);
         return addTerm(createRangeTerm<NodeTypes>(range, view, id, weight));
+    }
+    typename NodeTypes::StringRangeTerm& add_string_range_term(const StringRange& range, const string& view,
+                                                               int32_t id, Weight weight) {
+        adjustWeight(weight);
+        return addTerm(createStringRangeTerm<NodeTypes>(range, view, id, weight));
     }
     typename NodeTypes::StringTerm& addStringTerm(const string& term, const string& view, int32_t id, Weight weight) {
         adjustWeight(weight);

--- a/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
@@ -129,6 +129,11 @@ private:
         copyState(node, _builder.addPrefixTerm(node.getTerm(), node.getView(), node.getId(), node.getWeight()));
     }
 
+    void visit(StringRangeTerm& node) override {
+        copyState(node,
+                  _builder.add_string_range_term(node.getTerm(), node.getView(), node.getId(), node.getWeight()));
+    }
+
     void visit(RangeTerm& node) override {
         copyState(node, _builder.addRangeTerm(node.getTerm(), node.getView(), node.getId(), node.getWeight()));
     }

--- a/searchlib/src/vespa/searchlib/query/tree/queryvisitor.h
+++ b/searchlib/src/vespa/searchlib/query/tree/queryvisitor.h
@@ -15,6 +15,7 @@ class Or;
 class Phrase;
 class PrefixTerm;
 class RangeTerm;
+class StringRangeTerm;
 class Rank;
 class LabelWrapper;
 class StringTerm;
@@ -49,6 +50,7 @@ struct QueryVisitor {
     virtual void visit(SameElement& node) = 0;
     virtual void visit(PrefixTerm&) = 0;
     virtual void visit(RangeTerm&) = 0;
+    virtual void visit(StringRangeTerm&) = 0;
     virtual void visit(Rank&) = 0;
     virtual void visit(LabelWrapper&) = 0;
     virtual void visit(StringTerm&) = 0;

--- a/searchlib/src/vespa/searchlib/query/tree/simplequery.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/simplequery.cpp
@@ -42,6 +42,7 @@ SimpleLocationTerm::~SimpleLocationTerm() = default;
 SimplePrefixTerm::~SimplePrefixTerm() = default;
 
 SimpleRangeTerm::~SimpleRangeTerm() = default;
+SimpleStringRangeTerm::~SimpleStringRangeTerm() = default;
 
 SimpleStringTerm::~SimpleStringTerm() = default;
 

--- a/searchlib/src/vespa/searchlib/query/tree/simplequery.h
+++ b/searchlib/src/vespa/searchlib/query/tree/simplequery.h
@@ -104,6 +104,11 @@ struct SimpleRangeTerm : RangeTerm {
         : RangeTerm(term, std::move(view), id, weight) {}
     ~SimpleRangeTerm() override;
 };
+struct SimpleStringRangeTerm : StringRangeTerm {
+    SimpleStringRangeTerm(const Type& term, std::string view, int32_t id, Weight weight)
+        : StringRangeTerm(term, std::move(view), id, weight) {}
+    ~SimpleStringRangeTerm() override;
+};
 struct SimpleStringTerm : StringTerm {
     SimpleStringTerm(const Type& term, std::string view, int32_t id, Weight weight)
         : StringTerm(term, std::move(view), id, weight) {}
@@ -158,6 +163,7 @@ struct SimpleQueryNodeTypes {
     using SameElement = SimpleSameElement;
     using PrefixTerm = SimplePrefixTerm;
     using RangeTerm = SimpleRangeTerm;
+    using StringRangeTerm = SimpleStringRangeTerm;
     using Rank = SimpleRank;
     using LabelWrapper = SimpleLabelWrapper;
     using StringTerm = SimpleStringTerm;

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -10,6 +10,7 @@
 #include <vespa/searchlib/util/rawbuf.h>
 #include <vespa/vespalib/objects/nbo.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/size_literals.h>
 
 #include <cassert>
@@ -252,6 +253,11 @@ class QueryNodeConverter : public QueryVisitor {
     void visit(PrefixTerm& node) override { createTerm(node, ParseItem::ITEM_PREFIXTERM); }
 
     void visit(RangeTerm& node) override { createTerm(node, ParseItem::ITEM_NUMTERM); }
+
+    void visit(StringRangeTerm&) override {
+        // The query stack dump is a legacy serialization that string ranges are not part of.
+        vespalib::Issue::report("string range terms cannot be serialized to a query stack dump");
+    }
 
     void visit(StringTerm& node) override { createTerm(node, ParseItem::ITEM_TERM); }
 

--- a/searchlib/src/vespa/searchlib/query/tree/string_range.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/string_range.cpp
@@ -18,8 +18,8 @@ StringRange& StringRange::operator=(const StringRange& other) {
 StringRange::~StringRange() = default;
 
 bool operator==(const StringRange& r1, const StringRange& r2) {
-    const StringRangeSpec* s1 = r1.getSpec();
-    const StringRangeSpec* s2 = r2.getSpec();
+    const StringRangeSpec* s1 = r1.get_spec();
+    const StringRangeSpec* s2 = r2.get_spec();
     if (s1 == s2) {
         return true;
     }

--- a/searchlib/src/vespa/searchlib/query/tree/string_range.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/string_range.cpp
@@ -1,0 +1,32 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "string_range.h"
+
+namespace search::query {
+
+StringRange::StringRange(const StringRange& other)
+    : _spec(other._spec ? std::make_unique<StringRangeSpec>(*other._spec) : nullptr) {
+}
+
+StringRange& StringRange::operator=(const StringRange& other) {
+    if (this != &other) {
+        _spec = other._spec ? std::make_unique<StringRangeSpec>(*other._spec) : nullptr;
+    }
+    return *this;
+}
+
+StringRange::~StringRange() = default;
+
+bool operator==(const StringRange& r1, const StringRange& r2) {
+    const StringRangeSpec* s1 = r1.getSpec();
+    const StringRangeSpec* s2 = r2.getSpec();
+    if (s1 == s2) {
+        return true;
+    }
+    if (!s1 || !s2) {
+        return false;
+    }
+    return (*s1 == *s2);
+}
+
+} // namespace search::query

--- a/searchlib/src/vespa/searchlib/query/tree/string_range.h
+++ b/searchlib/src/vespa/searchlib/query/tree/string_range.h
@@ -23,7 +23,7 @@ public:
     StringRange& operator=(StringRange&& other) noexcept = default;
     ~StringRange();
 
-    const StringRangeSpec* getSpec() const noexcept { return _spec.get(); }
+    const StringRangeSpec* get_spec() const noexcept { return _spec.get(); }
 };
 
 bool operator==(const StringRange& r1, const StringRange& r2);

--- a/searchlib/src/vespa/searchlib/query/tree/string_range.h
+++ b/searchlib/src/vespa/searchlib/query/tree/string_range.h
@@ -1,0 +1,31 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchlib/query/string_range_spec.h>
+
+#include <memory>
+
+namespace search::query {
+
+/**
+ * The term of a StringRangeTerm query node, i.e. a lexical range over strings.
+ */
+class StringRange {
+    std::unique_ptr<StringRangeSpec> _spec;
+
+public:
+    StringRange() noexcept : _spec() {}
+    explicit StringRange(std::unique_ptr<StringRangeSpec> spec) noexcept : _spec(std::move(spec)) {}
+    StringRange(const StringRange& other);
+    StringRange(StringRange&& other) noexcept = default;
+    StringRange& operator=(const StringRange& other);
+    StringRange& operator=(StringRange&& other) noexcept = default;
+    ~StringRange();
+
+    const StringRangeSpec* getSpec() const noexcept { return _spec.get(); }
+};
+
+bool operator==(const StringRange& r1, const StringRange& r2);
+
+} // namespace search::query

--- a/searchlib/src/vespa/searchlib/query/tree/templatetermvisitor.h
+++ b/searchlib/src/vespa/searchlib/query/tree/templatetermvisitor.h
@@ -22,6 +22,7 @@ template <class Self, class NodeTypes> class TemplateTermVisitor : public Custom
     void visit(typename NodeTypes::LocationTerm& n) override { myVisit(n); }
     void visit(typename NodeTypes::PrefixTerm& n) override { myVisit(n); }
     void visit(typename NodeTypes::RangeTerm& n) override { myVisit(n); }
+    void visit(typename NodeTypes::StringRangeTerm& n) override { myVisit(n); }
     void visit(typename NodeTypes::StringTerm& n) override { myVisit(n); }
     void visit(typename NodeTypes::SubstringTerm& n) override { myVisit(n); }
     void visit(typename NodeTypes::SuffixTerm& n) override { myVisit(n); }

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.cpp
@@ -33,6 +33,7 @@ WordAlternatives::WordAlternatives(std::unique_ptr<TermVector> terms, const std:
 NumberTerm::~NumberTerm() = default;
 PrefixTerm::~PrefixTerm() = default;
 RangeTerm::~RangeTerm() = default;
+StringRangeTerm::~StringRangeTerm() = default;
 StringTerm::~StringTerm() = default;
 SubstringTerm::~SubstringTerm() = default;
 SuffixTerm::~SuffixTerm() = default;

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.h
@@ -7,6 +7,7 @@
 #include "predicate_query_term.h"
 #include "querynodemixin.h"
 #include "range.h"
+#include "string_range.h"
 #include "term.h"
 #include "term_vector.h"
 
@@ -42,6 +43,15 @@ public:
     RangeTerm(const Type& term, const std::string& view, int32_t id, Weight weight)
         : QueryNodeMixinType(term, view, id, weight) {}
     virtual ~RangeTerm() = 0;
+};
+
+//-----------------------------------------------------------------------------
+
+class StringRangeTerm : public QueryNodeMixin<StringRangeTerm, TermBase<StringRange>> {
+public:
+    StringRangeTerm(const Type& term, const std::string& view, int32_t id, Weight weight)
+        : QueryNodeMixinType(term, view, id, weight) {}
+    virtual ~StringRangeTerm() = 0;
 };
 
 //-----------------------------------------------------------------------------

--- a/searchlib/src/vespa/searchlib/queryeval/create_blueprint_visitor_helper.h
+++ b/searchlib/src/vespa/searchlib/queryeval/create_blueprint_visitor_helper.h
@@ -86,6 +86,7 @@ public:
     void visit(query::LocationTerm& n) override = 0;
     void visit(query::PrefixTerm& n) override = 0;
     void visit(query::RangeTerm& n) override = 0;
+    void visit(query::StringRangeTerm& n) override = 0;
     void visit(query::StringTerm& n) override = 0;
     void visit(query::SubstringTerm& n) override = 0;
     void visit(query::SuffixTerm& n) override = 0;

--- a/searchlib/src/vespa/searchlib/queryeval/fake_searchable.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_searchable.cpp
@@ -17,6 +17,7 @@ using search::query::PredicateQuery;
 using search::query::PrefixTerm;
 using search::query::RangeTerm;
 using search::query::RegExpTerm;
+using search::query::StringRangeTerm;
 using search::query::StringTerm;
 using search::query::SubstringTerm;
 using search::query::SuffixTerm;
@@ -53,6 +54,7 @@ public:
     void visit(LocationTerm& n) override { visitTerm(n); }
     void visit(PrefixTerm& n) override { visitTerm(n); }
     void visit(RangeTerm& n) override { visitTerm(n); }
+    void visit(StringRangeTerm&) override {}
     void visit(StringTerm& n) override { visitTerm(n); }
     void visit(SubstringTerm& n) override { visitTerm(n); }
     void visit(SuffixTerm& n) override { visitTerm(n); }

--- a/searchlib/src/vespa/searchlib/queryeval/termasstring.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/termasstring.cpp
@@ -36,6 +36,7 @@ using search::query::RangeTerm;
 using search::query::Rank;
 using search::query::RegExpTerm;
 using search::query::SameElement;
+using search::query::StringRangeTerm;
 using search::query::StringTerm;
 using search::query::SubstringTerm;
 using search::query::SuffixTerm;
@@ -105,6 +106,7 @@ struct TermAsStringVisitor : public QueryVisitor {
     void visit(LocationTerm& n) override { visitTerm(n); }
     void visit(PrefixTerm& n) override { visitTerm(n); }
     void visit(RangeTerm& n) override { visitTerm(n); }
+    void visit(StringRangeTerm&) override { illegalVisit(); }
     void visit(StringTerm& n) override { visitTerm(n); }
     void visit(SubstringTerm& n) override { visitTerm(n); }
     void visit(SuffixTerm& n) override { visitTerm(n); }

--- a/searchsummary/src/vespa/searchsummary/docsummary/juniper_query_adapter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/juniper_query_adapter.cpp
@@ -138,6 +138,7 @@ bool JuniperQueryAdapter::Traverse(juniper::IQueryVisitor* v) const {
         case search::ParseItem::ITEM_FUZZY:
         case search::ParseItem::ITEM_STRING_IN:
         case search::ParseItem::ITEM_NUMERIC_IN:
+        case search::ParseItem::ITEM_STRING_RANGE_TERM:
             if (!v->VisitOther(&item, iterator.getArity())) {
                 rc = skipItem(iterator);
             }


### PR DESCRIPTION
Wires the string ranges from Protobuf into the `AttributeBlueprintFactory`. They are not implemented/handled in the legacy query stack (`ProtoTreeIterator`).

Claude did the work and I went through it and cleaned it up a bit afterwards.

@johansolbakken fyi