### PR TITLE
model map type as subclass of Field.Type

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -6025,6 +6025,20 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.search.query.Sorting$FeatureSorter" : {
+    "superClass" : "com.yahoo.search.query.Sorting$AttributeSorter",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(java.lang.String)",
+      "public java.lang.String toSerialForm()",
+      "public int hashCode()",
+      "public boolean equals(java.lang.Object)"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.search.query.Sorting$FieldOrder" : {
     "superClass" : "java.lang.Object",
     "interfaces" : [
@@ -6046,20 +6060,6 @@
       "public boolean equals(java.lang.Object)",
       "public com.yahoo.search.query.Sorting$FieldOrder clone()",
       "public bridge synthetic java.lang.Object clone()"
-    ],
-    "fields" : [ ]
-  },
-  "com.yahoo.search.query.Sorting$FeatureSorter" : {
-    "superClass" : "com.yahoo.search.query.Sorting$AttributeSorter",
-    "interfaces" : [ ],
-    "attributes" : [
-      "public"
-    ],
-    "methods" : [
-      "public void <init>(java.lang.String)",
-      "public java.lang.String toSerialForm()",
-      "public int hashCode()",
-      "public boolean equals(java.lang.Object)"
     ],
     "fields" : [ ]
   },
@@ -9139,6 +9139,20 @@
       "public com.yahoo.search.schema.Field$Builder setBitPacked(boolean)",
       "public com.yahoo.search.schema.Field$Builder setFastMapSearch(boolean)",
       "public com.yahoo.search.schema.Field build()"
+    ],
+    "fields" : [ ]
+  },
+  "com.yahoo.search.schema.Field$MapFieldType" : {
+    "superClass" : "com.yahoo.search.schema.Field$Type",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(com.yahoo.search.schema.Field$Type, com.yahoo.search.schema.Field$Type)",
+      "public com.yahoo.search.schema.Field$Type keyType()",
+      "public com.yahoo.search.schema.Field$Type valueType()",
+      "public static com.yahoo.search.schema.Field$Type from(java.lang.String)"
     ],
     "fields" : [ ]
   },

--- a/container-search/src/main/java/com/yahoo/search/schema/Field.java
+++ b/container-search/src/main/java/com/yahoo/search/schema/Field.java
@@ -3,6 +3,7 @@ package com.yahoo.search.schema;
 
 import com.yahoo.tensor.TensorType;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -114,7 +115,7 @@ public class Field implements FieldInfo {
             if (typeString.equals("long"))
                 return new Type(Kind.LONG);
             if (typeString.startsWith("map<"))
-                return new Type(Kind.MAP); // TODO: Model as subclass
+                return MapFieldType.from(typeString);
             if (typeString.equals("position"))
                 return new Type(Kind.POSITION);
             if (typeString.equals("predicate"))
@@ -153,6 +154,34 @@ public class Field implements FieldInfo {
             return tensorType.toString();
         }
 
+    }
+
+    public static class MapFieldType extends Type {
+
+        private final Type keyType;
+        private final Type valueType;
+
+        public MapFieldType(Type keyType, Type valueType) {
+            super(Kind.MAP);
+            this.keyType = keyType;
+            this.valueType = valueType;
+        }
+
+        public Type keyType() {
+            return keyType;
+        }
+
+        public Type valueType() {
+            return valueType;
+        }
+
+        public static Type from(String typeString) {
+            typeString = typeString.substring("map<".length());
+            typeString = typeString.substring(0, typeString.lastIndexOf(">"));
+            // we can split on first comma, since key can only be primitive type.
+            String[] parts = Arrays.stream(typeString.split(",", 2)).map(String::trim).toArray(String[]::new);
+            return new MapFieldType(Type.from(parts[0]), Type.from(parts[1]));
+        }
     }
 
     public static class Builder {

--- a/container-search/src/test/java/com/yahoo/search/schema/FieldTest.java
+++ b/container-search/src/test/java/com/yahoo/search/schema/FieldTest.java
@@ -1,0 +1,58 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.schema;
+
+import com.yahoo.tensor.TensorType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * @author johsol
+ */
+public class FieldTest {
+
+    @Test
+    public void requireMapIsParsed() {
+        // Primitive key and value
+        assertMapType("map<string,int>", Field.Type.Kind.STRING, Field.Type.Kind.INT);
+        assertMapType("map<int,string>", Field.Type.Kind.INT, Field.Type.Kind.STRING);
+        assertMapType("map<long,double>", Field.Type.Kind.LONG, Field.Type.Kind.DOUBLE);
+        assertMapType("map<string,bool>", Field.Type.Kind.STRING, Field.Type.Kind.BOOL);
+
+        // Whitespace
+        assertMapType("map<string, int>", Field.Type.Kind.STRING, Field.Type.Kind.INT);
+        assertMapType("map< string , int >", Field.Type.Kind.STRING, Field.Type.Kind.INT);
+
+        // Struct value: the spec is the bare struct name
+        assertMapType("map<int,mystruct>", Field.Type.Kind.INT, Field.Type.Kind.STRUCT);
+
+        // Collection values
+        assertMapType("map<string,array<int>>", Field.Type.Kind.STRING, Field.Type.Kind.ARRAY);
+        assertMapType("map<string,weightedset<string>>", Field.Type.Kind.STRING, Field.Type.Kind.WEIGHTEDSET);
+
+        // Nested map value: the inner map is parsed as well. Keys are always primitive, see DisallowComplexMapAndWsetKeyTypes.
+        var nested = assertMapType("map<int,map<string,int>>", Field.Type.Kind.INT, Field.Type.Kind.MAP);
+        var innerMap = assertInstanceOf(Field.MapFieldType.class, nested.valueType());
+        assertEquals(Field.Type.Kind.STRING, innerMap.keyType().kind());
+        assertEquals(Field.Type.Kind.INT, innerMap.valueType().kind());
+
+        // Tensor value
+        var withTensor = assertMapType("map<string,tensor(x[2],y[2])>", Field.Type.Kind.STRING, Field.Type.Kind.TENSOR);
+        var tensorType = assertInstanceOf(Field.TensorFieldType.class, withTensor.valueType());
+        assertEquals(TensorType.fromSpec("tensor(x[2],y[2])"), tensorType.tensorType());
+        var withMappedTensor = assertMapType("map<string,tensor<float>(a{},b{})>", Field.Type.Kind.STRING, Field.Type.Kind.TENSOR);
+        var mappedTensorType = assertInstanceOf(Field.TensorFieldType.class, withMappedTensor.valueType());
+        assertEquals(TensorType.fromSpec("tensor<float>(a{},b{})"), mappedTensorType.tensorType());
+    }
+
+    /** Returns the map type for further assertions. */
+    Field.MapFieldType assertMapType(String typeSpec, Field.Type.Kind key, Field.Type.Kind value) {
+        var type = Field.Type.from(typeSpec);
+        var mapType = assertInstanceOf(Field.MapFieldType.class, type);
+        assertEquals(key, mapType.keyType().kind());
+        assertEquals(value, mapType.valueType().kind());
+        return mapType;
+    }
+
+}


### PR DESCRIPTION
Parses map type by stripping "map<" and the ending ">", then splitting on "," to get the key and value types. This works since the key type must be a primitive type, so the first comma is part of this map type we are parsing.

Need this when converting a query to a fast map search, since when the key or value type is int, we must rewrite it to the hex format.

@arnej27959 please review