### PR TITLE
More robust model management for triton

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidator.java
@@ -1,20 +1,27 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation.change;
 
+import ai.vespa.llm.clients.TritonConfig;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.text.Text;
 import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.utils.internal.ReflectionUtil;
 import com.yahoo.vespa.model.application.validation.Validation.ChangeContext;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerModelEvaluation;
+import com.yahoo.vespa.model.container.component.Component;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.yahoo.config.model.api.ConfigChangeRestartAction.ConfigChange.DEFER_UNTIL_RESTART;
 
 /**
- * Ensures that application container clusters are restarted when Triton ONNX Runtime component is added or removed.
+ * Ensures that application container clusters are restarted when the TritonOnnx Runtime component
+ * is added or removed, or when its config changes.
+ * TritonOnnxRuntime holds state shared across reconfigurations,
+ * which is only correct when its config never changes while the container serves.
  *
  * @author glebashnik
  */
@@ -34,15 +41,31 @@ public class RestartOnDeployForTritonOnnxRuntimeValidator implements ChangeValid
                 continue;
             }
 
-            var hadTritonRuntime = hasTritonOnnxRuntime(previousCluster);
-            var hasTritonRuntime = hasTritonOnnxRuntime(currentCluster);
+            var previousRuntime = getTritonOnnxRuntime(previousCluster);
+            var currentRuntime = getTritonOnnxRuntime(currentCluster);
 
-            if (hadTritonRuntime != hasTritonRuntime) {
-                var message = hasTritonRuntime
+            if (previousRuntime.isPresent() != currentRuntime.isPresent()) {
+                var message = currentRuntime.isPresent()
                         ? "Triton ONNX runtime was enabled for cluster '%s', services require restart"
                         : "Triton ONNX runtime was disabled for cluster '%s', services require restart";
                 var action = VespaRestartAction.ofCluster(currentCluster, Text.format(message, clusterId), DEFER_UNTIL_RESTART);
                 context.require(action);
+            } else if (currentRuntime.isPresent()) {
+                // Applies to self-hosted as well: without the restart, a config change would
+                // create runtimes with independent reference counts for the same Triton models.
+                var previousConfig = context.previousModel().getConfig(
+                        TritonConfig.class, previousRuntime.get().getConfigId());
+                var currentConfig = context.model().getConfig(
+                        TritonConfig.class, currentRuntime.get().getConfigId());
+                var changes = ReflectionUtil.getChangesRequiringRestart(previousConfig, currentConfig);
+
+                if (changes.needsRestart()) {
+                    var message = Text.format(
+                            "Triton config changed for cluster '%s', services require restart:\n%s",
+                            clusterId, changes.toString(""));
+                    var action = VespaRestartAction.ofCluster(currentCluster, message, DEFER_UNTIL_RESTART);
+                    context.require(action);
+                }
             }
         }
     }
@@ -52,9 +75,10 @@ public class RestartOnDeployForTritonOnnxRuntimeValidator implements ChangeValid
                 .collect(Collectors.toMap(ApplicationContainerCluster::id, cluster -> cluster));
     }
 
-    private static boolean hasTritonOnnxRuntime(ApplicationContainerCluster cluster) {
+    private static Optional<Component<?, ?>> getTritonOnnxRuntime(ApplicationContainerCluster cluster) {
         return cluster.getAllComponents().stream()
-                .anyMatch(component ->
-                        component.getClassId().getName().equals(ContainerModelEvaluation.TRITON_ONNX_RUNTIME_CLASS));
+                .filter(component ->
+                        component.getClassId().getName().equals(ContainerModelEvaluation.TRITON_ONNX_RUNTIME_CLASS))
+                .findFirst();
     }
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidatorTest.java
@@ -57,6 +57,16 @@ public class RestartOnDeployForTritonOnnxRuntimeValidatorTest {
         </services>
         """;
 
+    private static final String SERVICES_XML_WITH_TRITON_CONFIG = """
+        <services version='1.0'>
+          <container id='cluster1' version='1.0'>
+            <config name='ai.vespa.llm.clients.triton'>
+              <timeout>30000</timeout>
+            </config>
+          </container>
+        </services>
+        """;
+
     @Test
     void restart_when_triton_runtime_enabled() {
         var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER, false);
@@ -94,6 +104,22 @@ public class RestartOnDeployForTritonOnnxRuntimeValidatorTest {
         assertTrue(result.isEmpty());
     }
 
+    // TritonOnnxRuntime holds state shared across reconfigurations,
+    // so any change to its config requires a restart.
+    @Test
+    void restart_when_triton_config_changes() {
+        var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER, true);
+        var next = createModel(SERVICES_XML_WITH_TRITON_CONFIG, true);
+        var result = validateModel(previous, next);
+
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).getMessage().contains("Triton config changed"));
+        assertEquals(ConfigChangeAction.Type.RESTART, result.get(0).getType());
+
+        var restartAction = (VespaRestartAction) result.get(0);
+        assertEquals(ConfigChange.DEFER_UNTIL_RESTART, restartAction.configChange());
+    }
+
     @Test
     void no_restart_when_triton_runtime_remains_disabled() {
         var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER, false);
@@ -125,7 +151,10 @@ public class RestartOnDeployForTritonOnnxRuntimeValidatorTest {
         return ValidationTester.validateChanges(
                 new RestartOnDeployForTritonOnnxRuntimeValidator(),
                 next,
-                deployStateBuilder(false).previousModel(current).build());
+                deployStateBuilder(false)
+                        .properties(new TestProperties().setHostedVespa(true))
+                        .previousModel(current)
+                        .build());
     }
 
     private static VespaModel createModel(String servicesXml, boolean useTriton) {

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxClient.java
@@ -13,9 +13,6 @@ import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.text.Text;
 import com.yahoo.language.process.TimeoutException;
-import grpc.health.v1.HealthGrpc;
-import grpc.health.v1.HealthOuterClass.HealthCheckRequest;
-import grpc.health.v1.HealthOuterClass.HealthCheckResponse;
 import inference.GRPCInferenceServiceGrpc;
 import inference.GrpcService;
 import io.grpc.ManagedChannel;
@@ -35,7 +32,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -56,10 +52,18 @@ public class TritonOnnxClient implements AutoCloseable {
     private static final int MAX_MODEL_UNLOAD_ATTEMPTS = 5;
     private static final int MAX_MODEL_UNLOAD_WAIT_MILLIS = 1000;
 
+    // Deadline for status checks.
+    private static final Duration STATUS_CHECK_TIMEOUT = Duration.ofSeconds(10);
+
+    // Deadline for unload requests.
+    private static final Duration UNLOAD_TIMEOUT = Duration.ofMinutes(1);
+
+    // Deadline for load requests: generous, since loading a large model takes minutes.
+    private static final Duration LOAD_TIMEOUT = Duration.ofMinutes(5);
+
     private static final Logger log = Logger.getLogger(TritonOnnxClient.class.getName());
 
     private final GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingV2Stub grpcInferenceStub;
-    private final HealthGrpc.HealthBlockingV2Stub grpcHealthStub;
     private final Duration defaultTimeout;
 
     public static class TritonException extends RuntimeException {
@@ -84,7 +88,6 @@ public class TritonOnnxClient implements AutoCloseable {
                 .maxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE_MIB * 1024 * 1024)
                 .build();
         this.grpcInferenceStub = GRPCInferenceServiceGrpc.newBlockingV2Stub(ch);
-        this.grpcHealthStub = HealthGrpc.newBlockingV2Stub(ch);
         this.defaultTimeout = Duration.ofMillis(config.timeout());
     }
 
@@ -107,7 +110,8 @@ public class TritonOnnxClient implements AutoCloseable {
     public ModelMetadata getModelMetadata(String modelName) {
         var request =
                 GrpcService.ModelMetadataRequest.newBuilder().setName(modelName).build();
-        var response = invokeGrpc(grpcInferenceStub, s -> s.modelMetadata(request), "Failed to get model metadata");
+        var response = invokeGrpc(grpcInferenceStub.withDeadlineAfter(defaultTimeout),
+                s -> s.modelMetadata(request), "Failed to get model metadata");
         var inputs = toTensorTypes(response.getInputsList());
         var outputs = toTensorTypes(response.getOutputsList());
         return new ModelMetadata(inputs, outputs, response.getInputsList());
@@ -117,15 +121,45 @@ public class TritonOnnxClient implements AutoCloseable {
         var request =
                 GrpcService.ModelReadyRequest.newBuilder().setName(modelName).build();
         var response = invokeGrpc(
-                grpcInferenceStub, invocation -> invocation.modelReady(request), "Failed to check model ready");
+                statusStub(), invocation -> invocation.modelReady(request), "Failed to check model ready");
         return response.getReady();
     }
 
-    public boolean isHealthy() {
-        var req = HealthCheckRequest.newBuilder().build();
-        var response = invokeGrpc(grpcHealthStub, s -> s.check(req), "Failed to check Triton health");
-        log.fine(() -> "Triton health status: " + response.getStatus());
-        return response.getStatus() == HealthCheckResponse.ServingStatus.SERVING;
+    private GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingV2Stub statusStub() {
+        return grpcInferenceStub.withDeadlineAfter(STATUS_CHECK_TIMEOUT);
+    }
+
+    enum ModelActivity {
+        INACTIVE,
+        LOADED_OR_LOADING,
+        UNLOADING
+    }
+
+    // Package-private for tests.
+    ModelActivity modelActivity(String modelName) {
+        boolean unloading = false;
+
+        for (var model : getRepositoryIndex()) {
+            if (!modelName.equals(model.getName())) {
+                continue;
+            }
+
+            if ("READY".equals(model.getState()) || "LOADING".equals(model.getState())) {
+                return ModelActivity.LOADED_OR_LOADING;
+            }
+
+            if ("UNLOADING".equals(model.getState())) {
+                unloading = true;
+            }
+        }
+
+        return unloading ? ModelActivity.UNLOADING : ModelActivity.INACTIVE;
+    }
+
+    private List<GrpcService.RepositoryIndexResponse.ModelIndex> getRepositoryIndex() {
+        var request = GrpcService.RepositoryIndexRequest.newBuilder().build();
+        var response = invokeGrpc(statusStub(), s -> s.repositoryIndex(request), "Failed to get repository index");
+        return response.getModelsList();
     }
 
     public void loadModel(String modelName) {
@@ -133,7 +167,8 @@ public class TritonOnnxClient implements AutoCloseable {
         var request = GrpcService.RepositoryModelLoadRequest.newBuilder()
                 .setModelName(modelName)
                 .build();
-        invokeGrpc(grpcInferenceStub, s -> s.repositoryModelLoad(request), "Failed to load model");
+        invokeGrpc(grpcInferenceStub.withDeadlineAfter(LOAD_TIMEOUT),
+                s -> s.repositoryModelLoad(request), "Failed to load model");
     }
 
     public void unloadModel(String modelName) {
@@ -141,24 +176,20 @@ public class TritonOnnxClient implements AutoCloseable {
         var request = GrpcService.RepositoryModelUnloadRequest.newBuilder()
                 .setModelName(modelName)
                 .build();
-        invokeGrpc(grpcInferenceStub, s -> s.repositoryModelUnload(request), "Failed to unload model");
+        invokeGrpc(grpcInferenceStub.withDeadlineAfter(UNLOAD_TIMEOUT),
+                s -> s.repositoryModelUnload(request), "Failed to unload model");
     }
 
     public void unloadAllModels() {
         log.fine(() -> "Unloading all models");
-        var request =
-                GrpcService.RepositoryIndexRequest.newBuilder().setReady(true).build();
-        var response = invokeGrpc(grpcInferenceStub, s -> s.repositoryIndex(request), "Failed to get repository index");
 
-        for (var modelIndex : response.getModelsList()) {
-            var modelName = modelIndex.getName();
-
-            try {
-                unloadModel(modelName);
-            } catch (TritonException e) {
-                log.log(Level.SEVERE, e, () -> "Failed to unload model " + modelName);
-            }
-        }
+        getRepositoryIndex().stream()
+                .filter(model -> "READY".equals(model.getState())
+                        || "LOADING".equals(model.getState())
+                        || "UNLOADING".equals(model.getState()))
+                .map(GrpcService.RepositoryIndexResponse.ModelIndex::getName)
+                .distinct()
+                .forEach(this::unloadUntilModelNotReady);
     }
 
     /**
@@ -167,12 +198,16 @@ public class TritonOnnxClient implements AutoCloseable {
      * and the model can be loaded.
      */
     public void loadUntilModelReady(String modelName) {
-        if (isModelReady(modelName)) {
-            return;
+        try {
+            if (isModelReady(modelName)) {
+                return;
+            }
+        } catch (TritonException | TimeoutException e) {
+            // A failure must not abort before the first attempt to load the model.
         }
 
         boolean isLoaded = false;
-        TritonException lastException = null;
+        RuntimeException lastException = null;
         long startMillis = System.currentTimeMillis();
 
         for (int attempt = 0; attempt < MAX_MODEL_LOAD_ATTEMPTS; attempt++) {
@@ -185,7 +220,7 @@ public class TritonOnnxClient implements AutoCloseable {
                 if (isModelReady(modelName)) {
                     return;
                 }
-            } catch (TritonException e) {
+            } catch (TritonException | TimeoutException e) {
                 lastException = e;
             }
 
@@ -205,30 +240,31 @@ public class TritonOnnxClient implements AutoCloseable {
     }
 
     /**
-     * Makes several attempts to unload the model and check until it's not ready.
-     * This helps to mitigate a timing issue because of the delay between model unload request and the model not ready
-     * so that model files can be deleted.
+     * Makes several attempts to unload the model and waits until it is completely inactive.
      */
     public void unloadUntilModelNotReady(String modelName) {
-        if (!isModelReady(modelName)) {
-            return;
-        }
-
-        boolean isUnloaded = false;
-        TritonException lastException = null;
+        boolean unloadRequested = false;
+        RuntimeException lastException = null;
         long startMillis = System.currentTimeMillis();
 
         for (int attempt = 0; attempt < MAX_MODEL_UNLOAD_ATTEMPTS; attempt++) {
             try {
-                if (!isUnloaded) { // We only need one successful unload request.
-                    unloadModel(modelName);
-                    isUnloaded = true;
-                }
+                var activity = modelActivity(modelName);
 
-                if (!isModelReady(modelName)) {
+                if (activity == ModelActivity.INACTIVE) {
                     return;
                 }
-            } catch (TritonException e) {
+
+                // If Triton is already unloading the model, only poll.
+                if (!unloadRequested && activity != ModelActivity.UNLOADING) {
+                    unloadModel(modelName);
+                    unloadRequested = true;
+
+                    if (modelActivity(modelName) == ModelActivity.INACTIVE) {
+                        return;
+                    }
+                }
+            } catch (TritonException | TimeoutException e) {
                 lastException = e;
             }
 

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -9,12 +9,11 @@ import ai.vespa.modelintegration.utils.ModelPathOrData;
 import com.google.protobuf.TextFormat;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
-import com.yahoo.container.protect.ProcessTerminator;
 import com.yahoo.io.IOUtils;
-import com.yahoo.jdisc.AbstractResource;
 import com.yahoo.jdisc.ResourceReference;
-import com.yahoo.text.Text;
+import com.yahoo.language.process.TimeoutException;
 import com.yahoo.vespa.defaults.Defaults;
+import com.yahoo.yolean.Exceptions;
 import inference.ModelConfigOuterClass;
 
 import java.io.IOException;
@@ -25,14 +24,17 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
  * ONNX Runtime implementation that uses Triton Inference Server for model inference.
+ * It owns gRPC client, responsible for managing model repository and the reference-counted models loaded in Triton.
+ * There should be only one instance of TritonOnnxRuntime component, enforced by
+ * RestartOnDeployForTritonOnnxRuntimeValidator.
  *
  * @author bjorncs
  * @author glebashnik
@@ -40,40 +42,40 @@ import java.util.logging.Logger;
 public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime {
     private static final Logger log = Logger.getLogger(TritonOnnxRuntime.class.getName());
 
-    private final TritonConfig config;
     private final TritonOnnxClient tritonClient;
     private final boolean isModelControlExplicit;
     private final Path modelRepositoryPath;
-    private final ProcessTerminator processTerminator;
 
-    // The key is a model name containing hash of model content and options
+    // The key is a model name containing hash of model content and options.
+    // The map's per-key compute is the only synchronization of model bookkeeping:
+    // it guards the reference counts and serializes load and cleanup of the same model.
     private final ConcurrentMap<String, TritonModelResource> modelResources = new ConcurrentHashMap<>();
 
-    // Represents a model in Triton repository with reference counting.
-    // When created it copies model files to Triton repository and loads the model.
-    // When no references remain, the model is unloaded and model files are deleted.
-    class TritonModelResource extends AbstractResource {
-        public final String modelName;
+    // A model loaded in Triton, reference counted by the evaluators using it.
+    // When the count reaches zero, the model is unloaded and its files are deleted.
+    // Not using AbstractResource because it has its own synchronization mechanism that can create a deadlock
+    // when combined with synchronization through modelResources.
+    private static class TritonModelResource {
+        int referenceCount = 0;
+    }
 
-        private TritonModelResource(String modelName, String modelPath, OnnxEvaluatorOptions options) {
-            this.modelName = modelName;
+    @Inject
+    public TritonOnnxRuntime(TritonConfig config) {
+        this(config, new TritonOnnxClient(config));
+    }
 
-            if (isModelControlExplicit) {
-                var modelConfig = createModelConfig(modelName, options);
-                copyModelFilesToModelRepository(modelName, modelPath, modelConfig);
-                tritonClient.loadUntilModelReady(modelName);
-            }
-        }
+    // Injectable tritonClient for testing.
+    // Takes ownership of the client: deconstruct() closes it.
+    TritonOnnxRuntime(TritonConfig config, TritonOnnxClient tritonClient) {
+        log.info("Creating Triton ONNX runtime");
 
-        @Override
-        public void destroy() {
-            modelResources.computeIfPresent(modelName, (key, value) -> {
-                if (isModelControlExplicit) {
-                    tritonClient.unloadUntilModelNotReady(modelName);
-                    deleteModelFilesFromModelRepository(modelName);
-                }
-                return null; // remove from map
-            });
+        this.tritonClient = tritonClient;
+
+        isModelControlExplicit = config.modelControlMode() == TritonConfig.ModelControlMode.EXPLICIT;
+        modelRepositoryPath = Path.of(Defaults.getDefaults().underVespaHome(config.modelRepositoryPath()));
+
+        if (isModelControlExplicit) {
+            cleanUpLeftovers();
         }
     }
 
@@ -81,70 +83,114 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         return new TritonOnnxRuntime(new TritonConfig.Builder().build());
     }
 
-    @Inject
-    public TritonOnnxRuntime(TritonConfig config) {
-        this(config, new ProcessTerminator());
-    }
-
-    // Injectable ProcessTerminator for testing.
-    TritonOnnxRuntime(TritonConfig config, ProcessTerminator processTerminator) {
-        this(config, new TritonOnnxClient(config), processTerminator);
-    }
-
-    // Injectable tritonClient and ProcessTerminator for testing.
-    TritonOnnxRuntime(TritonConfig config, TritonOnnxClient tritonClient, ProcessTerminator processTerminator) {
-        log.info("Creating Triton ONNX runtime");
-        
-        this.config = config;
-        this.tritonClient = tritonClient;
-        this.processTerminator = processTerminator;
-
-        isModelControlExplicit = config.modelControlMode() == TritonConfig.ModelControlMode.EXPLICIT;
-        modelRepositoryPath = Path.of(Defaults.getDefaults().underVespaHome(config.modelRepositoryPath()));
-
-        if (isModelControlExplicit) {
-            try {
-                if (tritonClient.isHealthy()) {
-                    tritonClient.unloadAllModels();
-                }
-            } catch (TritonOnnxClient.TritonException e) {
-                // Ignore this since Triton might not be needed because there are no ONNX models in the app.
-            }
-            
-            deleteAllModelFilesFromModelRepository();
-        }
-    }
-
     @Override
     public OnnxEvaluator evaluatorOf(String modelPath, OnnxEvaluatorOptions options) {
-        // Needs a healthy Triton server to load a model.
-        try {
-            var isTritonHealthy = tritonClient.isHealthy();
-            
-            if (!isTritonHealthy) {
-                processTerminator.logAndDie(Text.format("Die because Triton server is not healthy at %s", config.target()));
-            }
-        } catch (TritonOnnxClient.TritonException e) {
-            processTerminator.logAndDie(Text.format("Die because Triton server can't be reached at %s", config.target()));
-        }
-
         var modelName = generateModelName(modelPath, options);
-        var modelReferenceHolder = new ResourceReference[1];
+        var modelReference = referenceModel(modelName, modelPath, options);
 
-        // Key synchronized create, reference, release and put model resource avoids concurrency issues.
-        modelResources.compute(modelName, (key, existingModelResource) -> {
-            if (existingModelResource != null) {
-                modelReferenceHolder[0] = existingModelResource.refer();
-                return existingModelResource;
+        try {
+            return new TritonOnnxEvaluator(modelName, modelReference, tritonClient, isModelControlExplicit);
+        } catch (RuntimeException e) {
+            modelReference.close(); // Don't leak the model when creating the evaluator fails.
+            throw e;
+        }
+    }
+
+    // Returns a reference to the model, first copying and loading it into Triton if needed.
+    // The map's per-key compute serializes this with a concurrent release of the same model.
+    private ResourceReference referenceModel(String modelName, String modelPath, OnnxEvaluatorOptions options) {
+        modelResources.compute(modelName, (key, modelResource) -> {
+            ensureModelReady(modelName, modelPath, options);
+
+            if (modelResource == null) {
+                modelResource = new TritonModelResource();
             }
 
-            var newModelResource = new TritonModelResource(modelName, modelPath, options);
-            modelReferenceHolder[0] = newModelResource.refer();
-            newModelResource.release();
-            return newModelResource;
+            modelResource.referenceCount++;
+            return modelResource;
         });
 
-        return new TritonOnnxEvaluator(modelName, modelReferenceHolder[0], tritonClient, isModelControlExplicit);
+        // Each reference releases the model exactly once.
+        var closed = new AtomicBoolean(false);
+
+        return () -> {
+            if (closed.getAndSet(true)) {
+                throw new IllegalStateException("The reference to model " + modelName + " is already closed");
+            }
+
+            releaseModel(modelName);
+        };
+    }
+
+    private void releaseModel(String modelName) {
+        modelResources.compute(modelName, (key, modelResource) -> {
+            // Already removed, e.g. force-released by deconstruct().
+            if (modelResource == null) {
+                return null;
+            }
+
+            modelResource.referenceCount--;
+
+            if (modelResource.referenceCount > 0) {
+                return modelResource;
+            }
+
+            if (isModelControlExplicit) {
+                cleanUpModel(modelName);
+            }
+
+            return null; // remove from map
+        });
+    }
+
+    // Uses an already-ready model, or copies the model into the repository and loads it into Triton.
+    // A load failure only fails the reconfiguration requesting this model; cleanup is best effort.
+    private void ensureModelReady(String modelName, String modelPath, OnnxEvaluatorOptions options) {
+        if (!isModelControlExplicit) {
+            return;
+        }
+
+        try {
+            if (tritonClient.isModelReady(modelName)) {
+                return; // Adopt a model that Triton already has ready
+            }
+        } catch (TritonOnnxClient.TritonException | TimeoutException e) {
+            // Still attempt to install and load the requested model below.
+        }
+
+        try {
+            var modelConfig = createModelConfig(modelName, options);
+            copyModelFilesToModelRepository(modelName, modelPath, modelConfig);
+            tritonClient.loadUntilModelReady(modelName);
+        } catch (RuntimeException e) {
+            // A failed load must not leave the model in Triton or its files in the repository.
+            cleanUpModel(modelName);
+            throw e;
+        }
+    }
+
+    // Best-effort unloading of a model from Triton and removing its files from the model repository.
+    private void cleanUpModel(String modelName) {
+        try {
+            tritonClient.unloadUntilModelNotReady(modelName);
+        } catch (RuntimeException e) {
+            // Keep the files if unload fails: deleting them while the model may still be loaded would break it.
+            log.log(Level.WARNING, e, () -> "Failed to unload model " + modelName + ", keeping its files");
+            return;
+        }
+
+        deleteModelFilesFromModelRepository(modelName);
+    }
+
+    // Best-effort cleanup of models left by a previous process.
+    private void cleanUpLeftovers() {
+        try {
+            tritonClient.unloadAllModels();
+            deleteAllModelFilesFromModelRepository();
+        } catch (RuntimeException e) {
+            // Triton may be down or not needed at all (no ONNX models in the app).
+            log.log(Level.WARNING, () -> "Skipped cleaning up leftover models: " + Exceptions.toMessageString(e));
+        }
     }
 
     static String generateModelName(String modelPath, OnnxEvaluatorOptions options) {
@@ -187,8 +233,13 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
     }
 
     private void deleteModelFilesFromModelRepository(String modelName) {
-        var modelDir = getModelDirInModelRepository(modelName);
-        IOUtils.recursiveDeleteDir(modelDir.toFile());
+        deleteModelDir(getModelDirInModelRepository(modelName));
+    }
+
+    private static void deleteModelDir(Path modelDir) {
+        if (Files.exists(modelDir) && !IOUtils.recursiveDeleteDir(modelDir.toFile())) {
+            log.warning(() -> "Failed to delete model files from Triton model repository: " + modelDir);
+        }
     }
 
     private static void addReadPermissions(Path path) throws IOException {
@@ -297,10 +348,7 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         try (var stream = Files.list(modelRepositoryPath)) {
             stream.forEach(path -> {
                 log.warning(() -> "Deleting leftover model files from Triton model repository: " + path);
-
-                if (!IOUtils.recursiveDeleteDir(path.toFile())) {
-                    log.warning(() -> "Failed to delete model files from Triton model repository: {}" + path);
-                }
+                deleteModelDir(path);
             });
         } catch (IOException e) {
             log.log(Level.SEVERE, e, () -> "Failed to list files in Triton model repository: " + modelRepositoryPath);
@@ -309,7 +357,16 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
 
     @Override
     public void deconstruct() {
-        modelResources.values().forEach(TritonModelResource::destroy);
+        for (var modelName : modelResources.keySet()) {
+            modelResources.compute(modelName, (key, modelResource) -> {
+                if (modelResource != null && isModelControlExplicit) {
+                    cleanUpModel(modelName);
+                }
+
+                return null; // remove from map
+            });
+        }
+
         tritonClient.close();
     }
 }

--- a/model-integration/src/main/resources/configdefinitions/triton.def
+++ b/model-integration/src/main/resources/configdefinitions/triton.def
@@ -1,17 +1,22 @@
 # Copyright Vespa.ai. Licensed under the Apache License, Version 2.0 (the "License");
 package=ai.vespa.llm.clients
 
+# All fields require a container restart on change,
+# enforced by RestartOnDeployForTritonOnnxRuntimeValidator in the config model.
+# TritonOnnxRuntime holds state shared across reconfigurations,
+# which is only correct when this config never changes while the container serves.
+
 # Endpoint of Nvidia Triton Inference Server
-target string default="triton:8001"
+target string default="triton:8001" restart
 
 # Model repository path where ONNX models are copied to.
-# Relative paths will be resolved relative to $VESPA_HOME. 
-modelRepositoryPath string default="/sidecars/triton/models"
+# Relative paths will be resolved relative to $VESPA_HOME.
+modelRepositoryPath string default="/sidecars/triton/models" restart
 
 # Model control mode. Client will only issue model load/unload requests if mode is EXPLICIT.
-modelControlMode enum {NONE, POLL, EXPLICIT} default=EXPLICIT
+modelControlMode enum {NONE, POLL, EXPLICIT} default=EXPLICIT restart
 
 # Default per-call gRPC deadline for inference requests, in milliseconds.
 # Used as a fallback when the caller (e.g. an embedder) does not supply a deadline derived
 # from the Vespa request context. When the caller does supply one, that value takes precedence.
-timeout long default=60000
+timeout long default=60000 restart

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxClientTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxClientTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -116,16 +117,16 @@ class TritonOnnxClientTest {
                     "attention_mask", Tensor.from("tensor<float>(d0[1],d1[5]):[1.0, 1.0, 1.0, 1.0, 1.0]"),
                     "token_type_ids", Tensor.from("tensor<float>(d0[1],d1[5]):[0.0, 0.0, 0.0, 0.0, 0.0]"));
 
-            assertThrows(TimeoutException.class,
-                    () -> tritonClient.evaluate(MODEL_NAME, metadata, inputs, "output_0", Duration.ofMillis(1)));
-        }
-    }
+            // Pausing the container guarantees that the server cannot answer, and we get a timeout.
+            var dockerClient = tritonContainer.getDockerClient();
+            dockerClient.pauseContainerCmd(tritonContainer.getContainerId()).exec();
 
-    @Test
-    void is_healthy_after_loading_model() {
-        try (var tritonClient = createTritonClient()) {
-            tritonClient.loadModel(MODEL_NAME);
-            assertTrue(tritonClient.isHealthy());
+            try {
+                assertThrows(TimeoutException.class,
+                        () -> tritonClient.evaluate(MODEL_NAME, metadata, inputs, "output_0", Duration.ofMillis(200)));
+            } finally {
+                dockerClient.unpauseContainerCmd(tritonContainer.getContainerId()).exec();
+            }
         }
     }
 
@@ -222,13 +223,18 @@ class TritonOnnxClientTest {
         try (var tritonClient = createTritonClient()) {
             var client = spy(tritonClient);
 
-            when(client.isModelReady(modelName)).thenReturn(true).thenReturn(false);
+            doReturn(
+                    TritonOnnxClient.ModelActivity.LOADED_OR_LOADING,
+                    TritonOnnxClient.ModelActivity.LOADED_OR_LOADING,
+                    TritonOnnxClient.ModelActivity.LOADED_OR_LOADING,
+                    TritonOnnxClient.ModelActivity.INACTIVE)
+                    .when(client).modelActivity(modelName);
             var exception = new TritonOnnxClient.TritonException("Unload failed");
             doThrow(exception).doThrow(exception).doNothing().when(client).unloadModel(modelName);
 
             client.unloadUntilModelNotReady(modelName);
 
-            verify(client, times(2)).isModelReady(modelName);
+            verify(client, times(4)).modelActivity(modelName);
             verify(client, times(3)).unloadModel(modelName);
         }
     }
@@ -240,16 +246,37 @@ class TritonOnnxClientTest {
         try (var tritonClient = createTritonClient()) {
             var client = spy(tritonClient);
 
-            when(client.isModelReady(modelName))
-                    .thenReturn(true)
-                    .thenReturn(true)
-                    .thenReturn(false);
+            doReturn(
+                    TritonOnnxClient.ModelActivity.LOADED_OR_LOADING,
+                    TritonOnnxClient.ModelActivity.LOADED_OR_LOADING,
+                    TritonOnnxClient.ModelActivity.LOADED_OR_LOADING,
+                    TritonOnnxClient.ModelActivity.INACTIVE)
+                    .when(client).modelActivity(modelName);
             doNothing().when(client).unloadModel(modelName);
 
             client.unloadUntilModelNotReady(modelName);
 
-            verify(client, times(3)).isModelReady(modelName);
+            verify(client, times(4)).modelActivity(modelName);
             verify(client, times(1)).unloadModel(modelName);
+        }
+    }
+
+    @Test
+    void unloadUntilModelNotReady_waits_for_an_already_unloading_model() {
+        var modelName = "test-model";
+
+        try (var tritonClient = createTritonClient()) {
+            var client = spy(tritonClient);
+
+            doReturn(
+                    TritonOnnxClient.ModelActivity.UNLOADING,
+                    TritonOnnxClient.ModelActivity.INACTIVE)
+                    .when(client).modelActivity(modelName);
+
+            client.unloadUntilModelNotReady(modelName);
+
+            verify(client, times(2)).modelActivity(modelName);
+            verify(client, times(0)).unloadModel(modelName);
         }
     }
 
@@ -260,13 +287,14 @@ class TritonOnnxClientTest {
         try (var tritonClient = createTritonClient()) {
             var client = spy(tritonClient);
 
-            when(client.isModelReady(modelName)).thenReturn(true);
+            doReturn(TritonOnnxClient.ModelActivity.LOADED_OR_LOADING)
+                    .when(client).modelActivity(modelName);
             var exception = new TritonOnnxClient.TritonException("Unload failed");
             doThrow(exception).when(client).unloadModel(modelName);
 
             assertThrows(TritonOnnxClient.TritonException.class, () -> client.unloadUntilModelNotReady(modelName));
 
-            verify(client, times(1)).isModelReady(modelName);
+            verify(client, times(5)).modelActivity(modelName);
             verify(client, times(5)).unloadModel(modelName);
         }
     }
@@ -278,12 +306,13 @@ class TritonOnnxClientTest {
         try (var tritonClient = createTritonClient()) {
             var client = spy(tritonClient);
 
-            when(client.isModelReady(modelName)).thenReturn(true);
+            doReturn(TritonOnnxClient.ModelActivity.LOADED_OR_LOADING)
+                    .when(client).modelActivity(modelName);
             doNothing().when(client).unloadModel(modelName);
 
             assertThrows(TritonOnnxClient.TritonException.class, () -> client.unloadUntilModelNotReady(modelName));
 
-            verify(client, times(6)).isModelReady(modelName);
+            verify(client, times(6)).modelActivity(modelName);
             verify(client, times(1)).unloadModel(modelName);
         }
     }

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
@@ -4,8 +4,9 @@ package ai.vespa.triton;
 import ai.vespa.llm.clients.TritonConfig;
 import ai.vespa.modelintegration.evaluator.OnnxEvaluator;
 import ai.vespa.modelintegration.evaluator.OnnxEvaluatorOptions;
-import com.yahoo.container.protect.ProcessTerminator;
+import com.yahoo.io.IOUtils;
 import com.yahoo.text.Text;
+import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -17,8 +18,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,6 +41,8 @@ import org.junit.jupiter.api.function.ThrowingSupplier;
 @ExtendWith(ContainerEnvironmentAvailableCondition.class)
 class TritonOnnxRuntimeTest {
 
+    private static final String MODEL_PATH = "src/test/models/onnx/transformer/dummy_transformer.onnx";
+
     private static TritonServerContainer tritonContainer;
     private final OnnxEvaluatorOptions.Builder optsBuilder = new OnnxEvaluatorOptions.Builder(8);
 
@@ -45,6 +52,7 @@ class TritonOnnxRuntimeTest {
         tritonContainer = new TritonServerContainer();
         tritonContainer.start();
     }
+
 
     @Test
     void load_model_with_defaults() throws IOException {
@@ -169,50 +177,92 @@ class TritonOnnxRuntimeTest {
             assertModelRepo(client, 0, Map.of(modelName1, false, modelName2, false));
         } finally {
             runtime.deconstruct();
+            client.close();
         }
     }
 
     @Test
-    void clean_model_repository_when_runtime_is_created() throws IOException {
+    void restore_requested_model_when_it_was_removed_independently() {
         var opts = optsBuilder.build();
+        var modelName = TritonOnnxRuntime.generateModelName(MODEL_PATH, opts);
+        var client = createClient();
+        var runtime = createRuntime();
 
-        var modelBaseName = "dummy_transformer";
-        var modelPath = Text.format("src/test/models/onnx/transformer/%s.onnx", modelBaseName);
-        var modelName = TritonOnnxRuntime.generateModelName(modelPath, opts);
+        try {
+            var firstEvaluator = runtime.evaluatorOf(MODEL_PATH, opts);
+            assertModelRepo(client, 1, Map.of(modelName, true));
+
+            // Simulate an external unload and repository cleanup while Vespa still references the model.
+            client.unloadUntilModelNotReady(modelName);
+            assertTrue(IOUtils.recursiveDeleteDir(
+                    tritonContainer.getModelRepositoryPath().resolve(modelName).toFile()));
+            assertModelRepo(client, 0, Map.of(modelName, false));
+
+            var secondEvaluator = runtime.evaluatorOf(MODEL_PATH, opts);
+            assertModelRepo(client, 1, Map.of(modelName, true));
+
+            secondEvaluator.close();
+            firstEvaluator.close();
+        } finally {
+            runtime.deconstruct();
+            client.close();
+        }
+    }
+
+    @Test
+    void clean_model_repository_when_runtime_is_created() {
+        var opts = optsBuilder.build();
+        var modelName = TritonOnnxRuntime.generateModelName(MODEL_PATH, opts);
 
         var client = createClient();
         var runtime = createRuntime();
 
-        runtime.evaluatorOf(modelPath, opts);
-        assertModelRepo(client, 1, Map.of(modelName, true));
+        try {
+            var evaluator = runtime.evaluatorOf(MODEL_PATH, opts);
+            try {
+                assertModelRepo(client, 1, Map.of(modelName, true));
 
-        createRuntime();
-        assertModelRepo(client, 0, Map.of(modelName, false));
+                // A runtime is only constructed at container start, so leftovers are from a previous run.
+                var newRuntime = createRuntime();
+                try {
+                    assertModelRepo(client, 0, Map.of(modelName, false));
+                } finally {
+                    newRuntime.deconstruct();
+                }
+            } finally {
+                evaluator.close();
+            }
+        } finally {
+            runtime.deconstruct();
+            client.close();
+        }
     }
 
     private TritonOnnxClient createClient() {
-        var tritonConfig = new TritonConfig.Builder()
-                .target(tritonContainer.getGrpcEndpoint())
-                .modelControlMode(TritonConfig.ModelControlMode.EXPLICIT)
-                .modelRepositoryPath(tritonContainer.getModelRepositoryPath().toString())
-                .build();
-        return new TritonOnnxClient(tritonConfig);
+        return new TritonOnnxClient(testConfig(TritonConfig.ModelControlMode.EXPLICIT));
     }
 
     private TritonOnnxRuntime createRuntime() {
-        var tritonConfig = new TritonConfig.Builder()
+        return new TritonOnnxRuntime(testConfig(TritonConfig.ModelControlMode.EXPLICIT));
+    }
+
+    private static TritonConfig testConfig(TritonConfig.ModelControlMode.Enum mode) {
+        return new TritonConfig.Builder()
                 .target(tritonContainer.getGrpcEndpoint())
-                .modelControlMode(TritonConfig.ModelControlMode.EXPLICIT)
+                .modelControlMode(mode)
                 .modelRepositoryPath(tritonContainer.getModelRepositoryPath().toString())
                 .build();
-        return new TritonOnnxRuntime(tritonConfig);
     }
 
     private void assertModelRepo(TritonOnnxClient client, int numFiles, Map<String, Boolean> modelReady) {
-        var repoFiles = tritonContainer.getModelRepositoryPath().toFile().list();
-        assertNotNull(repoFiles);
-        assertEquals(numFiles, repoFiles.length);
+        assertRepoFileCount(tritonContainer, numFiles);
         modelReady.forEach((modelName, isReady) -> assertEquals(isReady, client.isModelReady(modelName)));
+    }
+
+    private static void assertRepoFileCount(TritonServerContainer container, int expected) {
+        var repoFiles = container.getModelRepositoryPath().toFile().list();
+        assertNotNull(repoFiles);
+        assertEquals(expected, repoFiles.length);
     }
 
     // expectedConfigPath == null means we expect an error during model loading
@@ -257,90 +307,75 @@ class TritonOnnxRuntimeTest {
         assertEquals(normalizedExpected, normalizedActual);
     }
 
+    // Simulates deploying a faulty model followed by a working one.
+    // The faulty model must fail with an exception, not kill the process, and leave no state behind.
+    // The working model must load even though Triton still tracks the unrelated failed model.
     @Test
-    void die_when_triton_server_is_unreachable() {
-        var config = new TritonConfig.Builder()
-                .target("localhost:9999")  // Non-existent server
-                .build();
-        var mockTerminator = new MockProcessTerminator();
-
-        var runtime = new TritonOnnxRuntime(config, mockTerminator);
-        var modelPath = "src/test/models/onnx/transformer/dummy_transformer.onnx";
+    void recover_when_faulty_model_is_replaced_by_working_model() throws IOException {
+        var faultyModelPath = Files.createTempFile("faulty_model", ".onnx");
+        Files.writeString(faultyModelPath, "this is not a valid onnx model");
+        var runtime = createRuntime();
         var opts = optsBuilder.build();
 
-        assertThrows(MockProcessTerminationException.class, () -> runtime.evaluatorOf(modelPath, opts));
-        assertEquals(1, mockTerminator.dieRequests);
-        assertTrue(mockTerminator.lastMessage.contains("can't be reached"));
-        assertTrue(mockTerminator.lastMessage.contains("localhost:9999"));
+        try {
+            var exception = assertThrows(
+                    TritonOnnxClient.TritonException.class,
+                    () -> runtime.evaluatorOf(faultyModelPath.toString(), opts));
+            var message = Exceptions.toMessageString(exception);
+            assertTrue(message.contains("faulty_model"), message);
+            assertTrue(message.contains("failed"), message);
+            assertTrue(message.contains("Protobuf parsing failed"), message);
+
+            // The failed model must not leave files behind in the model repository.
+            assertRepoFileCount(tritonContainer, 0);
+
+            var evaluator = assertDoesNotThrow(() -> runtime.evaluatorOf(MODEL_PATH, opts));
+            assertNotNull(evaluator);
+            evaluator.close();
+        } finally {
+            runtime.deconstruct();
+            Files.deleteIfExists(faultyModelPath);
+        }
     }
 
+    // Hammers concurrent create and close of the same model from multiple threads,
+    // exercising the deadlock and adoption races between evaluatorOf and evaluator close.
+    // A deadlock fails the test through the future timeouts.
     @Test
-    void die_when_triton_server_is_unhealthy() {
-        var config = new TritonConfig.Builder()
-                .target(tritonContainer.getGrpcEndpoint())
-                .build();
-        
-        var mockClient = new TritonOnnxClient(config) {
-            @Override
-            public boolean isHealthy() {
-                return false;
+    void concurrent_create_and_close_of_the_same_model() throws Exception {
+        var opts = optsBuilder.build();
+        var modelName = TritonOnnxRuntime.generateModelName(MODEL_PATH, opts);
+        var client = createClient();
+        var runtime = createRuntime();
+        var threads = 4;
+        var iterations = 25;
+        var executor = Executors.newFixedThreadPool(threads);
+
+        try {
+            try {
+                var futures = new ArrayList<Future<?>>();
+
+                for (int thread = 0; thread < threads; thread++) {
+                    futures.add(executor.submit(() -> {
+                        for (int i = 0; i < iterations; i++) {
+                            runtime.evaluatorOf(MODEL_PATH, opts).close();
+                        }
+                        return null;
+                    }));
+                }
+
+                for (var future : futures) {
+                    future.get(120, TimeUnit.SECONDS);
+                }
+            } finally {
+                executor.shutdownNow();
+                runtime.deconstruct();
             }
-        };
-        
-        var mockTerminator = new MockProcessTerminator();
-        var runtime = new TritonOnnxRuntime(config, mockClient, mockTerminator);
-        var modelPath = "src/test/models/onnx/transformer/dummy_transformer.onnx";
-        var opts = optsBuilder.build();
 
-        assertThrows(MockProcessTerminationException.class, () -> runtime.evaluatorOf(modelPath, opts));
-        assertEquals(1, mockTerminator.dieRequests);
-        assertTrue(mockTerminator.lastMessage.contains("not healthy"));
-        assertTrue(mockTerminator.lastMessage.contains(tritonContainer.getGrpcEndpoint()));
-    }
-
-    @Test
-    void not_die_when_triton_server_is_healthy() {
-        var config = new TritonConfig.Builder()
-                .target(tritonContainer.getGrpcEndpoint())
-                .modelControlMode(TritonConfig.ModelControlMode.EXPLICIT)
-                .modelRepositoryPath(tritonContainer.getModelRepositoryPath().toString())
-                .build();
-
-        var mockTerminator = new MockProcessTerminator();
-        var runtime = new TritonOnnxRuntime(config, mockTerminator);
-
-        var modelPath = "src/test/models/onnx/transformer/dummy_transformer.onnx";
-        var opts = optsBuilder.build();
-
-        // Verify that evaluatorOf succeeds when server is healthy
-        var evaluator = assertDoesNotThrow(() -> runtime.evaluatorOf(modelPath, opts));
-        assertNotNull(evaluator);
-        assertEquals(0, mockTerminator.dieRequests);
-
-        evaluator.close();
-        runtime.deconstruct();
-    }
-
-    private static class MockProcessTerminator extends ProcessTerminator {
-        public int dieRequests = 0;
-        public String lastMessage = null;
-
-        @Override
-        public void logAndDie(String message, boolean dumpThreads) {
-            dieRequests++;
-            lastMessage = message;
-            throw new MockProcessTerminationException("Simulated process termination: " + message);
-        }
-
-        @Override
-        public void logAndDie(String message) {
-            logAndDie(message, false);
+            assertModelRepo(client, 0, Map.of(modelName, false));
+        } finally {
+            client.close();
         }
     }
 
-    private static class MockProcessTerminationException extends RuntimeException {
-        public MockProcessTerminationException(String message) {
-            super(message);
-        }
-    }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The main change is in TritonOnnxRuntime, which manages model references and triton model repository on disk and through explicit RPC calls. Each model can be used in one or several evaluators. Unused models are unloaded from triton memory and files deleted. This should handle reconfigurations, process restarts and triton failures. A lot of this has been already in place before this PR. What changed is:

1. Now triton config change triggers restarts and defers reconfiguration until restart as ensured by [RestartOnDeployForTritonOnnxRuntimeValidator.java](https://github.com/vespa-engine/vespa/compare/glebashnik/fix-triton-model-management?expand=1#diff-e87c0b1f12f86b01380816eabbc53bc5efe44fd41efe52add7296e270751ed5c). This is to avoid having two TritonOnnxRuntimes running at the same time.
2. Previous implementation had a potential deadlock when combining synchronization of ModelResource that inherited AbstractResource with synchronization through modelResources concurrent map in TritonOnnxRuntime. The easiest way to eliminate it was to do synchronization through the map only.
3. Health check in Triton can hold to previously failed model load, preventing recovery on redeployment. This has been fixed by not using health check but checking individual model readiness.