### PR TITLE
robustify sort by rank feature

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -11,6 +11,7 @@
 #include <vespa/searchcore/proton/matching/match_tools.h>
 #include <vespa/searchcore/proton/matching/matcher.h>
 #include <vespa/searchcore/proton/matching/querynodes.h>
+#include <vespa/searchcore/proton/matching/result_processor.h>
 #include <vespa/searchcore/proton/matching/sessionmanager.h>
 #include <vespa/searchcore/proton/matching/viewresolver.h>
 #include <vespa/searchcore/proton/test/bucketfactory.h>
@@ -18,6 +19,7 @@
 #include <vespa/searchlib/aggregation/grouping.h>
 #include <vespa/searchlib/aggregation/perdocexpression.h>
 #include <vespa/searchlib/attribute/extendableattributes.h>
+#include <vespa/searchlib/common/converters.h>
 #include <vespa/searchlib/engine/docsumreply.h>
 #include <vespa/searchlib/engine/docsumrequest.h>
 #include <vespa/searchlib/engine/searchreply.h>
@@ -1803,6 +1805,64 @@ TEST_F(MatchingTest, weak_and_stop_word_strategy_is_resolved_correctly) {
     EXPECT_TRUE(stop_words.should_drop(501));
     EXPECT_FALSE(stop_words.keep_all());
     EXPECT_TRUE(stop_words.allow_drop_all());
+}
+
+namespace {
+
+struct FakeSortValueProvider : INumericSortValueProvider {
+    std::vector<std::string> names;
+    explicit FakeSortValueProvider(std::vector<std::string> names_in) : names(std::move(names_in)) {}
+    uint32_t ordinal(std::string_view public_name) const override {
+        for (uint32_t i = 0; i < names.size(); ++i) {
+            if (names[i] == public_name) {
+                return i;
+            }
+        }
+        return invalid_ordinal;
+    }
+    void seek(uint32_t) override {}
+    double get(uint32_t) const override { return 0.0; }
+    bool failed() const noexcept override { return false; }
+    void consumed() override {}
+};
+
+} // namespace
+
+TEST(SortBindingTest, feature_sort_binds_when_all_values_are_available) {
+    MockAttributeContext  ac;
+    FakeSortValueProvider provider({"by_a1"});
+    ResultProcessor::Sort sort(7, vespalib::Doom::never(), ac, "-feature(by_a1)", &provider);
+    EXPECT_FALSE(sort.feature_binding_failed());
+    EXPECT_TRUE(sort.hasSortData());
+}
+
+TEST(SortBindingTest, feature_sort_binding_fails_when_a_value_is_unavailable) {
+    MockAttributeContext  ac;
+    FakeSortValueProvider provider({"by_a1"});
+    ResultProcessor::Sort sort(7, vespalib::Doom::never(), ac, "-feature(by_a1) +feature(gone)", &provider);
+    EXPECT_TRUE(sort.feature_binding_failed());
+    EXPECT_FALSE(sort.hasSortData());
+}
+
+TEST(SortBindingTest, feature_sort_binding_fails_without_a_provider) {
+    MockAttributeContext  ac;
+    ResultProcessor::Sort sort(7, vespalib::Doom::never(), ac, "-feature(by_a1)", nullptr);
+    EXPECT_TRUE(sort.feature_binding_failed());
+    EXPECT_FALSE(sort.hasSortData());
+}
+
+TEST(SortBindingTest, sort_without_features_needs_no_provider) {
+    MockAttributeContext  ac;
+    ResultProcessor::Sort sort(7, vespalib::Doom::never(), ac, "+[rank]", nullptr);
+    EXPECT_FALSE(sort.feature_binding_failed());
+    EXPECT_TRUE(sort.hasSortData());
+}
+
+TEST(SortBindingTest, failed_attribute_sort_is_not_a_feature_binding_failure) {
+    MockAttributeContext  ac;
+    ResultProcessor::Sort sort(7, vespalib::Doom::never(), ac, "+no_such_attribute", nullptr);
+    EXPECT_FALSE(sort.feature_binding_failed());
+    EXPECT_FALSE(sort.hasSortData());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchcore/src/tests/proton/matching/sort_feature_store_test.cpp
+++ b/searchcore/src/tests/proton/matching/sort_feature_store_test.cpp
@@ -100,4 +100,99 @@ TEST(SortFeatureStoreTest, grows_across_chunk_boundaries) {
     EXPECT_EQ(double(n - 1), store.get(0));
 }
 
+TEST(SortFeatureStoreTest, successful_consumption_is_not_a_failure) {
+    SortFeatureStore store({"foo"});
+    const double     a[] = {1.0};
+    store.record(10, a);
+    store.ensure_sorted_for_read();
+    store.seek(10);
+    EXPECT_EQ(1.0, store.get(0));
+    EXPECT_FALSE(store.failed());
+    store.consumed();
+    EXPECT_FALSE(store.failed());
+}
+
+TEST(SortFeatureStoreTest, seek_for_an_unrecorded_docid_fails_gracefully) {
+    SortFeatureStore store({"foo"});
+    const double     a[] = {1.0};
+    const double     b[] = {2.0};
+    store.record(10, a);
+    store.record(30, b);
+    store.ensure_sorted_for_read();
+    store.seek(20);
+    EXPECT_TRUE(store.failed());
+    EXPECT_EQ(-HUGE_VAL, store.get(0));
+}
+
+TEST(SortFeatureStoreTest, backwards_seek_fails_gracefully) {
+    SortFeatureStore store({"foo"});
+    const double     a[] = {1.0};
+    const double     b[] = {2.0};
+    store.record(10, a);
+    store.record(20, b);
+    store.ensure_sorted_for_read();
+    store.seek(20);
+    EXPECT_FALSE(store.failed());
+    store.seek(10);
+    EXPECT_TRUE(store.failed());
+    EXPECT_EQ(-HUGE_VAL, store.get(0));
+}
+
+TEST(SortFeatureStoreTest, seek_past_the_last_recorded_row_fails_gracefully) {
+    SortFeatureStore store({"foo"});
+    const double     a[] = {1.0};
+    store.record(10, a);
+    store.ensure_sorted_for_read();
+    store.seek(20);
+    EXPECT_TRUE(store.failed());
+    EXPECT_EQ(-HUGE_VAL, store.get(0));
+}
+
+TEST(SortFeatureStoreTest, seek_without_any_recorded_row_fails_gracefully) {
+    SortFeatureStore store({"foo"});
+    store.ensure_sorted_for_read();
+    store.seek(1);
+    EXPECT_TRUE(store.failed());
+    EXPECT_EQ(-HUGE_VAL, store.get(0));
+}
+
+TEST(SortFeatureStoreTest, seek_after_release_fails_gracefully) {
+    SortFeatureStore store({"foo"});
+    const double     a[] = {1.0};
+    store.record(10, a);
+    store.ensure_sorted_for_read();
+    store.consumed();
+    store.seek(10);
+    EXPECT_TRUE(store.failed());
+    EXPECT_EQ(-HUGE_VAL, store.get(0));
+}
+
+TEST(SortFeatureStoreTest, seek_before_preparing_for_read_fails_gracefully) {
+    SortFeatureStore store({"foo"});
+    const double     a[] = {1.0};
+    store.record(10, a);
+    store.seek(10);
+    EXPECT_TRUE(store.failed());
+    EXPECT_EQ(-HUGE_VAL, store.get(0));
+}
+
+TEST(SortFeatureStoreTest, failure_is_sticky_across_later_seeks_and_release) {
+    SortFeatureStore store({"foo"});
+    const double     a[] = {1.0};
+    const double     b[] = {2.0};
+    store.record(10, a);
+    store.record(20, b);
+    store.ensure_sorted_for_read();
+    store.seek(15);
+    EXPECT_TRUE(store.failed());
+    // A subsequent seek that would have been satisfiable does not clear the failure.
+    store.seek(20);
+    EXPECT_TRUE(store.failed());
+    EXPECT_EQ(-HUGE_VAL, store.get(0));
+    store.consumed();
+    EXPECT_TRUE(store.failed());
+    // Failure does not keep the storage alive for the rest of the query.
+    EXPECT_EQ(0u, store.num_rows());
+}
+
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchcore/src/vespa/searchcore/proton/matching/match_thread.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_thread.cpp
@@ -113,6 +113,8 @@ MatchThread::Context::Context(std::optional<double> first_phase_rank_score_drop_
       dropped() {
 }
 
+MatchThread::Context::~Context() = default;
+
 template <MatchThread::RankDropLimitE use_rank_drop_limit> bool MatchThread::Context::rankHit(uint32_t docId) {
     double score = (*_score_feature).as_number(docId);
     // convert NaN and Inf scores to -Inf
@@ -448,6 +450,10 @@ void MatchThread::processResult(const Doom& doom, search::ResultSet::UP result, 
         return;
     size_t sortLimit = hasGrouping ? numHits : context.result->maxSize();
     result->sort(*context.sort->sorter, sortLimit);
+    if (context.sort->sortSpec.feature_values_failed()) {
+        // The hits are not in the requested order; the matcher fails the query.
+        resultProcessor.note_sort_feature_failure();
+    }
     if (doom.hard_doom())
         return;
     if (hasGrouping) {
@@ -520,7 +526,12 @@ void MatchThread::run() {
      */
     search::ResultSet::UP result = findMatches(*matchTools);
     match_time_s = vespalib::to_s(match_time.elapsed());
-    resultContext = resultProcessor.createThreadContext(matchTools->getDoom(), thread_id, _distributionKey);
+    // The store is handed over even when its values will never be read, so that
+    // binding a doomed or otherwise unused query fails only on a genuinely
+    // unavailable feature.
+    SortFeatureStore* sort_store = matchTools->sort_store();
+    resultContext =
+        resultProcessor.createThreadContext(matchTools->getDoom(), thread_id, _distributionKey, sort_store);
     {
         trace->addEvent(5, "Wait for result processing token");
         WaitTimer               get_token_timer(wait_time_s);
@@ -528,14 +539,15 @@ void MatchThread::run() {
             matchTools->getDoom(), scheduler.total_size(thread_id), result->getNumHits(),
             resultContext->sort->hasSortData(), bool(resultContext->grouping)));
         get_token_timer.done();
-        if (SortFeatureStore* store = matchTools->sort_store()) {
-            if (matchTools->getDoom().hard_doom()) {
-                store->consumed();
+        // The recorded values are of no use once we are past the hard deadline or
+        // when the selected sorter does not read them; releasing them here frees
+        // the storage before the sorter allocates its own scratch. Otherwise the
+        // store must be in docid order before result processing seeks in it.
+        if (sort_store) {
+            if (matchTools->getDoom().hard_doom() || !resultContext->sort->hasSortData()) {
+                sort_store->consumed();
             } else {
-                store->ensure_sorted_for_read();
-                if (resultContext->sort->hasSortData()) {
-                    resultContext->sort->sortSpec.bind_numeric_provider(*store);
-                }
+                sort_store->ensure_sorted_for_read();
             }
         }
         trace->addEvent(5, "Start result processing");

--- a/searchcore/src/vespa/searchcore/proton/matching/match_thread.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_thread.h
@@ -84,6 +84,7 @@ private:
         Context(std::optional<double> first_phase_rank_score_drop_limit, MatchTools& tools, HitCollector& hits,
                 uint32_t num_threads, std::optional<LazyValue> score_feature, SortFeatureStore* sort_store,
                 std::span<const LazyValue> sort_seeds, bool sort_needs_unpack) __attribute__((noinline));
+        ~Context();
         template <RankDropLimitE use_rank_drop_limit> bool rankHit(uint32_t docId);
         void addHit(uint32_t docId) { _hits.addHit(docId, search::zero_rank_value); }
         void record_sort(uint32_t docId);

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -148,18 +148,40 @@ void MatchTools::setup_first_phase_and_sort(ExecutionProfiler* first_phase_profi
     _sort_programs.reserve(_sort_public_names.size());
     _sort_seeds.reserve(_sort_public_names.size());
     HandleRecorder recorder(_needed_handles);
+    bool           sort_setup_failed = false;
     {
         HandleRecorder::Binder bind(recorder);
         for (const auto& public_name : _sort_public_names) {
             auto program = _rankSetup.create_sort_program(public_name);
+            if (!program) {
+                // Leaving the store uncreated means nothing supplies the sort
+                // values, and the result processor fails the query when it
+                // cannot bind them. Matching itself still has to run.
+                sort_setup_failed = true;
+                break;
+            }
             program->setup(*_match_data, _queryEnv, _featureOverrides, nullptr);
             search::fef::FeatureResolver seeds(program->get_seeds());
-            assert(seeds.num_features() == 1u);
+            if (seeds.num_features() != 1u) {
+                // RankSetup::compile() rejects sort features that do not resolve
+                // to a single seed, so this should be unreachable.
+                vespalib::Issue::report("sort feature '%s' resolved to %zu values instead of one",
+                                        public_name.c_str(), seeds.num_features());
+                sort_setup_failed = true;
+                break;
+            }
             _sort_seeds.push_back(seeds.resolve(0));
             _sort_programs.push_back(std::move(program));
         }
-        // Re-registering an existing handle still means sort evaluation needs unpack.
-        _sort_needs_unpack = recorder.registration_attempted();
+        if (sort_setup_failed) {
+            _sort_seeds.clear();
+            _sort_programs.clear();
+            // Nothing is evaluated during matching, so nothing needs unpack.
+            _sort_needs_unpack = false;
+        } else {
+            // Re-registering an existing handle still means sort evaluation needs unpack.
+            _sort_needs_unpack = recorder.registration_attempted();
+        }
         if (match_with_ranking) {
             _rank_program = _rankSetup.create_first_phase_program();
             _rank_program->setup(*_match_data, _queryEnv, _featureOverrides, first_phase_profiler);
@@ -171,7 +193,9 @@ void MatchTools::setup_first_phase_and_sort(ExecutionProfiler* first_phase_profi
     _search = _query.createSearch(*_match_data);
     _used_handles = std::move(recorder).steal_handles();
     _search_has_changed = false;
-    _sort_store = std::make_unique<SortFeatureStore>(_sort_public_names);
+    if (!sort_setup_failed) {
+        _sort_store = std::make_unique<SortFeatureStore>(_sort_public_names);
+    }
 }
 
 void MatchTools::release_sort_programs() {
@@ -307,10 +331,13 @@ MatchTools::UP MatchToolsFactory::createMatchTools() const {
                                         _mdl, _rankSetup, _featureOverrides, _needed_handles, _sort_public_names);
 }
 
-void MatchToolsFactory::prepare_and_install_sort_features(const std::vector<std::string>& public_names) {
+bool MatchToolsFactory::prepare_and_install_sort_features(const std::vector<std::string>& public_names) {
     assert(_object_store != nullptr);
-    _rankSetup.prepare_sort_shared_state(_queryEnv, *_object_store, public_names);
+    if (!_rankSetup.prepare_sort_shared_state(_queryEnv, *_object_store, public_names)) {
+        return false;
+    }
     _sort_public_names = public_names;
+    return true;
 }
 
 std::unique_ptr<IDiversifier> MatchToolsFactory::createDiversifier(uint32_t want_hits) const {

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
@@ -187,7 +187,14 @@ public:
     bool valid() const { return _valid; }
     const MaybeMatchPhaseLimiter& match_limiter() const { return *_match_limiter; }
     MatchTools::UP createMatchTools() const;
-    void prepare_and_install_sort_features(const std::vector<std::string>& public_names);
+
+    /**
+     * Prepares shared state for the selected sort features and arms the match
+     * tools to record them. Returns false, having installed nothing, if one of
+     * the names is not an allowed sort feature; the caller must then fail the
+     * query rather than order the hits some other way.
+     **/
+    [[nodiscard]] bool prepare_and_install_sort_features(const std::vector<std::string>& public_names);
     bool should_diversify() const { return _diversityParams.enabled(); }
     std::unique_ptr<IDiversifier> createDiversifier(uint32_t heapSize) const;
     search::queryeval::Blueprint::HitEstimate estimate() const { return _query.estimate(); }

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -133,7 +133,8 @@ SelectedSortFeatures select_sort_features(const std::string& sort_spec, const Ra
                 continue;
             }
             if (std::find(selected.public_names.begin(), selected.public_names.end(), field._field) !=
-                selected.public_names.end()) {
+                selected.public_names.end())
+            {
                 continue;
             }
             if (!rank_setup.has_sort_feature(field._field)) {
@@ -396,7 +397,11 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
 
         const bool ordered_hits_needed = (params.hits != 0) || !groupingContext.empty();
         if (!selected_sort.public_names.empty() && ordered_hits_needed) {
-            mtf->prepare_and_install_sort_features(selected_sort.public_names);
+            if (!mtf->prepare_and_install_sort_features(selected_sort.public_names)) {
+                Issue::report("sort spec '%s': rank feature sort values are unavailable; failing the query",
+                              request.sortSpec.c_str());
+                return reply;
+            }
             if (mtf->get_request_context().getDoom().soft_doom()) {
                 reply->coverage.degradeTimeout();
                 vespalib::Issue::report("Search request soft doomed during query setup and initialization.");
@@ -425,15 +430,27 @@ SearchReply::UP Matcher::match(const SearchRequest& request, vespalib::ThreadBun
             master.match(request.trace(), params, limitedThreadBundle, *mtf, rp, _distributionKey, numParts);
         my_stats = MatchMaster::getStats(std::move(master));
         my_stats.add_query_setup_stats(setup_stats);
-        reply = std::move(result->_reply);
-        updateCoverage(reply->coverage, mtf->match_limiter(), my_stats, metaStore, bucketdb);
+        // Sorting on a rank feature whose values turned out to be unavailable cannot
+        // be silently downgraded to another order; fail the query closed instead.
+        const bool sort_feature_failed = rp.sort_feature_failed();
+        if (sort_feature_failed) {
+            Issue::report("sort spec '%s': rank feature sort values were not available; failing the query",
+                          request.sortSpec.c_str());
+            reply = std::make_unique<SearchReply>();
+            initCoverage(reply->coverage, metaStore, bucketdb);
+        } else {
+            reply = std::move(result->_reply);
+            updateCoverage(reply->coverage, mtf->match_limiter(), my_stats, metaStore, bucketdb);
+        }
 
         LOG(debug,
             "numThreadsPerSearch = %zu. Configured = %d, estimated hits=%d, totalHits=%" PRIu64 ", rankprofile=%s",
             numThreadsPerSearch, _rankSetup->getNumThreadsPerSearch(), mtf->estimate().estHits, reply->totalHitCount,
             request.ranking.c_str());
 
-        if (shouldCacheSearchSession && ((result->_numFs4Hits != 0) || shouldCacheGroupingSession)) {
+        if (!sort_feature_failed && shouldCacheSearchSession &&
+            ((result->_numFs4Hits != 0) || shouldCacheGroupingSession))
+        {
             auto session = std::make_shared<SearchSession>(sessionId, request.getStartTime(), request.getTimeOfDoom(),
                                                            std::move(mtf), std::move(owned_objects));
             session->releaseEnumGuards();

--- a/searchcore/src/vespa/searchcore/proton/matching/result_processor.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/result_processor.cpp
@@ -28,14 +28,21 @@ ResultProcessor::Result::Result(std::unique_ptr<search::engine::SearchReply> rep
 ResultProcessor::Result::~Result() = default;
 
 ResultProcessor::Sort::Sort(uint32_t partitionId, const vespalib::Doom& doom, IAttributeContext& ac,
-                            const std::string& ss)
+                            const std::string& ss, INumericSortValueProvider* sort_value_provider)
     : sorter(FastS_DefaultResultSorter::instance()),
       _ucaFactory(std::make_unique<search::uca::UcaConverterFactory>()),
-      sortSpec(DocumentMetaStoreAttribute::getFixedName(), partitionId, doom, *_ucaFactory) {
+      sortSpec(DocumentMetaStoreAttribute::getFixedName(), partitionId, doom, *_ucaFactory),
+      _feature_binding_failed(false) {
     if (!ss.empty() && sortSpec.Init(ss.c_str(), ac)) {
-        sorter = &sortSpec;
+        if (sortSpec.bind_numeric_provider(sort_value_provider)) {
+            sorter = &sortSpec;
+        } else {
+            _feature_binding_failed = true;
+        }
     }
 }
+
+ResultProcessor::Sort::~Sort() = default;
 
 ResultProcessor::Context::Context(const search::BitVector& validLids, Sort::UP s, PartialResultUP r,
                                   GroupingContext::UP g)
@@ -69,7 +76,8 @@ ResultProcessor::ResultProcessor(IAttributeContext& attrContext, const search::I
       _sortSpec(sortSpec),
       _offset(offset),
       _hits(hits),
-      _wasMerged(false) {
+      _wasMerged(false),
+      _sort_feature_failed(false) {
     if (!_groupingContext.empty()) {
         _groupingSession = std::make_unique<GroupingSession>(sessionId, _groupingContext, attrContext, nullptr);
     }
@@ -87,8 +95,12 @@ void ResultProcessor::prepareThreadContextCreation(size_t num_threads) {
 }
 
 std::unique_ptr<ResultProcessor::Context>
-ResultProcessor::createThreadContext(const vespalib::Doom& hardDoom, size_t thread_id, uint32_t distributionKey) {
-    auto sort = std::make_unique<Sort>(distributionKey, hardDoom, _attrContext, _sortSpec);
+ResultProcessor::createThreadContext(const vespalib::Doom& hardDoom, size_t thread_id, uint32_t distributionKey,
+                                     INumericSortValueProvider* sort_value_provider) {
+    auto sort = std::make_unique<Sort>(distributionKey, hardDoom, _attrContext, _sortSpec, sort_value_provider);
+    if (sort->feature_binding_failed()) {
+        note_sort_feature_failure();
+    }
     auto result = std::make_unique<PartialResult>((_offset + _hits), sort->hasSortData());
     search::grouping::GroupingContext::UP groupingContext;
     if (_groupingSession) {

--- a/searchcore/src/vespa/searchcore/proton/matching/result_processor.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/result_processor.h
@@ -5,6 +5,8 @@
 #include <vespa/searchlib/common/sortresults.h>
 #include <vespa/vespalib/util/dual_merge_director.h>
 
+#include <atomic>
+
 namespace search {
 namespace engine {
 class SearchReply;
@@ -40,8 +42,20 @@ public:
         FastS_SortSpec                                    sortSpec;
         Sort(const Sort&) = delete;
         Sort& operator=(const Sort&) = delete;
-        Sort(uint32_t partitionId, const vespalib::Doom& doom, IAttributeContext& ac, const std::string& ss);
+        /**
+         * The sort value provider is only needed when the sort spec sorts on
+         * rank features. If it cannot supply all the features named by the
+         * sort spec, feature_binding_failed is set; the hits cannot be ordered
+         * as requested and the query must fail.
+         **/
+        Sort(uint32_t partitionId, const vespalib::Doom& doom, IAttributeContext& ac, const std::string& ss,
+             INumericSortValueProvider* sort_value_provider);
+        ~Sort();
         bool hasSortData() const noexcept { return (sorter == (const FastS_IResultSorter*)&sortSpec); }
+        bool feature_binding_failed() const noexcept { return _feature_binding_failed; }
+
+    private:
+        bool _feature_binding_failed;
     };
 
     /**
@@ -88,6 +102,7 @@ private:
     size_t                            _offset;
     size_t                            _hits;
     bool                              _wasMerged;
+    std::atomic<bool>                 _sort_feature_failed;
 
 public:
     ResultProcessor(IAttributeContext& attrContext, const search::IDocumentMetaStore& metaStore,
@@ -97,9 +112,23 @@ public:
 
     void prepareThreadContextCreation(size_t num_threads);
     std::unique_ptr<Context> createThreadContext(const vespalib::Doom& hardDoom, size_t thread_id,
-                                                 uint32_t distributionKey);
+                                                 uint32_t                   distributionKey,
+                                                 INumericSortValueProvider* sort_value_provider);
     std::vector<std::pair<uint32_t, uint32_t>> extract_docid_ordering(const PartialResult& result) const;
     std::unique_ptr<Result> makeReply(PartialResultUP full_result);
+
+    /**
+     * Records that a thread could not order its hits by the requested rank
+     * features, either because binding failed or because the sort values of
+     * some hit were missing while the sort blobs were encoded.
+     **/
+    void note_sort_feature_failure() noexcept { _sort_feature_failed.store(true, std::memory_order_relaxed); }
+
+    /**
+     * True if any thread's sort spec named a rank feature whose sort values
+     * were not available. Only meaningful once all match threads are done.
+     **/
+    bool sort_feature_failed() const noexcept { return _sort_feature_failed.load(std::memory_order_relaxed); }
 };
 
 } // namespace proton::matching

--- a/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.cpp
@@ -2,10 +2,15 @@
 
 #include "sort_feature_store.h"
 
+#include <vespa/vespalib/util/issue.h>
+
 #include <algorithm>
+#include <cassert>
 #include <cmath>
-#include <cstdlib>
 #include <numeric>
+
+#include <vespa/log/log.h>
+LOG_SETUP(".proton.matching.sort_feature_store");
 
 namespace proton::matching {
 
@@ -16,6 +21,17 @@ double sanitize(double value) {
         return -HUGE_VAL;
     }
     return value;
+}
+
+// Ordinals are the indexes into the public name list; ordinal() returns the
+// first match, so a duplicate name would leave a column unreachable.
+[[maybe_unused]] bool no_duplicates(const std::vector<std::string>& names) {
+    for (size_t i = 1; i < names.size(); ++i) {
+        if (std::find(names.begin(), names.begin() + i, names[i]) != names.begin() + i) {
+            return false;
+        }
+    }
+    return true;
 }
 
 } // namespace
@@ -33,12 +49,14 @@ SortFeatureStore::SortFeatureStore(std::vector<std::string> public_names)
       _public_names(std::move(public_names)),
       _chunks(),
       _read_order() {
+    assert(no_duplicates(_public_names));
 }
 
+SortFeatureStore::~SortFeatureStore() = default;
+
 void SortFeatureStore::record(uint32_t docid, std::span<const double> values) {
-    if (_phase != Phase::recording || values.size() != _num_features) {
-        abort();
-    }
+    assert(_phase == Phase::recording);
+    assert(values.size() == _num_features);
     if (_rows > 0 && docid < _last_docid) {
         _recorded_in_docid_order = false;
     }
@@ -61,6 +79,11 @@ void SortFeatureStore::record(uint32_t docid, std::span<const double> values) {
 
 void SortFeatureStore::ensure_sorted_for_read() {
     if (_phase != Phase::recording) {
+        if (_phase != Phase::reading) {
+            // Re-preparing while already reading is idempotent; any other
+            // phase means the caller has the lifecycle wrong.
+            LOG(warning, "ensure_sorted_for_read() called, but _phase=%s", current_phase());
+        }
         return;
     }
     _phase = Phase::reading;
@@ -98,13 +121,46 @@ const double* SortFeatureStore::row_values(uint32_t row) const {
     return _chunks[chunk_idx]->values.data() + static_cast<size_t>(local) * _num_features;
 }
 
+void SortFeatureStore::fail(const char* reason, uint32_t docid) {
+    if (failed()) {
+        return;
+    }
+    _phase = Phase::failed;
+    _seek_row = ~0u;
+    LOG(warning, "error [%s] in sort feature store (docid=%u)", reason, docid);
+    vespalib::Issue::report("sort feature store: %s (docid %u); failing the query", reason, docid);
+}
+
+const char* SortFeatureStore::current_phase() const noexcept {
+    switch (_phase) {
+    case Phase::recording:
+        return "recording";
+    case Phase::reading:
+        return "reading";
+    case Phase::consumed:
+        return "consumed";
+    case Phase::failed:
+        return "failed";
+    }
+    return "<unknown>";
+}
+
 void SortFeatureStore::seek(uint32_t docid) {
+    if (failed()) {
+        return;
+    }
+    if (_phase == Phase::consumed) {
+        fail("sort values already released", docid);
+        return;
+    }
     if (_phase != Phase::reading) {
-        abort();
+        fail("sort values were not prepared for reading", docid);
+        return;
     }
     if (_bound) {
         if (docid < _bound_docid) {
-            abort();
+            fail("hits are not in non-decreasing docid order", docid);
+            return;
         }
         if (docid == _bound_docid) {
             return;
@@ -113,31 +169,44 @@ void SortFeatureStore::seek(uint32_t docid) {
     while (_consume_pos < _rows) {
         uint32_t row = ordered_row(_consume_pos);
         uint32_t stored = row_docid(row);
-        if (stored >= docid) {
-            if (stored != docid) {
-                abort();
-            }
+        if (stored == docid) {
             _seek_row = row;
             _bound_docid = docid;
             _bound = true;
             ++_consume_pos;
             return;
         }
-        ++_consume_pos;
+        if (stored < docid) [[likely]] {
+            ++_consume_pos;
+        } else {
+            fail("no sort values were recorded for this hit", docid);
+            return;
+        }
     }
-    abort();
+    fail("ran out of recorded sort values", docid);
 }
 
 double SortFeatureStore::get(uint32_t ordinal) const {
-    if (_seek_row == ~0u || ordinal >= _num_features) {
-        abort();
+    if (failed() || _seek_row == ~0u) {
+        // The caller fails the query on failed(), so this value is never presented.
+        return -HUGE_VAL;
     }
+    assert(ordinal < _num_features);
     return row_values(_seek_row)[ordinal];
 }
 
 void SortFeatureStore::consumed() {
     if (_phase == Phase::consumed) {
         return;
+    }
+    if (failed()) {
+        // Keep the failed phase, so the caller still sees failed() and fails
+        // the query, but release the storage as any other consumed() does.
+        clear_storage();
+        return;
+    }
+    if (_phase != Phase::reading) {
+        LOG(warning, "consumed() called, but _phase=%s", current_phase());
     }
     _phase = Phase::consumed;
     clear_storage();

--- a/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/sort_feature_store.h
@@ -29,7 +29,7 @@ namespace proton::matching {
 class SortFeatureStore : public INumericSortValueProvider {
 public:
     SortFeatureStore(std::vector<std::string> public_names);
-    ~SortFeatureStore() override = default;
+    ~SortFeatureStore() override;
 
     uint32_t num_features() const noexcept { return _num_features; }
     uint32_t num_rows() const noexcept { return _rows; }
@@ -40,10 +40,11 @@ public:
     uint32_t ordinal(std::string_view public_name) const override;
     void seek(uint32_t docid) override;
     double get(uint32_t ordinal) const override;
+    bool failed() const noexcept override { return _phase == Phase::failed; }
     void consumed() override;
 
 private:
-    enum class Phase { recording, reading, consumed };
+    enum class Phase { recording, reading, consumed, failed };
 
     static constexpr uint32_t chunk_rows = 1024;
 
@@ -57,6 +58,8 @@ private:
     uint32_t row_docid(uint32_t row) const;
     const double* row_values(uint32_t row) const;
     void clear_storage();
+    void fail(const char* reason, uint32_t docid);
+    const char* current_phase() const noexcept;
 
     uint32_t                            _num_features;
     uint32_t                            _rows;

--- a/searchlib/src/tests/ranksetup/ranksetup_test.cpp
+++ b/searchlib/src/tests/ranksetup/ranksetup_test.cpp
@@ -1046,12 +1046,37 @@ TEST_F(RankSetupTest, sort_features_prepare_only_selected_public_names) {
     EXPECT_TRUE(rs.has_sort_feature("countprepare"));
     EXPECT_TRUE(rs.has_sort_feature("value(2)"));
     QueryEnvironment queryEnv;
-    rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"value(2)"});
+    EXPECT_TRUE(rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"value(2)"}));
     EXPECT_EQ(0, CountPrepareBlueprint::prepares);
-    rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"countprepare"});
+    EXPECT_TRUE(rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"countprepare"}));
     EXPECT_EQ(1, CountPrepareBlueprint::prepares);
-    rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"countprepare", "countprepare"});
+    EXPECT_TRUE(rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"countprepare", "countprepare"}));
     EXPECT_EQ(2, CountPrepareBlueprint::prepares);
+}
+
+TEST_F(RankSetupTest, an_unknown_sort_feature_is_reported_rather_than_fatal) {
+    RankSetup rs(_factory, _indexEnv);
+    rs.setFirstPhaseRank("value(1)");
+    rs.add_sort_feature("value(2)");
+    ASSERT_TRUE(rs.compile());
+    EXPECT_FALSE(rs.has_sort_feature("value(3)"));
+
+    // A name that was never added as a sort feature, and one that exists as a
+    // rank feature but was not selected for sorting.
+    EXPECT_FALSE(rs.create_sort_program("value(3)"));
+    EXPECT_FALSE(rs.create_sort_program("value(1)"));
+
+    QueryEnvironment queryEnv;
+    EXPECT_FALSE(rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"value(3)"}));
+    EXPECT_FALSE(rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {"value(2)", "value(3)"}));
+}
+
+TEST_F(RankSetupTest, preparing_no_sort_features_succeeds) {
+    RankSetup rs(_factory, _indexEnv);
+    rs.setFirstPhaseRank("value(1)");
+    ASSERT_TRUE(rs.compile());
+    QueryEnvironment queryEnv;
+    EXPECT_TRUE(rs.prepare_sort_shared_state(queryEnv, queryEnv.getObjectStore(), {}));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/sortspec/multilevelsort_test.cpp
+++ b/searchlib/src/tests/sortspec/multilevelsort_test.cpp
@@ -502,6 +502,8 @@ public:
         }
         return _by_docid[_bound_docid][ord];
     }
+    void set_failed() { _failed = true; }
+    bool failed() const noexcept override { return _failed; }
     void consumed() override { ++_consumed; }
 
 private:
@@ -513,6 +515,7 @@ private:
     uint32_t                         _bound_docid = 0;
     bool                             _bound = false;
     bool                             _started = false;
+    bool                             _failed = false;
 };
 
 TEST(SortTest, feature_sort_binds_provider_and_seeks_each_hit_once) {
@@ -530,7 +533,7 @@ TEST(SortTest, feature_sort_binds_provider_and_seeks_each_hit_once) {
     by_docid[3] = {2.0, 10.0};
     by_docid[4] = {2.0, 10.0};
     FakeNumericSortProvider provider({"pri", "sec"}, std::move(by_docid));
-    sorter.bind_numeric_provider(provider);
+    ASSERT_TRUE(sorter.bind_numeric_provider(&provider));
 
     RankedHit hits[4] = {RankedHit(1, 0.0), RankedHit(2, 0.0), RankedHit(3, 0.0), RankedHit(4, 0.0)};
     sorter.sortResults(hits, 4, 4);
@@ -540,6 +543,107 @@ TEST(SortTest, feature_sort_binds_provider_and_seeks_each_hit_once) {
     EXPECT_EQ(4u, hits[3].getDocId());
     EXPECT_EQ(4u, provider.seek_count());
     EXPECT_EQ(1u, provider.consumed_count());
+}
+
+TEST(SortTest, binding_fails_when_a_sort_feature_is_not_available) {
+    search::uca::UcaConverterFactory ucaFactory;
+    search::AttributeManager         mgr;
+    search::AttributeContext         ac(mgr);
+    FastS_SortSpec                   sorter("no-metastore", 7, vespalib::Doom::never(), ucaFactory);
+    ASSERT_TRUE(sorter.Init("+feature(pri) -feature(gone)", ac));
+
+    FakeNumericSortProvider provider({"pri"}, std::vector<std::vector<double>>(5));
+    EXPECT_FALSE(sorter.bind_numeric_provider(&provider));
+    EXPECT_TRUE(sorter.feature_values_failed());
+}
+
+TEST(SortTest, binding_fails_when_a_sort_feature_has_no_provider) {
+    search::uca::UcaConverterFactory ucaFactory;
+    search::AttributeManager         mgr;
+    search::AttributeContext         ac(mgr);
+    FastS_SortSpec                   sorter("no-metastore", 7, vespalib::Doom::never(), ucaFactory);
+    ASSERT_TRUE(sorter.Init("+feature(pri)", ac));
+
+    EXPECT_FALSE(sorter.bind_numeric_provider(nullptr));
+    EXPECT_TRUE(sorter.feature_values_failed());
+}
+
+TEST(SortTest, a_provider_that_runs_out_of_sort_values_fails_the_sort) {
+    search::uca::UcaConverterFactory ucaFactory;
+    search::AttributeManager         mgr;
+    search::AttributeContext         ac(mgr);
+    FastS_SortSpec                   sorter("no-metastore", 7, vespalib::Doom::never(), ucaFactory);
+    ASSERT_TRUE(sorter.Init("+feature(pri)", ac));
+
+    std::vector<std::vector<double>> by_docid(3);
+    by_docid[1] = {1.0};
+    by_docid[2] = {2.0};
+    FakeNumericSortProvider provider({"pri"}, std::move(by_docid));
+    ASSERT_TRUE(sorter.bind_numeric_provider(&provider));
+    EXPECT_FALSE(sorter.feature_values_failed());
+
+    provider.set_failed();
+    RankedHit hits[2] = {RankedHit(1, 0.0), RankedHit(2, 0.0)};
+    sorter.sortResults(hits, 2, 2);
+    // The blobs were encoded and consumed, but the order cannot be trusted.
+    EXPECT_TRUE(sorter.feature_values_failed());
+    EXPECT_EQ(1u, provider.consumed_count());
+}
+
+TEST(SortTest, a_successful_feature_sort_is_not_a_value_failure) {
+    search::uca::UcaConverterFactory ucaFactory;
+    search::AttributeManager         mgr;
+    search::AttributeContext         ac(mgr);
+    FastS_SortSpec                   sorter("no-metastore", 7, vespalib::Doom::never(), ucaFactory);
+    ASSERT_TRUE(sorter.Init("+feature(pri)", ac));
+
+    std::vector<std::vector<double>> by_docid(3);
+    by_docid[1] = {2.0};
+    by_docid[2] = {1.0};
+    FakeNumericSortProvider provider({"pri"}, std::move(by_docid));
+    ASSERT_TRUE(sorter.bind_numeric_provider(&provider));
+
+    RankedHit hits[2] = {RankedHit(1, 0.0), RankedHit(2, 0.0)};
+    sorter.sortResults(hits, 2, 2);
+    EXPECT_EQ(2u, hits[0].getDocId());
+    EXPECT_EQ(1u, hits[1].getDocId());
+    EXPECT_FALSE(sorter.feature_values_failed());
+}
+
+TEST(SortTest, sorting_twice_on_a_feature_fails_rather_than_reusing_consumed_values) {
+    search::uca::UcaConverterFactory ucaFactory;
+    search::AttributeManager         mgr;
+    search::AttributeContext         ac(mgr);
+    FastS_SortSpec                   sorter("no-metastore", 7, vespalib::Doom::never(), ucaFactory);
+    ASSERT_TRUE(sorter.Init("+feature(pri)", ac));
+
+    std::vector<std::vector<double>> by_docid(3);
+    by_docid[1] = {2.0};
+    by_docid[2] = {1.0};
+    FakeNumericSortProvider provider({"pri"}, std::move(by_docid));
+    ASSERT_TRUE(sorter.bind_numeric_provider(&provider));
+
+    RankedHit hits[2] = {RankedHit(1, 0.0), RankedHit(2, 0.0)};
+    sorter.sortResults(hits, 2, 2);
+    ASSERT_FALSE(sorter.feature_values_failed());
+    EXPECT_EQ(1u, provider.consumed_count());
+
+    // The values were released by the first sort; a second one has nothing to
+    // encode and must not be presented as ordered by the feature.
+    sorter.sortResults(hits, 2, 2);
+    EXPECT_TRUE(sorter.feature_values_failed());
+    EXPECT_EQ(1u, provider.consumed_count());
+}
+
+TEST(SortTest, binding_a_null_provider_is_ok_without_sort_features) {
+    search::uca::UcaConverterFactory ucaFactory;
+    search::AttributeManager         mgr;
+    search::AttributeContext         ac(mgr);
+    FastS_SortSpec                   sorter("no-metastore", 7, vespalib::Doom::never(), ucaFactory);
+    ASSERT_TRUE(sorter.Init("+[rank] -[docid]", ac));
+
+    EXPECT_TRUE(sorter.bind_numeric_provider(nullptr));
+    EXPECT_FALSE(sorter.feature_values_failed());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/common/sortresults.cpp
+++ b/searchlib/src/vespa/searchlib/common/sortresults.cpp
@@ -10,6 +10,9 @@
 #include <vespa/vespalib/util/array.h>
 #include <vespa/vespalib/util/issue.h>
 
+#include <cassert>
+#include <cmath>
+
 using vespalib::Issue;
 
 #include <vespa/log/log.h>
@@ -243,12 +246,18 @@ void FastS_SortSpec::initSortData(const RankedHit* hits, uint32_t n) {
     _binarySortData.resize((fixedWidth + variableWidth) * n);
     _sortDataArray.resize(n);
 
+    // Feature levels need a provider bound by bind_numeric_provider() and not
+    // yet consumed by an earlier sort. Without one the levels encode as a
+    // placeholder and the query must be failed.
+    const bool seek_features = has_feature && (_numeric_provider != nullptr);
+    if (has_feature && !seek_features) {
+        Issue::report("sort spec: no sort values available for the rank feature sort levels");
+        _feature_values_failed = true;
+    }
+
     size_t offset = 0;
     for (uint32_t i(0), idx(0); (i < n) && !_doom.hard_doom(); ++i) {
-        if (has_feature) {
-            if (_numeric_provider == nullptr) {
-                abort();
-            }
+        if (seek_features) {
             _numeric_provider->seek(hits[i].getDocId());
         }
         uint32_t len = 0;
@@ -266,9 +275,20 @@ void FastS_SortSpec::initSortData(const RankedHit* hits, uint32_t n) {
         idx += len;
     }
     if (_numeric_provider != nullptr) {
+        // A provider that ran out of sort values leaves the encoded blobs
+        // ordered by a placeholder; remember it so the query can be failed.
+        if (_numeric_provider->failed()) {
+            _feature_values_failed = true;
+        }
         _numeric_provider->consumed();
         _numeric_provider = nullptr;
     }
+}
+
+double FastS_SortSpec::feature_value(uint32_t ordinal) const {
+    // A missing provider is recorded as a failure by the caller; encode a
+    // placeholder so the blob layout stays as the widths were computed.
+    return (_numeric_provider != nullptr) ? _numeric_provider->get(ordinal) : -HUGE_VAL;
 }
 
 int FastS_SortSpec::initSortData(const VectorRef& vec, const RankedHit& hit, size_t offset) {
@@ -312,12 +332,12 @@ int FastS_SortSpec::initSortData(const VectorRef& vec, const RankedHit& hit, siz
             written = serializeForSort<convertForSort<search::HitRank, false>>(hit.getRank(), mySortData, available);
             break;
         case ASC_FEATURE:
-            written = serializeForSort<convertForSort<double, true>>(_numeric_provider->get(vec._feature_ordinal),
-                                                                     mySortData, available);
+            written = serializeForSort<convertForSort<double, true>>(feature_value(vec._feature_ordinal), mySortData,
+                                                                     available);
             break;
         case DESC_FEATURE:
-            written = serializeForSort<convertForSort<double, false>>(_numeric_provider->get(vec._feature_ordinal),
-                                                                      mySortData, available);
+            written = serializeForSort<convertForSort<double, false>>(feature_value(vec._feature_ordinal), mySortData,
+                                                                      available);
             break;
         case ASC_VECTOR:
             written = vec._writer->write(hit.getDocId(), mySortData, available);
@@ -341,25 +361,31 @@ FastS_SortSpec::FastS_SortSpec(std::string_view documentmetastore, uint32_t part
       _ucaFactory(ucaFactory),
       _sortSpec(),
       _vectors(),
-      _numeric_provider(nullptr) {
+      _numeric_provider(nullptr),
+      _feature_values_failed(false) {
 }
 
-void FastS_SortSpec::bind_numeric_provider(INumericSortValueProvider& provider) {
-    _numeric_provider = &provider;
+bool FastS_SortSpec::bind_numeric_provider(INumericSortValueProvider* provider) {
+    _numeric_provider = provider;
     auto spec = _sortSpec.begin();
     for (auto& vec : _vectors) {
-        if (spec == _sortSpec.end()) {
-            abort();
-        }
+        assert(spec != _sortSpec.end());
         if (spec->_is_rank_feature) {
-            uint32_t ordinal = provider.ordinal(spec->_field);
+            uint32_t ordinal =
+                (provider != nullptr) ? provider->ordinal(spec->_field) : INumericSortValueProvider::invalid_ordinal;
             if (ordinal == INumericSortValueProvider::invalid_ordinal) {
-                abort();
+                Issue::report("sort spec: no sort value available for rank feature '%s'", spec->_field.c_str());
+                _numeric_provider = nullptr;
+                // Leave the object unusable for sorting even if the caller ignores
+                // the return value and sorts anyway.
+                _feature_values_failed = true;
+                return false;
             }
             vec._feature_ordinal = ordinal;
         }
         ++spec;
     }
+    return true;
 }
 
 FastS_SortSpec::~FastS_SortSpec() {

--- a/searchlib/src/vespa/searchlib/common/sortresults.h
+++ b/searchlib/src/vespa/searchlib/common/sortresults.h
@@ -65,6 +65,12 @@ public:
  * encoding, seek() is called once per hit in non-decreasing docid order;
  * get() reads the row bound by the most recent seek(). consumed() ends the
  * binding and permits the provider to release its storage.
+ *
+ * A provider that cannot honour a seek() records the fact and keeps going,
+ * returning placeholder values from get(); failed() then stays true for the
+ * rest of the encoding. The resulting sort blobs are meaningless, so the
+ * caller must fail the query rather than present the hits in some other
+ * order. Check failed() after encoding, before consumed().
  */
 class INumericSortValueProvider {
 public:
@@ -73,6 +79,7 @@ public:
     virtual uint32_t ordinal(std::string_view public_name) const = 0;
     virtual void seek(uint32_t docid) = 0;
     virtual double get(uint32_t ordinal) const = 0;
+    virtual bool failed() const noexcept = 0;
     virtual void consumed() = 0;
 };
 
@@ -126,8 +133,10 @@ private:
     BinarySortData             _binarySortData;
     SortDataArray              _sortDataArray;
     INumericSortValueProvider* _numeric_provider;
+    bool                       _feature_values_failed;
 
     bool Add(search::attribute::IAttributeContext& vecMan, const search::common::FieldSortSpec& field_sort_spec);
+    double feature_value(uint32_t ordinal) const;
     void initSortData(const search::RankedHit* a, uint32_t n);
     int initSortData(const VectorRef& vec, const search::RankedHit& hit, size_t offset);
 
@@ -147,7 +156,25 @@ public:
     void copySortData(uint32_t offset, uint32_t n, uint32_t* idx, char* buf);
     void freeSortData();
     void initWithoutSorting(const search::RankedHit* hits, uint32_t hitCnt);
-    void bind_numeric_provider(INumericSortValueProvider& provider);
+
+    /**
+     * Resolves the feature ordinals of the rank feature sort levels, if any.
+     * The provider may be null; it is only required when the sort spec has
+     * rank feature levels. Returns false (leaving this object unbound and
+     * unusable for sorting) if a rank feature level has no sort value
+     * available. The caller cannot order the hits as requested and is expected
+     * to fail the query rather than to sort them some other way.
+     **/
+    [[nodiscard]] bool bind_numeric_provider(INumericSortValueProvider* provider);
+
+    /**
+     * True if a rank feature sort level could not be bound, or if the bound
+     * provider could not supply the sort values of every hit while the sort
+     * blobs were encoded. The encoded blobs order the hits by a placeholder
+     * value rather than by the requested rank features, so the caller is
+     * expected to fail the query.
+     **/
+    [[nodiscard]] bool feature_values_failed() const noexcept { return _feature_values_failed; }
 };
 
 //-----------------------------------------------------------------------------

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
@@ -8,10 +8,10 @@
 #include "indexproperties.h"
 
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 #include <algorithm>
-#include <cstdlib>
 
 using vespalib::make_string_short::fmt;
 
@@ -310,19 +310,21 @@ void RankSetup::prepareSharedState(const IQueryEnvironment& queryEnv, IObjectSto
 RankProgram::UP RankSetup::create_sort_program(const std::string& public_name) const {
     auto it = _sort_resolver_by_public.find(public_name);
     if (it == _sort_resolver_by_public.end() || !it->second) {
-        abort();
+        vespalib::Issue::report("'%s' is not an allowed sort feature", public_name.c_str());
+        return {};
     }
     return std::make_unique<RankProgram>(it->second);
 }
 
-void RankSetup::prepare_sort_shared_state(const IQueryEnvironment& queryEnv, IObjectStore& objectStore,
+bool RankSetup::prepare_sort_shared_state(const IQueryEnvironment& queryEnv, IObjectStore& objectStore,
                                           const std::vector<std::string>& selected_public_names) const {
     assert(_compiled && !_compileError);
     std::vector<const BlueprintResolver*> prepared;
     for (const auto& public_name : selected_public_names) {
         auto it = _sort_resolver_by_public.find(public_name);
         if (it == _sort_resolver_by_public.end() || !it->second) {
-            abort();
+            vespalib::Issue::report("'%s' is not an allowed sort feature", public_name.c_str());
+            return false;
         }
         const BlueprintResolver* resolver = it->second.get();
         if (std::find(prepared.begin(), prepared.end(), resolver) != prepared.end()) {
@@ -333,6 +335,7 @@ void RankSetup::prepare_sort_shared_state(const IQueryEnvironment& queryEnv, IOb
             spec.blueprint->prepareSharedState(queryEnv, objectStore);
         }
     }
+    return true;
 }
 
 std::string RankSetup::getJoinedWarnings() const {

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.h
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.h
@@ -465,13 +465,22 @@ public:
     bool has_sort_feature(const std::string& public_name) const {
         return _sort_resolver_by_public.contains(public_name);
     }
+
+    /**
+     * Creates the program evaluating the named sort feature. Returns nullptr if
+     * the name is not an allowed sort feature; callers reaching this with a name
+     * they have not checked with has_sort_feature() must fail the query rather
+     * than order the hits some other way.
+     **/
     RankProgram::UP create_sort_program(const std::string& public_name) const;
 
     /**
      * Prepare shared state only for the unique resolvers selected by public name.
+     * Returns false, having prepared nothing further, if one of the names is not
+     * an allowed sort feature.
      **/
-    void prepare_sort_shared_state(const IQueryEnvironment& queryEnv, IObjectStore& objectStore,
-                                   const std::vector<std::string>& selected_public_names) const;
+    [[nodiscard]] bool prepare_sort_shared_state(const IQueryEnvironment& queryEnv, IObjectStore& objectStore,
+                                                 const std::vector<std::string>& selected_public_names) const;
 
     /**
      * Here you can do some preprocessing. State must be stored in the IObjectStore.


### PR DESCRIPTION
Sorting on a rank feature had no failure path: an unknown sort feature, a sort level that could not be bound to its recorded values, a hit whose values were never recorded, or a sort spec sorted twice all ended in abort() or in an enabled assert(), so one malformed query took down proton. Ignoring the errors is no better, since the sort blobs would then order hits by something other than what was asked for. So fail the query closed instead, along one channel from where the problem is noticed up to Matcher::match():

 - create_sort_program() returns nullptr and prepare_sort_shared_state() returns false for a name that is not an allowed sort feature.
 - bind_numeric_provider() takes a nullable provider and returns false, reporting an issue, when a rank feature sort level has no sort values. ResultProcessor::Sort binds where it decides whether to install the sort spec as sorter, keeping hasSortData() and PartialResult consistent.
 - SortFeatureStore::seek() marks itself failed instead of aborting when the recorded rows cannot satisfy a seek; get() then yields a placeholder so blob encoding still completes. The new failed() reaches MatchThread via FastS_SortSpec::feature_values_failed().
 - Matcher::match() fails the query -- no hits, no coverage, no cached session -- if any match thread saw either kind of failure, as already happens for a sort spec naming an unknown feature.

Asserts remain only for invariants internal to the store: row arity comes from num_features(), ordinals are validated by bind_numeric_provider(), and the public name list has no duplicates.

Two bugs found on the way: initSortData() releases the provider on its way out, so sorting twice aborted; and seek() asserted the reading phase in front of its own graceful handling of a released store, making that branch dead whenever assertions are on.

Also while here: SortFeatureStore's _failed flag becomes a fourth Phase, since nothing kept the two in sync and failure is terminal (consumed() keeps the failed phase but releases the rows); fail() and out-of-phase calls now log a warning, not just a query Issue; the seek() scan is flattened to put the exact-docid match first; MatchThread::run() decides in one place whether to release the store or move it to the read phase; and MatchThread::Context, ResultProcessor::Sort and SortFeatureStore get out-of-line destructors, which gcc declines to inline, tripping -Winline.
