### PR TITLE
Remove more dead code left over from v7 legacy geo position removal

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/derived/SummaryClass.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/SummaryClass.java
@@ -136,6 +136,7 @@ public class SummaryClass extends Derived {
         if (transform == SummaryTransform.NONE) {
             return "";
         } else if (transform == SummaryTransform.DISTANCE) {
+            // Unreachable in practice, see SummaryTransform.DISTANCE.
             return "absdist";
         } else if (transform.isDynamic()) {
             return "dynamicteaser";
@@ -152,9 +153,9 @@ public class SummaryClass extends Derived {
         if (summaryField.getTransform() == SummaryTransform.ATTRIBUTE ||
                 (summaryField.getTransform() == SummaryTransform.ATTRIBUTECOMBINER && summaryField.hasExplicitSingleSource()) ||
                 summaryField.getTransform() == SummaryTransform.COPY ||
-                summaryField.getTransform() == SummaryTransform.DISTANCE ||
+                summaryField.getTransform() == SummaryTransform.DISTANCE || // unreachable in practice, see SummaryTransform.DISTANCE
                 summaryField.getTransform() == SummaryTransform.GEOPOS ||
-                summaryField.getTransform() == SummaryTransform.POSITIONS ||
+                summaryField.getTransform() == SummaryTransform.POSITIONS || // unreachable in practice, see SummaryTransform.POSITIONS
                 summaryField.getTransform() == SummaryTransform.TOKENS ||
                 summaryField.getTransform() == SummaryTransform.ATTRIBUTE_TOKENS)
         {

--- a/config-model/src/main/java/com/yahoo/schema/derived/SummaryClassField.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/SummaryClassField.java
@@ -128,6 +128,7 @@ public class SummaryClassField {
             return Type.TENSOR;
         } else if (fieldType instanceof CollectionDataType) {
             if (transform != null && transform.equals(SummaryTransform.POSITIONS)) {
+                // Unreachable in practice, see SummaryTransform.POSITIONS.
                 return Type.XMLSTRING;
             } else {
                 return Type.JSONSTRING;

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedSummaryField.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedSummaryField.java
@@ -27,6 +27,7 @@ public class ParsedSummaryField extends ParsedBlock {
 
     public ParsedSummaryField(String name, ParsedType type) {
         super(name, "summary field");
+        verifyThat(! name.contains("."), "invalid name, must not contain '.'");
         this.type = type;
     }
 

--- a/config-model/src/main/java/com/yahoo/schema/processing/AdjustPositionSummaryFields.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/AdjustPositionSummaryFields.java
@@ -18,8 +18,7 @@ import com.yahoo.vespa.documentmodel.SummaryTransform;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
 
 /*
- * Adjusts position summary fields by adding derived summary fields (.distance and .position) and setting summary
- * transform and source.
+ * Sets summary transform and source for position summary fields.
  */
 public class AdjustPositionSummaryFields extends Processor {
 
@@ -37,16 +36,6 @@ public class AdjustPositionSummaryFields extends Processor {
         for (DocumentSummary summary : schema.getSummaries().values()) {
             scanSummary(summary);
         }
-    }
-
-    static String getPositionSummaryFieldName(String fieldName) {
-        // Only used in v7 legacy mode, remove in Vespa 9
-        return fieldName + ".position";
-    }
-
-    static String getDistanceSummaryFieldName(String fieldName) {
-        // Only used in v7 legacy mode, remove in Vespa 9
-        return fieldName + ".distance";
     }
 
     private void scanSummary(DocumentSummary summary) {
@@ -67,7 +56,7 @@ public class AdjustPositionSummaryFields extends Processor {
                     if (zCurve != null) {
                         if (hasPositionAttribute(zCurve)) {
                             Source source = new Source(zCurve);
-                            adjustPositionField(summary, summaryField, source);
+                            adjustPositionField(summaryField, source);
                         } else if (sourceField.isImportedField() || !summaryField.getName().equals(originalSource)) {
                             fail(summaryField, "No position attribute '" + zCurve + "'");
                         }
@@ -77,36 +66,10 @@ public class AdjustPositionSummaryFields extends Processor {
         }
     }
 
-    private void adjustPositionField(DocumentSummary summary, SummaryField summaryField, Source source) {
+    private void adjustPositionField(SummaryField summaryField, Source source) {
         summaryField.setTransform(SummaryTransform.GEOPOS);
         summaryField.getSources().clear();
         summaryField.addSource(source);
-        ensureSummaryField(summary,
-                           getPositionSummaryFieldName(summaryField.getName()),
-                           DataType.getArray(DataType.STRING),
-                           source,
-                           SummaryTransform.POSITIONS);
-        ensureSummaryField(summary,
-                           getDistanceSummaryFieldName(summaryField.getName()),
-                           DataType.INT,
-                           source,
-                           SummaryTransform.DISTANCE);
-    }
-
-    private void ensureSummaryField(DocumentSummary summary, String fieldName, DataType dataType, Source source, SummaryTransform transform) {
-        SummaryField oldField = schema.getSummaryField(fieldName);
-        if (oldField == null) {
-            return;
-        }
-        if (!oldField.getDataType().equals(dataType)) {
-            fail(oldField, "exists with type '" + oldField.getDataType().toString() + "', should be of type '" + dataType.toString() + "'");
-        }
-        if (oldField.getTransform() != transform) {
-            fail(oldField, "has summary transform '" + oldField.getTransform().toString() + "', should have transform '" + transform.toString() + "'");
-        }
-        if (oldField.getSourceCount() != 1 || !oldField.getSingleSource().equals(source.getName())) {
-            fail(oldField, "has source '" + oldField.getSources().toString() + "', should have source '" + source + "'");
-        }
     }
 
     private boolean hasPositionAttribute(String name) {

--- a/config-model/src/main/java/com/yahoo/schema/processing/ImplicitSummaries.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/ImplicitSummaries.java
@@ -86,23 +86,6 @@ public class ImplicitSummaries extends Processor {
             addedSummaryField.setTransform(SummaryTransform.ATTRIBUTECOMBINER);
         }
 
-        // Position attributes
-        if (field.doesSummarying()) {
-            for (Attribute attribute : field.getAttributes().values()) {
-                if ( ! attribute.isPosition()) continue;
-                var distField = field.getSummaryField(AdjustPositionSummaryFields.getDistanceSummaryFieldName(fieldName));
-                if (distField != null) {
-                    DocumentSummary attributePrefetchSummary = getOrCreateAttributePrefetchSummary(schema);
-                    attributePrefetchSummary.add(distField);
-                }
-                var posField = field.getSummaryField(AdjustPositionSummaryFields.getPositionSummaryFieldName(fieldName));
-                if (posField != null) {
-                    DocumentSummary attributePrefetchSummary = getOrCreateAttributePrefetchSummary(schema);
-                    attributePrefetchSummary.add(posField);
-                }
-            }
-        }
-
         // Explicits
         for (SummaryField summaryField : field.getSummaryFields().values()) {
             // Make sure we fetch from attribute here too
@@ -148,6 +131,7 @@ public class ImplicitSummaries extends Processor {
 
     // Returns whether this is valid. Warns if invalid and ignorable. Throws if not ignorable.
     private boolean isValid(SummaryField summaryField, Schema schema, boolean validate) {
+        // DISTANCE/POSITIONS transforms are unreachable in practice, see SummaryTransform.
         if (summaryField.getTransform() == SummaryTransform.DISTANCE ||
             summaryField.getTransform() == SummaryTransform.POSITIONS) {
             int sourceCount = summaryField.getSourceCount();

--- a/config-model/src/main/java/com/yahoo/vespa/documentmodel/SummaryTransform.java
+++ b/config-model/src/main/java/com/yahoo/vespa/documentmodel/SummaryTransform.java
@@ -12,6 +12,11 @@ public enum SummaryTransform {
     NONE("none"),
     ATTRIBUTE("attribute"),
     BOLDED("bolded"),
+    // DISTANCE and POSITIONS are unreachable in practice: no code constructs a SummaryField with
+    // either transform. They used to be set by auto-created ".distance"/".position" summary fields
+    // in v7 legacy geo position mode; that field-creation code was removed, but the values (and the
+    // code checking for them, e.g. in AdjustPositionSummaryFields, ImplicitSummaries, SummaryClass)
+    // were kept for now.
     DISTANCE("distance"),
     DYNAMICBOLDED("dynamicbolded"),
     DYNAMICTEASER("dynamicteaser"),

--- a/config-model/src/test/java/com/yahoo/schema/processing/AdjustPositionSummaryFieldsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/AdjustPositionSummaryFieldsTestCase.java
@@ -29,6 +29,20 @@ public class AdjustPositionSummaryFieldsTestCase {
     }
 
     @Test
+    void test_pos_summary_sourced_from_original_and_from_zcurve_field() {
+        // Two summary fields in the same schema, resolving the z-curve attribute name via the
+        // two different branches in scanSummary(): "my_pos" has the position field itself as
+        // source (name -> name + "_zcurve"), while "my_pos2" has the z-curve attribute field
+        // itself as source (name already ends with "_zcurve", so it is used as-is).
+        SearchModel model = new SearchModel(false);
+        model.addSummaryField("my_pos", PositionDataType.INSTANCE, null, "pos");
+        model.addSummaryField("my_pos2", PositionDataType.INSTANCE, null, "pos_zcurve");
+        model.resolve();
+        model.assertSummaryField("my_pos", PositionDataType.INSTANCE, SummaryTransform.GEOPOS, "pos_zcurve");
+        model.assertSummaryField("my_pos2", PositionDataType.INSTANCE, SummaryTransform.GEOPOS, "pos_zcurve");
+    }
+
+    @Test
     void test_imported_pos_summary() {
         SearchModel model = new SearchModel();
         model.addSummaryField("my_pos", PositionDataType.INSTANCE, null, null);
@@ -126,42 +140,6 @@ public class AdjustPositionSummaryFieldsTestCase {
         });
         assertTrue(exception.getMessage().contains("For schema 'child', field 'my_pos': "
                 + "No position attribute 'my_pos_zcurve'"));
-    }
-
-    @Test
-    void test_my_pos_position_summary_bad_datatype() {
-        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-            SearchModel model = new SearchModel();
-            model.addSummaryField("my_pos", PositionDataType.INSTANCE, null, null);
-            model.addSummaryField("my_pos.position", DataType.STRING, null, "pos");
-            model.resolve();
-        });
-        assertTrue(exception.getMessage().contains("For schema 'child', field 'my_pos.position': "
-                + "exists with type 'datatype string (code: 2)', should be of type 'datatype Array<string> (code: -1486737430)"));
-    }
-
-    @Test
-    void test_my_pos_position_summary_bad_transform() {
-        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-            SearchModel model = new SearchModel();
-            model.addSummaryField("my_pos", PositionDataType.INSTANCE, null, null);
-            model.addSummaryField("my_pos.position", DataType.getArray(DataType.STRING), null, "pos");
-            model.resolve();
-        });
-        assertTrue(exception.getMessage().contains("For schema 'child', field 'my_pos.position': "
-                + "has summary transform 'none', should have transform 'positions'"));
-    }
-
-    @Test
-    void test_my_pos_position_summary_bad_source() {
-        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-            SearchModel model = new SearchModel();
-            model.addSummaryField("my_pos", PositionDataType.INSTANCE, null, null);
-            model.addSummaryField("my_pos.position", DataType.getArray(DataType.STRING), SummaryTransform.POSITIONS, "pos");
-            model.resolve();
-        });
-        assertTrue(exception.getMessage().contains("For schema 'child', field 'my_pos.position': "
-                + "has source '[source field 'pos']', should have source 'source field 'my_pos_zcurve''"));
     }
 
     static class SearchModel extends ParentChildSearchModel {

--- a/config-model/src/test/java/com/yahoo/schema/processing/PositionTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/PositionTestCase.java
@@ -263,8 +263,8 @@ public class PositionTestCase {
                            PositionDataType.getZCurveFieldName(fieldName),
                            (isArray ? DataType.getArray(PositionDataType.INSTANCE) : PositionDataType.INSTANCE),
                            SummaryTransform.GEOPOS);
-        assertNull(schema.getSummaryField(AdjustPositionSummaryFields.getDistanceSummaryFieldName(fieldName)));
-        assertNull(schema.getSummaryField(AdjustPositionSummaryFields.getPositionSummaryFieldName(fieldName)));
+        assertNull(schema.getSummaryField(fieldName + ".distance"));
+        assertNull(schema.getSummaryField(fieldName + ".position"));
     }
 
     private static void assertSummaryField(Schema schema, String fieldName, String sourceName, DataType dataType,


### PR DESCRIPTION
AdjustPositionSummaryFields.ensureSummaryField() could only ever validate a pre-existing "field.distance"/"field.position" summary field, but nothing has created or transformed such fields since the v7 legacy geo position support was removed, and no code sets SummaryTransform.DISTANCE/POSITIONS on any real field. Reject dotted summary field names in ParsedSummaryField to close the one remaining (and always-failing) way to declare such a field from a schema, and drop the now-certainly-unreachable validation logic together with the tests that only exercised it via direct Java model construction.

Also drop the similarly-unreachable "Position attributes" block in ImplicitSummaries (CreatePositionZCurve always relocates the position attribute to a differently-named _zcurve field before this code runs, so it could never find a match), and add a test covering both branches of AdjustPositionSummaryFields' z-curve name resolution in one schema.

Comment the remaining DISTANCE/POSITIONS checks (SummaryTransform, ImplicitSummaries, SummaryClass, SummaryClassField) as unreachable in practice, to save the next reader the trip through git history.

