### PR TITLE
add fancy map syntax to yql for strings

### DIFF
--- a/container-search/src/main/antlr4/com/yahoo/search/yql/yqlplus.g4
+++ b/container-search/src/main/antlr4/com/yahoo/search/yql/yqlplus.g4
@@ -410,14 +410,18 @@ dereferenced_expression
 	     (
 	        indexref[in_select]
           | propertyref
+          | mapref[in_select]
 	     )*
 	;
-	
+
 indexref[boolean in_select]
 	:	LBRACKET idx=expression[in_select] RBRACKET
 	;
 propertyref
 	: 	DOT nm=IDENTIFIER
+	;
+mapref[boolean in_select]
+	:	LBRACE key=expression[in_select] RBRACE
 	;
 
 primary_expression

--- a/container-search/src/main/java/com/yahoo/search/yql/ExpressionOperator.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/ExpressionOperator.java
@@ -46,6 +46,7 @@ enum ExpressionOperator implements Operator {
 
     INDEX(ExpressionOperator.class, ExpressionOperator.class),
     PROPREF(ExpressionOperator.class, String.class),
+    MAPREF(ExpressionOperator.class, ExpressionOperator.class),
 
     CALL(TypeCheckers.LIST_OF_STRING, TypeCheckers.EXPRS),
 

--- a/container-search/src/main/java/com/yahoo/search/yql/ProgramParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/ProgramParser.java
@@ -631,7 +631,7 @@ final class ProgramParser {
                 }
                 return OperatorNode.create(toLocation(scope, expressionList.isEmpty()? parseTree:expressionList.get(0)), ExpressionOperator.ARRAY, values);
             }
-            // dereferencedExpression: primaryExpression(indexref[in_select]| propertyref)*
+            // dereferencedExpression: primaryExpression(indexref[in_select]| propertyref | mapref[in_select])*
             case yqlplusParser.RULE_dereferenced_expression: {
                 Dereferenced_expressionContext dereferencedExpression = (Dereferenced_expressionContext) parseTree;
                 Iterator<ParseTree> it = dereferencedExpression.children.iterator();
@@ -641,6 +641,9 @@ final class ProgramParser {
                     if (getParseTreeIndex(defTree) == yqlplusParser.RULE_propertyref) {
                         // DOT nm=ID
                         result = OperatorNode.create(toLocation(scope, parseTree), ExpressionOperator.PROPREF, result, defTree.getChild(1).getText());
+                    } else if (getParseTreeIndex(defTree) == yqlplusParser.RULE_mapref) {
+                        // LBRACE key=expression RBRACE
+                        result = OperatorNode.create(toLocation(scope, parseTree), ExpressionOperator.MAPREF, result, convertExpr(defTree.getChild(1), scope));
                     } else {
                         // indexref
                         result = OperatorNode.create(toLocation(scope, parseTree), ExpressionOperator.INDEX, result, convertExpr(defTree.getChild(1), scope));

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -456,14 +456,15 @@ public class YqlParser implements Parser {
 
     /**
      * Recognizes and rewrites from:
-     *      field{'key'} = value
+     *      field{'key'} contains 'value'   (string values)
+     *      field{'key'} = value            (numeric values)
      * to:
      *      field contains sameElement(key contains 'key', value contains value)
      * <p>
-     * Expected input: EQ( MAPREF ( field_name, key ), value )
+     * Expected input: CONTAINS( MAPREF ( field_name, key ), value ) or EQ( MAPREF ( field_name, key ), value )
      */
     private OperatorNode<ExpressionOperator> rewriteMapAccess(OperatorNode<ExpressionOperator> ast) {
-        if (ast.getOperator() != ExpressionOperator.EQ) {
+        if (ast.getOperator() != ExpressionOperator.CONTAINS && ast.getOperator() != ExpressionOperator.EQ) {
             return ast;
         }
 

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -381,6 +381,7 @@ public class YqlParser implements Parser {
         try {
             annotationStack.addFirst(ast);
             ast = rewriteIndexedAccess(ast);
+            ast = rewriteMapAccess(ast);
             return switch (ast.getOperator()) {
                 case AND -> buildAnd(ast, currentField);
                 case OR -> buildOr(ast, currentField);
@@ -449,6 +450,54 @@ public class YqlParser implements Parser {
                 List.of(SAME_ELEMENT),
                 List.of(value));
         sameElement.putAnnotation(ELEMENT_FILTER, List.of(elementIndex));
+
+        return OperatorNode.create(ast.getLocation(), ExpressionOperator.CONTAINS, field, sameElement);
+    }
+
+    /**
+     * Recognizes and rewrites from:
+     *      field{'key'} = value
+     * to:
+     *      field contains sameElement(key contains 'key', value contains value)
+     * <p>
+     * Expected input: EQ( MAPREF ( field_name, key ), value )
+     */
+    private OperatorNode<ExpressionOperator> rewriteMapAccess(OperatorNode<ExpressionOperator> ast) {
+        if (ast.getOperator() != ExpressionOperator.EQ) {
+            return ast;
+        }
+
+        OperatorNode<ExpressionOperator> lhs = ast.getArgument(0);
+        OperatorNode<ExpressionOperator> value = ast.getArgument(1);
+        if (lhs.getOperator() != ExpressionOperator.MAPREF) {
+            return ast;
+        }
+
+        OperatorNode<ExpressionOperator> field = lhs.getArgument(0);
+        OperatorNode<ExpressionOperator> key = lhs.getArgument(1);
+        if (key.getOperator() != ExpressionOperator.LITERAL) {
+            throw newUnexpectedArgumentException(key.getOperator(), ExpressionOperator.LITERAL);
+        }
+
+        // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
+        key = toLiteralString(key);
+        value = toLiteralString(value);
+
+        OperatorNode<ExpressionOperator> keyMatch = OperatorNode.create(
+                ast.getLocation(),
+                ExpressionOperator.CONTAINS,
+                OperatorNode.create(lhs.getLocation(), ExpressionOperator.READ_FIELD, "", "key"),
+                key);
+        OperatorNode<ExpressionOperator> valueMatch = OperatorNode.create(
+                ast.getLocation(),
+                ExpressionOperator.CONTAINS,
+                OperatorNode.create(lhs.getLocation(), ExpressionOperator.READ_FIELD, "", "value"),
+                value);
+        OperatorNode<ExpressionOperator> sameElement = OperatorNode.create(
+                ast.getLocation(),
+                ExpressionOperator.CALL,
+                List.of(SAME_ELEMENT),
+                List.of(keyMatch, valueMatch));
 
         return OperatorNode.create(ast.getLocation(), ExpressionOperator.CONTAINS, field, sameElement);
     }

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -579,6 +579,31 @@ public class YqlParserTestCase {
     }
 
     @Test
+    void testMapAccessRewritesToSameElement() {
+        // my_map{'foo'} = 'bar' should rewrite to my_map contains sameElement(key contains 'foo', value contains 'bar')
+        assertParse("select * from sources * where my_map{'foo'} = 'bar'",
+                    "my_map:{key:foo value:bar}");
+
+        // Non-string values are converted to string, as in the indexed access rewrite.
+        assertParse("select * from sources * where my_map{'foo'} = 10",
+                    "my_map:{key:foo value:10}");
+
+        // Numeric keys are converted to string, for maps with numeric key types.
+        assertParse("select * from sources * where my_map{1} = 'bar'",
+                    "my_map:{key:1 value:bar}");
+
+        // The rewritten tree serializes and re-parses to the same tree.
+        assertCanonicalParse("select * from sources * where my_map{'foo'} = 'bar'",
+                             "my_map:{key:foo value:bar}");
+    }
+
+    @Test
+    void testMapAccessRequiresLiteralKey() {
+        assertParseFail("select * from sources * where my_map{key_field} = 'bar'",
+                        new IllegalArgumentException("Expected LITERAL, got READ_FIELD."));
+    }
+
+    @Test
     void testPhrase() {
         assertParse("select foo from bar where baz contains phrase(\"a\", \"b\")",
                 "baz:\"a b\"");

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -580,26 +580,26 @@ public class YqlParserTestCase {
 
     @Test
     void testMapAccessRewritesToSameElement() {
-        // my_map{'foo'} = 'bar' should rewrite to my_map contains sameElement(key contains 'foo', value contains 'bar')
-        assertParse("select * from sources * where my_map{'foo'} = 'bar'",
+        // my_map{'foo'} contains 'bar' should rewrite to my_map contains sameElement(key contains 'foo', value contains 'bar')
+        assertParse("select * from sources * where my_map{'foo'} contains 'bar'",
                     "my_map:{key:foo value:bar}");
 
-        // Non-string values are converted to string, as in the indexed access rewrite.
+        // Numeric values use '=', as for plain fields, and are converted to string as in the indexed access rewrite.
         assertParse("select * from sources * where my_map{'foo'} = 10",
                     "my_map:{key:foo value:10}");
 
         // Numeric keys are converted to string, for maps with numeric key types.
-        assertParse("select * from sources * where my_map{1} = 'bar'",
+        assertParse("select * from sources * where my_map{1} contains 'bar'",
                     "my_map:{key:1 value:bar}");
 
         // The rewritten tree serializes and re-parses to the same tree.
-        assertCanonicalParse("select * from sources * where my_map{'foo'} = 'bar'",
+        assertCanonicalParse("select * from sources * where my_map{'foo'} contains 'bar'",
                              "my_map:{key:foo value:bar}");
     }
 
     @Test
     void testMapAccessRequiresLiteralKey() {
-        assertParseFail("select * from sources * where my_map{key_field} = 'bar'",
+        assertParseFail("select * from sources * where my_map{key_field} contains 'bar'",
                         new IllegalArgumentException("Expected LITERAL, got READ_FIELD."));
     }
 


### PR DESCRIPTION
Rewrites `field{'key'} contains 'value'` to:

```
field contains sameElement(key contians 'key', value contains 'value')
```

Same approach as we did with rewriteIndexedAccess.