### PR TITLE
Serialize StringRangeTerm in the legacy query stack dump format

### DIFF
--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -878,7 +878,28 @@ TEST(QueryBuilderTest, string_range_node_survives_protobuf_round_trip) {
         auto            serialized_query_tree =
             SerializedQueryTree::fromProtobuf(std::make_unique<decltype(proto_query_tree)>(proto_query_tree));
 
+        // via ProtoTreeConverter
         auto new_node = serialized_query_tree->apply(QueryTreeCreator<SimpleQueryNodeTypes>());
+        EXPECT_TRUE(checkTerm(as_node<StringRangeTerm>(new_node.get()), expected, view[9], id[9], weight[9]));
+
+        // via ProtoTreeIterator -> StackDumpQueryCreator
+        auto iterator = serialized_query_tree->makeIterator();
+        new_node = QueryTreeCreator<SimpleQueryNodeTypes>::create(*iterator);
+        EXPECT_TRUE(checkTerm(as_node<StringRangeTerm>(new_node.get()), expected, view[9], id[9], weight[9]));
+    }
+}
+
+TEST(QueryBuilderTest, string_range_node_survives_stack_dump_round_trip) {
+    for (const auto& expected : string_ranges()) {
+        QueryBuilder<SimpleQueryNodeTypes> builder;
+        builder.add_string_range_term(expected, view[9], id[9], weight[9]);
+        Node::UP node = builder.build();
+
+        auto stackDump = StackDumpCreator::create(*node);
+        auto serializedQueryTree = SerializedQueryTree::fromStackDump(stackDump);
+        auto iterator = serializedQueryTree->makeIterator();
+
+        Node::UP new_node = QueryTreeCreator<SimpleQueryNodeTypes>::create(*iterator);
         EXPECT_TRUE(checkTerm(as_node<StringRangeTerm>(new_node.get()), expected, view[9], id[9], weight[9]));
     }
 }
@@ -911,7 +932,7 @@ TEST(QueryBuilderTest, require_that_empty_intermediate_node_can_be_added) {
 }
 
 TEST(QueryBuilderTest, control_size_of_SimpleQueryStackDumpIterator) {
-    EXPECT_EQ(192u, sizeof(SimpleQueryStackDumpIterator));
+    EXPECT_EQ(200u, sizeof(SimpleQueryStackDumpIterator));
 }
 
 TEST(QueryBuilderTest, test_query_parsing_error) {

--- a/searchlib/src/vespa/searchlib/parsequery/parse.h
+++ b/searchlib/src/vespa/searchlib/parsequery/parse.h
@@ -98,6 +98,17 @@ public:
         IFLAG_PREFIX_MATCH = 0x00000010
     };
 
+    /**
+     * Bits of the extra flag byte following the generic term header
+     * of an ITEM_STRING_RANGE_TERM item.
+     */
+    enum StringRangeTermFlags {
+        SRT_LEFT_UNBOUNDED = 0x01,
+        SRT_RIGHT_UNBOUNDED = 0x02,
+        SRT_LEFT_CLOSED = 0x04,
+        SRT_RIGHT_CLOSED = 0x08,
+    };
+
     /** Extra information on each item (creator id) coded in bit 3 of flags */
     static inline ItemCreator GetCreator(uint8_t flags) { return static_cast<ItemCreator>((flags >> 3) & 0x01); }
 

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
@@ -200,6 +200,10 @@ bool SimpleQueryStackDumpIterator::readNext() {
     case ParseItem::ITEM_NUMERIC_IN:
         read_numeric_in(p);
         break;
+    case ParseItem::ITEM_STRING_RANGE_TERM:
+        _d.index_view = read_string_view(p);
+        read_string_range_term(p);
+        break;
     default:
         // Unknown item, so report that no more are available
         return false;
@@ -281,6 +285,23 @@ void SimpleQueryStackDumpIterator::read_numeric_in(const char*& p) {
         terms->addTerm(read_value<int64_t>(p));
     }
     _d.termVector = std::move(terms);
+}
+
+void SimpleQueryStackDumpIterator::read_string_range_term(const char*& p) {
+    uint8_t flags = read_value<uint8_t>(p);
+    auto    spec = std::make_unique<StringRangeSpec>();
+    spec->left_unbounded = (flags & ParseItem::SRT_LEFT_UNBOUNDED) != 0;
+    spec->right_unbounded = (flags & ParseItem::SRT_RIGHT_UNBOUNDED) != 0;
+    spec->left_closed = (flags & ParseItem::SRT_LEFT_CLOSED) != 0;
+    spec->right_closed = (flags & ParseItem::SRT_RIGHT_CLOSED) != 0;
+    if (!spec->left_unbounded) {
+        spec->left = std::string(read_string_view(p));
+    }
+    if (!spec->right_unbounded) {
+        spec->right = std::string(read_string_view(p));
+    }
+    _d.stringRangeSpec = std::move(spec);
+    _d.arity = 0;
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
@@ -37,6 +37,7 @@ private:
     VESPA_DLL_LOCAL void readFuzzy(const char*& p);
     VESPA_DLL_LOCAL void read_string_in(const char*& p);
     VESPA_DLL_LOCAL void read_numeric_in(const char*& p);
+    VESPA_DLL_LOCAL void read_string_range_term(const char*& p);
     VESPA_DLL_LOCAL bool readNext();
 
 public:

--- a/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
@@ -285,10 +285,20 @@ bool handle(const ItemFloatingPointRangeTerm& item, QueryStackIterator::Data& _d
     return true;
 }
 bool handle(const ItemStringRangeTerm& item, QueryStackIterator::Data& _d) {
-    // The range itself is not exposed here, as the query stack is only used by consumers
-    // that do not support string ranges.
     fillTermProperties(item.properties(), _d);
     _d.itemType = ParseItem::ItemType::ITEM_STRING_RANGE_TERM;
+    auto spec = std::make_unique<StringRangeSpec>();
+    spec->left_unbounded = !item.has_lower_limit();
+    spec->right_unbounded = !item.has_upper_limit();
+    if (item.has_lower_limit()) {
+        spec->left = item.lower_limit();
+    }
+    if (item.has_upper_limit()) {
+        spec->right = item.upper_limit();
+    }
+    spec->left_closed = item.lower_inclusive();
+    spec->right_closed = item.upper_inclusive();
+    _d.stringRangeSpec = std::move(spec);
     return true;
 }
 

--- a/searchlib/src/vespa/searchlib/query/query_stack_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_stack_iterator.cpp
@@ -26,6 +26,9 @@ std::unique_ptr<query::PredicateQueryTerm> QueryStackIterator::getPredicateQuery
 std::unique_ptr<query::TermVector> QueryStackIterator::get_terms() {
     return std::move(_d.termVector);
 }
+std::unique_ptr<StringRangeSpec> QueryStackIterator::get_string_range_spec() {
+    return std::move(_d.stringRangeSpec);
+}
 
 std::string_view QueryStackIterator::DEFAULT_INDEX = "default";
 

--- a/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
+++ b/searchlib/src/vespa/searchlib/query/query_stack_iterator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <vespa/searchlib/parsequery/parse.h>
+#include <vespa/searchlib/query/string_range_spec.h>
 
 #include <memory>
 #include <string>
@@ -39,6 +40,7 @@ public:
 
         std::unique_ptr<query::PredicateQueryTerm> predicateQueryTerm;
         std::unique_ptr<query::TermVector>         termVector;
+        std::unique_ptr<StringRangeSpec>           stringRangeSpec;
 
         std::string_view index_view;
         std::string_view term_view;
@@ -107,6 +109,7 @@ public:
 
     std::unique_ptr<query::PredicateQueryTerm> getPredicateQueryTerm();
     std::unique_ptr<query::TermVector> get_terms();
+    std::unique_ptr<StringRangeSpec> get_string_range_spec();
 
     /** The index name (field name) in the current item */
     std::string_view index_as_view() const noexcept { return _d.index_view; }

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -10,7 +10,6 @@
 #include <vespa/searchlib/util/rawbuf.h>
 #include <vespa/vespalib/objects/nbo.h>
 #include <vespa/vespalib/stllike/asciistream.h>
-#include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/size_literals.h>
 
 #include <cassert>
@@ -254,9 +253,29 @@ class QueryNodeConverter : public QueryVisitor {
 
     void visit(RangeTerm& node) override { createTerm(node, ParseItem::ITEM_NUMTERM); }
 
-    void visit(StringRangeTerm&) override {
-        // The query stack dump is a legacy serialization that string ranges are not part of.
-        vespalib::Issue::report("string range terms cannot be serialized to a query stack dump");
+    void visit(StringRangeTerm& node) override {
+        createTermNode(node, ParseItem::ITEM_STRING_RANGE_TERM);
+        const auto* spec = node.getTerm().get_spec();
+        bool        left_unbounded = (spec == nullptr) || spec->left_unbounded;
+        bool        right_unbounded = (spec == nullptr) || spec->right_unbounded;
+        bool        left_closed = (spec == nullptr) || spec->left_closed;
+        bool        right_closed = (spec == nullptr) || spec->right_closed;
+        uint8_t     flags = 0;
+        if (left_unbounded)
+            flags |= ParseItem::SRT_LEFT_UNBOUNDED;
+        if (right_unbounded)
+            flags |= ParseItem::SRT_RIGHT_UNBOUNDED;
+        if (left_closed)
+            flags |= ParseItem::SRT_LEFT_CLOSED;
+        if (right_closed)
+            flags |= ParseItem::SRT_RIGHT_CLOSED;
+        appendByte(flags);
+        if (!left_unbounded) {
+            appendString(spec->left);
+        }
+        if (!right_unbounded) {
+            appendString(spec->right);
+        }
     }
 
     void visit(StringTerm& node) override { createTerm(node, ParseItem::ITEM_TERM); }

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
@@ -208,6 +208,8 @@ private:
                 t = &builder.add_in_term(queryStack.get_terms(), MultiTerm::Type::STRING, view, id, weight);
             } else if (type == ParseItem::ITEM_NUMERIC_IN) {
                 t = &builder.add_in_term(queryStack.get_terms(), MultiTerm::Type::INTEGER, view, id, weight);
+            } else if (type == ParseItem::ITEM_STRING_RANGE_TERM) {
+                t = &builder.add_string_range_term(StringRange(queryStack.get_string_range_spec()), view, id, weight);
             } else {
                 vespalib::Issue::report("query builder: Unable to create query tree from stack dump. node type = %d.",
                                         type);


### PR DESCRIPTION
StringRangeTerm already had full protobuf serialization, but the legacy binary query stack dump encoder refused to write it and the decoder had no case for it. Add a dedicated structured wire encoding (flag byte + optional bound strings) for ITEM_STRING_RANGE_TERM, following the same pattern as ITEM_STRING_IN/ITEM_NUMERIC_IN rather than the numeric range's unsafe bracket-string trick. Also complete the protobuf decode path in proto_tree_iterator.cpp, which previously dropped the bound values since nothing downstream could consume them.
