### PR TITLE
 fast map search: do not create attribute when parent already has done it

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
@@ -56,7 +56,15 @@ public class CreateFastMapSearch extends Processor {
             if (!shouldCreateFastMapAttribute(field)) {
                 continue;
             }
-            SDField keyValueField = createFastMapField(field, FastMapSearch.toKeyValueFieldName(field.getName()), validate);
+
+            String fieldName = FastMapSearch.toKeyValueFieldName(field.getName());
+            // Inheritance: there is a parent that has already made the attribute.
+            var existing = schema.getConcreteField(fieldName);
+            if (existing != null && existing.isInternalField()) {
+                continue;
+            }
+
+            SDField keyValueField = createFastMapField(field, fieldName, validate);
             schema.addExtraField(keyValueField);
             schema.fieldSets().addBuiltInFieldSetItem(BuiltInFieldSets.INTERNAL_FIELDSET_NAME, keyValueField.getName());
         }

--- a/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
@@ -133,15 +133,12 @@ public class CreateFastMapSearchTest {
         var builder = new ApplicationBuilder(new TestProperties().fastMapSearch(true));
         builder.addSchema(joinLines("schema parent {",
                                     "  document parent {",
-                                    fastSearchMap("map<string, string>"),
+                                    fastSearchMap("foo", "string"),
                                     "  }",
                                     "}"));
         builder.addSchema(joinLines("schema child inherits parent {",
                                     "  document child inherits parent {",
-                                    "    field bar type map<string, string> {",
-                                    "      indexing: summary",
-                                    "      map: fast-search",
-                                    "    }",
+                                    fastSearchMap("bar", "string"),
                                     "  }",
                                     "}"));
         builder.build(true);

--- a/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
@@ -155,7 +155,12 @@ public class CreateFastMapSearchTest {
         assertNotNull(child.getConcreteField("bar$keyvalue"), "Expected key-value field for the child's own map");
         assertNull(parent.getConcreteField("bar$keyvalue"));
     }
-
+    private static String fastSearchMap(String name, String valueType) {
+        return joinLines("field " + name + " type map<string," + valueType + "> {",
+                         "  indexing: summary",
+                         "  map: fast-search",
+                         "}");
+    }
     private static String fastSearchMap(String type) {
         return joinLines("field foo type " + type + " {",
                          "  indexing: summary",

--- a/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
@@ -14,6 +14,7 @@ import static com.yahoo.config.model.test.TestUtil.joinLines;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -121,6 +122,41 @@ public class CreateFastMapSearchTest {
                                                            "}")));
         assertTrue(exception.getMessage().contains("Incompatible map attribute 'foo$keyvalue' already created"),
                    "Unexpected message: " + exception.getMessage());
+    }
+
+    /**
+     * A child schema sees the parent's key-value field through inheritance. It must reuse
+     * that field rather than derive it again, while still deriving its own fast-search maps.
+     */
+    @Test
+    void requireInheritedFastSearchMapIsNotDerivedAgain() throws ParseException {
+        var builder = new ApplicationBuilder(new TestProperties().fastMapSearch(true));
+        builder.addSchema(joinLines("schema parent {",
+                                    "  document parent {",
+                                    fastSearchMap("map<string, string>"),
+                                    "  }",
+                                    "}"));
+        builder.addSchema(joinLines("schema child inherits parent {",
+                                    "  document child inherits parent {",
+                                    "    field bar type map<string, string> {",
+                                    "      indexing: summary",
+                                    "      map: fast-search",
+                                    "    }",
+                                    "  }",
+                                    "}"));
+        builder.build(true);
+        Schema parent = builder.getSchema("parent");
+        Schema child = builder.getSchema("child");
+
+        // The inherited key-value field is the parent's, not a copy made by the child. A copy would
+        // shadow the parent's field, since own extra fields are looked up before inherited ones.
+        SDField inherited = child.getConcreteField("foo$keyvalue");
+        assertNotNull(inherited, "Expected child to see the inherited key-value field");
+        assertSame(parent.getConcreteField("foo$keyvalue"), inherited);
+
+        // The child's own fast-search map is still derived, and only in the child.
+        assertNotNull(child.getConcreteField("bar$keyvalue"), "Expected key-value field for the child's own map");
+        assertNull(parent.getConcreteField("bar$keyvalue"));
     }
 
     private static String fastSearchMap(String type) {


### PR DESCRIPTION
When processing fields in CreateFastMapProcessor, if the parent has a map with fast search, it creates an internal field and an attribute. When the child runs the same loop, it will see the newly created attribute.

Before, it failed, saying that this field already exists. With this fix, we skip if the field already exists as an internal field.

@boeker fyi