### PR TITLE
Add dequantizing tensor attribute feature executor

### DIFF
--- a/searchlib/src/tests/features/tensor/CMakeLists.txt
+++ b/searchlib/src/tests/features/tensor/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_executable(searchlib_tensor_test_app TEST
     tensor_test.cpp
     DEPENDS
     vespa_searchlib
+    searchlib_test
     GTest::gtest
 )
 vespa_add_test(NAME searchlib_tensor_test_app COMMAND searchlib_tensor_test_app)

--- a/searchlib/src/tests/features/tensor/tensor_test.cpp
+++ b/searchlib/src/tests/features/tensor/tensor_test.cpp
@@ -15,6 +15,8 @@
 #include <vespa/searchlib/fef/test/indexenvironment.h>
 #include <vespa/searchlib/tensor/direct_tensor_attribute.h>
 #include <vespa/searchlib/tensor/tensor_attribute.h>
+#include <vespa/searchlib/test/tensor_divergence.h>
+#include <vespa/searchlib/test/test_quantization_params.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/objects/nbostream.h>
 
@@ -25,8 +27,10 @@ using namespace search::fef::test;
 using namespace search::features;
 using search::AttributeFactory;
 using search::AttributeVector;
+using search::attribute::QuantizationParams;
 using search::tensor::DirectTensorAttribute;
 using search::tensor::TensorAttribute;
+using search::test::compute_tensor_nrmse;
 using vespalib::eval::Function;
 using vespalib::eval::SimpleValue;
 using vespalib::eval::spec_from_value;
@@ -65,10 +69,15 @@ struct ExecFixture {
         return AttributeFactory::createAttribute(attrName, AVC(AVBT::STRING, AVCT::SINGLE));
     }
     AttributeVector::SP createTensorAttribute(const std::string& attrName, const std::string& type,
-                                              bool direct = false) {
+                                              bool direct = false, bool quantized = false) {
         addAttributeField(attrName);
         AVC config(AVBT::TENSOR, AVCT::SINGLE);
-        config.setTensorType(ValueType::from_spec(type));
+        if (!quantized) {
+            config.setTensorType(ValueType::from_spec(type));
+        } else {
+            config.set_tensor_type_with_quantization(ValueType::from_spec(type),
+                                                     search::test::mse_4bit_quantization_params());
+        }
         config.setFastSearch(direct);
         return AttributeFactory::createAttribute(attrName, config);
     }
@@ -86,11 +95,13 @@ struct ExecFixture {
         std::vector<AttributePtr> attrs;
         attrs.push_back(createTensorAttribute("tensorattr", "tensor(x{})"));
         attrs.push_back(createTensorAttribute("directattr", "tensor(x{})", true));
+        attrs.push_back(createTensorAttribute("quantattr", "tensor(x[10])", false, true));
         attrs.push_back(createStringAttribute("singlestr"));
         attrs.push_back(createTensorAttribute("wrongtype", "tensor(y{})"));
         addAttributeField("null");
         setAttributeTensorType("tensorattr", "tensor(x{})");
         setAttributeTensorType("directattr", "tensor(x{})");
+        setAttributeTensorType("quantattr", "tensor(x[10])");
         setAttributeTensorType("wrongtype", "tensor(x{})");
         setAttributeTensorType("null", "tensor(x{})");
 
@@ -103,13 +114,18 @@ struct ExecFixture {
             test.getIndexEnv().getAttributeMap().add(attr);
         }
 
-        TensorAttribute*       tensorAttr = dynamic_cast<TensorAttribute*>(attrs[0].get());
-        DirectTensorAttribute* directAttr = dynamic_cast<DirectTensorAttribute*>(attrs[1].get());
+        auto* tensorAttr = dynamic_cast<TensorAttribute*>(attrs[0].get());
+        auto* directAttr = dynamic_cast<DirectTensorAttribute*>(attrs[1].get());
+        auto* quantized_attr = dynamic_cast<TensorAttribute*>(attrs[2].get());
 
         auto doc_tensor = SimpleValue::from_spec(
             TensorSpec("tensor(x{})").add({{"x", "a"}}, 3).add({{"x", "b"}}, 5).add({{"x", "c"}}, 7));
         tensorAttr->setTensor(1, *doc_tensor);
         directAttr->setTensor(1, *doc_tensor);
+
+        auto dense_doc_tensor = SimpleValue::from_spec(
+            TensorSpec("tensor(x[10])").add({{"x", 1}}, 3).add({{"x", 3}}, 5).add({{"x", 8}}, 7));
+        quantized_attr->setTensor(1, *quantized_attr->make_quantizer()->quantize(*dense_doc_tensor));
 
         for (const auto& attr : attrs) {
             attr->commit();
@@ -197,6 +213,20 @@ TEST(TensorTest, require_that_empty_tensor_with_correct_type_is_returned_by_dire
 TEST(TensorTest, require_that_wrong_tensor_type_from_query_tensor_gives_empty_tensor) {
     ExecFixture f("query(mappedtensorquery)");
     EXPECT_EQ(TensorSpec("tensor(x[2])").add({{"x", 0}}, 0).add({{"x", 1}}, 0), spec_from_value(f.execute()));
+}
+
+TEST(TensorTest, quantized_tensor_attribute_can_be_extracted_as_dequantized_tensor_in_attribute_feature) {
+    ExecFixture f("attribute(quantattr)");
+    const auto  expected =
+        SimpleValue::from_spec(TensorSpec("tensor(x[10])").add({{"x", 1}}, 3).add({{"x", 3}}, 5).add({{"x", 8}}, 7));
+    const auto&      actual = f.execute();
+    constexpr double max_error = 0.035;
+    EXPECT_LE(compute_tensor_nrmse(*expected, actual), max_error);
+}
+
+TEST(TensorTest, empty_tensor_with_correct_unquantized_type_is_created_if_document_has_no_quantized_tensor) {
+    ExecFixture f("attribute(quantattr)");
+    EXPECT_EQ(*make_empty("tensor(x[10])"), f.execute(2));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/features/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/features/CMakeLists.txt
@@ -15,6 +15,7 @@ vespa_add_library(searchlib_features OBJECT
     debug_attribute_wait.cpp
     debug_wait.cpp
     dense_tensor_attribute_executor.cpp
+    dequantizing_tensor_attribute_executor.cpp
     direct_tensor_attribute_executor.cpp
     distance_calculator_bundle.cpp
     distancefeature.cpp

--- a/searchlib/src/vespa/searchlib/features/attributefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/attributefeature.cpp
@@ -4,6 +4,7 @@
 
 #include "constant_tensor_executor.h"
 #include "dense_tensor_attribute_executor.h"
+#include "dequantizing_tensor_attribute_executor.h"
 #include "direct_tensor_attribute_executor.h"
 #include "tensor_attribute_executor.h"
 #include "utils.h"
@@ -414,7 +415,7 @@ fef::FeatureExecutor& createTensorAttributeExecutor(const IAttributeVector* attr
     if (attribute->getCollectionType() != attribute::CollectionType::SINGLE ||
         attribute->getBasicType() != attribute::BasicType::TENSOR)
     {
-        Issue::report("attribute feature: The attribute vector '%s' is NOT of type tensor."
+        Issue::report("attribute feature: The attribute vector '%s' is NOT of type tensor. "
                       "Returning empty tensor.",
                       attribute->getName().c_str());
         return ConstantTensorExecutor::createEmpty(tensorType, stash);
@@ -426,12 +427,21 @@ fef::FeatureExecutor& createTensorAttributeExecutor(const IAttributeVector* attr
                       attribute->getName().c_str());
         return ConstantTensorExecutor::createEmpty(tensorType, stash);
     }
-    if (tensorType != tensorAttribute->getTensorType()) {
+    // Quantized tensors will be transparently dequantized to the type configured in the schema,
+    // so the attribute feature type must match the schema type (_not_ the internal, quantized type).
+    // For non-quantized tensors, this is always equal to the configured schema type.
+    if (tensorType != tensorAttribute->unquantized_tensor_type()) {
         Issue::report("attribute feature: The tensor attribute '%s' has tensor type '%s',"
                       " while the feature executor expects type '%s'. Returning empty tensor.",
-                      attribute->getName().c_str(), tensorAttribute->getTensorType().to_spec().c_str(),
+                      attribute->getName().c_str(), tensorAttribute->unquantized_tensor_type().to_spec().c_str(),
                       tensorType.to_spec().c_str());
         return ConstantTensorExecutor::createEmpty(tensorType, stash);
+    }
+    // Quantization takes precedence over extract_cells_ref/get_tensor_ref support.
+    // TODO consider having a dedicated executor for quantized + get_tensor_ref support,
+    //  since the dequantization API takes in a `const eval::Value&`.
+    if (tensorAttribute->is_quantized()) {
+        return stash.create<DequantizingTensorAttributeExecutor>(*tensorAttribute);
     }
     if (tensorAttribute->supports_extract_cells_ref()) {
         return stash.create<DenseTensorAttributeExecutor>(*tensorAttribute);

--- a/searchlib/src/vespa/searchlib/features/dequantizing_tensor_attribute_executor.cpp
+++ b/searchlib/src/vespa/searchlib/features/dequantizing_tensor_attribute_executor.cpp
@@ -1,0 +1,29 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "dequantizing_tensor_attribute_executor.h"
+
+#include <vespa/searchlib/tensor/i_tensor_attribute.h>
+#include <vespa/searchlib/tensor/tensor_quantization.h>
+
+namespace search::features {
+
+DequantizingTensorAttributeExecutor::DequantizingTensorAttributeExecutor(const tensor::ITensorAttribute& attribute)
+    : _attribute(attribute),
+      _dequantizer(attribute.make_dequantizer()),
+      _empty_tensor(_dequantizer->dequantize(*attribute.getEmptyTensor())), // Must be of _unquantized_ type
+      _tensor() {
+}
+
+DequantizingTensorAttributeExecutor::~DequantizingTensorAttributeExecutor() = default;
+
+void DequantizingTensorAttributeExecutor::execute(const uint32_t doc_id) {
+    _tensor = _attribute.getTensor(doc_id);
+    if (_tensor) {
+        _tensor = _dequantizer->dequantize(*_tensor);
+        outputs().set_object(0, *_tensor);
+    } else {
+        outputs().set_object(0, *_empty_tensor);
+    }
+}
+
+} // namespace search::features

--- a/searchlib/src/vespa/searchlib/features/dequantizing_tensor_attribute_executor.h
+++ b/searchlib/src/vespa/searchlib/features/dequantizing_tensor_attribute_executor.h
@@ -1,0 +1,32 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/eval/eval/value.h>
+#include <vespa/searchcommon/attribute/iattributevector.h>
+#include <vespa/searchlib/fef/featureexecutor.h>
+
+namespace search::tensor {
+class ITensorAttribute;
+class TensorDequantizer;
+} // namespace search::tensor
+
+namespace search::features {
+
+/*
+ * Attribute executor that only operates on quantized tensor attributes,
+ * transparently dequantizing any retrieved tensors.
+ */
+class DequantizingTensorAttributeExecutor : public fef::FeatureExecutor {
+    const tensor::ITensorAttribute&            _attribute;
+    std::unique_ptr<tensor::TensorDequantizer> _dequantizer;
+    std::unique_ptr<vespalib::eval::Value>     _empty_tensor;
+    std::unique_ptr<vespalib::eval::Value>     _tensor;
+
+public:
+    DequantizingTensorAttributeExecutor(const tensor::ITensorAttribute& attribute);
+    ~DequantizingTensorAttributeExecutor() override;
+    void execute(uint32_t doc_id) override;
+};
+
+} // namespace search::features


### PR DESCRIPTION
@arnej27959 @toregge please review

The internal tensor type (and representation) of quantized tensor attributes is inherently different from that configured in the schema. When exposing the attribute contents as a feature, we must therefore do a conversion on the fly to the expected form.

This adds a dedicated dequantizing attribute feature executor which exposes the contents of a quantized tensor attribute by transparently dequantizing all fetched tensors. The executor caches and reuses a `TensorDequantizer` instance to minimize
per-tensor overhead.

Tensor attribute feature type checking has been updated to use the _unquantized_ tensor attribute type, as that is the only type we expose to the outside world. For non-quantized tensors, this is always equal to the original type and incurs zero changes to semantics.
