### PR TITLE
Add StringRangeItem and YQL parsing of string ranges

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -805,6 +805,7 @@
       "public static final enum com.yahoo.prelude.query.Item$ItemType STRING_IN",
       "public static final enum com.yahoo.prelude.query.Item$ItemType NUMERIC_IN",
       "public static final enum com.yahoo.prelude.query.Item$ItemType LABEL_WRAPPER",
+      "public static final enum com.yahoo.prelude.query.Item$ItemType STRING_RANGE",
       "public final int code"
     ]
   },
@@ -1707,6 +1708,33 @@
       "public com.yahoo.prelude.query.StringInItem clone()",
       "public bridge synthetic com.yahoo.prelude.query.Item clone()",
       "public bridge synthetic java.lang.Object clone()"
+    ],
+    "fields" : [ ]
+  },
+  "com.yahoo.prelude.query.StringRangeItem" : {
+    "superClass" : "com.yahoo.prelude.query.TermItem",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(java.lang.String, boolean, java.lang.String, boolean, java.lang.String, boolean)",
+      "public final java.lang.String getFrom()",
+      "public final boolean isFromInclusive()",
+      "public final java.lang.String getTo()",
+      "public final boolean isToInclusive()",
+      "public java.lang.String getIndexedString()",
+      "public java.lang.String getRawWord()",
+      "public com.yahoo.prelude.query.Item$ItemType getItemType()",
+      "public java.lang.String getName()",
+      "public java.lang.String stringValue()",
+      "public void setValue(java.lang.String)",
+      "public int hashCode()",
+      "public boolean equals(java.lang.Object)",
+      "protected void encodeThis(java.nio.ByteBuffer, com.yahoo.prelude.query.SerializationContext)",
+      "public int getNumWords()",
+      "public boolean isStemmed()",
+      "public boolean isWords()"
     ],
     "fields" : [ ]
   },
@@ -6025,6 +6053,20 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.search.query.Sorting$FeatureSorter" : {
+    "superClass" : "com.yahoo.search.query.Sorting$AttributeSorter",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>(java.lang.String)",
+      "public java.lang.String toSerialForm()",
+      "public int hashCode()",
+      "public boolean equals(java.lang.Object)"
+    ],
+    "fields" : [ ]
+  },
   "com.yahoo.search.query.Sorting$FieldOrder" : {
     "superClass" : "java.lang.Object",
     "interfaces" : [
@@ -6046,20 +6088,6 @@
       "public boolean equals(java.lang.Object)",
       "public com.yahoo.search.query.Sorting$FieldOrder clone()",
       "public bridge synthetic java.lang.Object clone()"
-    ],
-    "fields" : [ ]
-  },
-  "com.yahoo.search.query.Sorting$FeatureSorter" : {
-    "superClass" : "com.yahoo.search.query.Sorting$AttributeSorter",
-    "interfaces" : [ ],
-    "attributes" : [
-      "public"
-    ],
-    "methods" : [
-      "public void <init>(java.lang.String)",
-      "public java.lang.String toSerialForm()",
-      "public int hashCode()",
-      "public boolean equals(java.lang.Object)"
     ],
     "fields" : [ ]
   },

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -1718,7 +1718,7 @@
       "public"
     ],
     "methods" : [
-      "public void <init>(java.lang.String, boolean, java.lang.String, boolean, java.lang.String, boolean)",
+      "public void <init>(java.lang.String, boolean, java.lang.String, boolean, java.lang.String, boolean, com.yahoo.prelude.query.Substring)",
       "public final java.lang.String getFrom()",
       "public final boolean isFromInclusive()",
       "public final java.lang.String getTo()",

--- a/container-search/src/main/java/com/yahoo/prelude/query/Item.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/Item.java
@@ -60,7 +60,8 @@ public abstract class Item implements Cloneable {
         FUZZY(30),
         STRING_IN(31),
         NUMERIC_IN(32),
-        LABEL_WRAPPER(33);
+        LABEL_WRAPPER(33),
+        STRING_RANGE(34);
         // The next type added here is 34: ITEM_UNDEF in parse.h is kept last and moves up
 
         public final int code;

--- a/container-search/src/main/java/com/yahoo/prelude/query/StringRangeItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/StringRangeItem.java
@@ -1,0 +1,158 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.prelude.query;
+
+import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * This class represents an open, half-open, or closed interval of strings.
+ * Unbounded intervals are represented by endpoints that are null.
+ *
+ * @author boeker
+ */
+public class StringRangeItem extends TermItem {
+
+    /** The left endpoint of this interval. Is null if the interval is unbounded to the left. */
+    private final String from;
+
+    /** Whether this interval is closed to the left, i.e., whether the left endpoint is included. */
+    private final boolean fromInclusive;
+
+    /** The right endpoint of this interval. Is null if the interval is unbounded to the right.*/
+    private final String to;
+
+    /** Whether this interval is closed to the right, i.e., whether the left right is included. */
+    private final boolean toInclusive;
+
+    /**
+     * Create a StringRangeItem.
+     */
+    public StringRangeItem(String from, boolean fromInclusive, String to, boolean toInclusive, String indexName, boolean isFromQuery) {
+        super(indexName, isFromQuery);
+        this.from = from;
+        this.fromInclusive = fromInclusive && from != null; // Negative infinity cannot be included
+        this.to = to;
+        this.toInclusive = toInclusive && to != null; // Positive infinity cannot be included
+    }
+
+    /** Returns the left endpoint of this interval, where null means negative infinity. */
+    public final String getFrom() {
+        return from;
+    }
+
+    /** Returns whether the left endpoint is included in the interval. */
+    public final boolean isFromInclusive() {
+        return fromInclusive;
+    }
+
+    /** Returns the right endpoint of this interval, where null means positive infinity. */
+    public final String getTo() {
+        return to;
+    }
+
+    /** Returns whether the right endpoint is included in the interval. */
+    public final boolean isToInclusive() {
+        return toInclusive;
+    }
+
+    /** Returns a string representation of this interval. Can be ambiguous and is only for printing purposes. */
+    @Override
+    public String getIndexedString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.fromInclusive ? "[" : "<" ).append(this.from != null ? "\"" + this.from + "\"" : "-Infinity");
+        sb.append(";");
+        sb.append(this.to != null ? "\"" + this.to+ "\"" : "Infinity").append(this.toInclusive ? "]" : ">" );
+        return sb.toString();
+    }
+
+    @Override
+    public String getRawWord() {
+        return getIndexedString();
+    }
+
+    @Override
+    public ItemType getItemType() {
+        return ItemType.STRING_RANGE;
+    }
+
+    @Override
+    public String getName() {
+        return "STRING_RANGE";
+    }
+
+    @Override
+    public String stringValue() {
+        return getIndexedString();
+    }
+
+    /**
+     * Not supported.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public void setValue(String value) {
+        throw new UnsupportedOperationException("Cannot setValue(" + value + ") on " + getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), from, fromInclusive, to, toInclusive);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!super.equals(object)) return false;
+
+        StringRangeItem other = (StringRangeItem) object; // Ensured by superclass
+        if (!Objects.equals(from, other.from)) return false;
+        if (fromInclusive != other.fromInclusive) return false;
+        if (!Objects.equals(to, other.to)) return false;
+        if (toInclusive != other.toInclusive) return false;
+        return true;
+    }
+
+    /**
+     * Not supported.
+     */
+    @Override
+    protected void encodeThis(ByteBuffer buffer, SerializationContext context) {
+        super.encodeThis(buffer, context); // takes care of index bytes
+        // Not implemented
+    }
+
+    @Override
+    public int getNumWords() {
+        return 1;
+    }
+
+    @Override
+    public boolean isStemmed() {
+        return true;
+    }
+
+    @Override
+    public boolean isWords() {
+        return false;
+    }
+
+    @Override
+    SearchProtocol.QueryTreeItem toProtobuf(SerializationContext context) {
+        var builder = SearchProtocol.ItemStringRangeTerm.newBuilder();
+        builder.setProperties(ToProtobuf.buildTermProperties(this, getIndexName()));
+        if (from != null) {
+            builder.setLowerLimit(from);
+        }
+        builder.setLowerInclusive(fromInclusive);
+        if (to != null) {
+            builder.setUpperLimit(to);
+        }
+        builder.setUpperInclusive(toInclusive);
+        return SearchProtocol.QueryTreeItem.newBuilder()
+                .setItemStringRangeTerm(builder.build())
+                .build();
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/prelude/query/StringRangeItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/StringRangeItem.java
@@ -29,8 +29,8 @@ public class StringRangeItem extends TermItem {
     /**
      * Create a StringRangeItem.
      */
-    public StringRangeItem(String from, boolean fromInclusive, String to, boolean toInclusive, String indexName, boolean isFromQuery) {
-        super(indexName, isFromQuery);
+    public StringRangeItem(String from, boolean fromInclusive, String to, boolean toInclusive, String indexName, boolean isFromQuery, Substring origin) {
+        super(indexName, isFromQuery, origin);
         this.from = from;
         this.fromInclusive = fromInclusive && from != null; // Negative infinity cannot be included
         this.to = to;
@@ -69,7 +69,11 @@ public class StringRangeItem extends TermItem {
 
     @Override
     public String getRawWord() {
-        return getIndexedString();
+        if (getOrigin() == null) {
+            return stringValue();
+        } else {
+            return getOrigin().getValue();
+        }
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/prelude/query/StringRangeItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/StringRangeItem.java
@@ -123,8 +123,7 @@ public class StringRangeItem extends TermItem {
      */
     @Override
     protected void encodeThis(ByteBuffer buffer, SerializationContext context) {
-        super.encodeThis(buffer, context); // takes care of index bytes
-        // Not implemented
+        throw new UnsupportedOperationException("Cannot encodeThis(" + buffer + ", " + context + ") on " + getName());
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -107,6 +107,7 @@ import com.yahoo.prelude.query.SameElementItem;
 import com.yahoo.prelude.query.SegmentItem;
 import com.yahoo.prelude.query.SegmentingRule;
 import com.yahoo.prelude.query.StringInItem;
+import com.yahoo.prelude.query.StringRangeItem;
 import com.yahoo.prelude.query.Substring;
 import com.yahoo.prelude.query.SubstringItem;
 import com.yahoo.prelude.query.SuffixItem;
@@ -917,6 +918,61 @@ public class VespaSerializer {
         }
     }
 
+    private static class StringRangeSerializer extends Serializer<StringRangeItem> {
+
+        @Override
+        void onExit(StringBuilder destination, StringRangeItem item) { }
+
+        @Override
+        boolean serialize(StringBuilder destination, StringRangeItem range, Boolean includeField) {
+            String leafAnnotations = leafAnnotations(range);
+            String boundsAnnotation = boundsAnnotation(range);
+            String annotations = leafAnnotations + (!leafAnnotations.isEmpty() && !boundsAnnotation.isEmpty() ? ", " : "") + boundsAnnotation;
+            if (!annotations.isEmpty()) {
+                destination.append("{").append(annotations).append("}");
+            }
+
+            // range
+            destination.append(RANGE).append('(')
+                    .append(normalizeIndexName(range.getIndexName()))
+                    .append(", ");
+
+            // from
+            String from = range.getFrom();
+            if (from != null) {
+                destination.append("\"");
+                escape(from, destination);
+                destination.append("\"");
+            } else {
+                destination.append("-Infinity");
+            }
+            destination.append(", ");
+
+            // to
+            String to = range.getTo();
+            if (to!= null) {
+                destination.append("\"");
+                escape(to, destination);
+                destination.append("\"");
+            } else {
+                destination.append("Infinity");
+            }
+
+            destination.append(")");
+
+            return false;
+        }
+
+        private static String boundsAnnotation(StringRangeItem range) {
+            boolean leftOpen = !range.isFromInclusive();
+            boolean rightOpen = !range.isToInclusive();
+            if (leftOpen && rightOpen) return BOUNDS + ": \"" + BOUNDS_OPEN + "\"";
+            if (leftOpen) return BOUNDS + ": \"" + BOUNDS_LEFT_OPEN + "\"";
+            if (rightOpen) return BOUNDS + ": \"" + BOUNDS_RIGHT_OPEN + "\"";
+            return "";
+        }
+    }
+
     private static class RankSerializer extends Serializer<RankItem> {
 
         @Override
@@ -1322,6 +1378,7 @@ public class VespaSerializer {
         dispatchBuilder.put(EquivItem.class, new EquivSerializer());
         dispatchBuilder.put(ExactStringItem.class, new WordSerializer());
         dispatchBuilder.put(IntItem.class, new NumberSerializer());
+        dispatchBuilder.put(StringRangeItem.class, new StringRangeSerializer());
         dispatchBuilder.put(GeoLocationItem.class, new GeoLocationSerializer());
         dispatchBuilder.put(BoolItem.class, new BoolSerializer());
         dispatchBuilder.put(TrueItem.class, new TrueSerializer());

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -1626,7 +1626,7 @@ public class YqlParser implements Parser {
         String bounds = getAnnotation(spec, BOUNDS, String.class, null,
                 "whether bounds should be open or closed");
         if (bounds == null) {
-            return new StringRangeItem(left, true, right, true, getIndex(args.get(0)), true);
+            return new StringRangeItem(left, true, right, true, getIndex(args.get(0)), true, getSubstring(spec));
         } else {
             boolean leftClosed = true;
             boolean rightClosed = true;
@@ -1644,7 +1644,7 @@ public class YqlParser implements Parser {
                 default ->
                         throw newUnexpectedArgumentException(bounds, BOUNDS_OPEN, BOUNDS_LEFT_OPEN, BOUNDS_RIGHT_OPEN);
             }
-            return new StringRangeItem(left, leftClosed, right, rightClosed, getIndex(args.get(0)), true);
+            return new StringRangeItem(left, leftClosed, right, rightClosed, getIndex(args.get(0)), true, getSubstring(spec));
         }
     }
 

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -67,6 +67,7 @@ import com.yahoo.prelude.query.SameElementItem;
 import com.yahoo.prelude.query.SegmentItem;
 import com.yahoo.prelude.query.SegmentingRule;
 import com.yahoo.prelude.query.StringInItem;
+import com.yahoo.prelude.query.StringRangeItem;
 import com.yahoo.prelude.query.Substring;
 import com.yahoo.prelude.query.SubstringItem;
 import com.yahoo.prelude.query.SuffixItem;
@@ -1584,8 +1585,19 @@ public class YqlParser implements Parser {
         assertHasOperator(spec, ExpressionOperator.CALL);
         assertHasFunctionName(spec, RANGE);
 
-        IntItem range = instantiateRangeItem(spec.getArgument(1), spec);
-        return leafStyleSettings(spec, range);
+        List<OperatorNode<ExpressionOperator>> args = spec.getArgument(1);
+        Preconditions.checkArgument(args.size() == 3,
+                "Expected 3 arguments, got %s.", args.size());
+
+        var index = indexFactsSession.getIndex(indexNameExpander.expand(getIndex(args.get(0))));
+        if (index.isString() && !index.isInteger() && !index.isNumerical()) {
+            StringRangeItem range = instantiateStringRangeItem(args, spec);
+            return leafStyleSettings(spec, range);
+        } else {
+            IntItem range = instantiateIntRangeItem(args, spec);
+            return leafStyleSettings(spec, range);
+        }
+
     }
 
     private static Number negate(Number x) {
@@ -1606,11 +1618,69 @@ public class YqlParser implements Parser {
         }
     }
 
-    private IntItem instantiateRangeItem(List<OperatorNode<ExpressionOperator>> args,
-                                         OperatorNode<ExpressionOperator> spec) {
-        Preconditions.checkArgument(args.size() == 3,
-                "Expected 3 arguments, got %s.", args.size());
+    private StringRangeItem instantiateStringRangeItem(List<OperatorNode<ExpressionOperator>> args,
+                                            OperatorNode<ExpressionOperator> spec) {
+        // Pre-condition: args.size() == 3
+        String left = getLeftStringRangeBound(args.get(1));
+        String right = getRightStringRangeBound(args.get(2));
+        String bounds = getAnnotation(spec, BOUNDS, String.class, null,
+                "whether bounds should be open or closed");
+        if (bounds == null) {
+            return new StringRangeItem(left, true, right, true, getIndex(args.get(0)), true);
+        } else {
+            boolean leftClosed = true;
+            boolean rightClosed = true;
+            switch (bounds) {
+                case BOUNDS_OPEN -> {
+                    leftClosed = false;
+                    rightClosed = false;
+                }
+                case BOUNDS_LEFT_OPEN -> {
+                    leftClosed = false;
+                }
+                case BOUNDS_RIGHT_OPEN -> {
+                    rightClosed = false;
+                }
+                default ->
+                        throw newUnexpectedArgumentException(bounds, BOUNDS_OPEN, BOUNDS_LEFT_OPEN, BOUNDS_RIGHT_OPEN);
+            }
+            return new StringRangeItem(left, leftClosed, right, rightClosed, getIndex(args.get(0)), true);
+        }
+    }
 
+    private String getLeftStringRangeBound(OperatorNode<ExpressionOperator> bound) {
+        if (bound.getOperator() == ExpressionOperator.NEGATE && isInfinity(bound.getArgument(0))) {
+            return null;
+        } else if (bound.getOperator() == ExpressionOperator.LITERAL) { // String in quotes
+            return bound.getArgument(0).toString();
+        } else {
+            String asString = bound.getArguments().length > 1 ? bound.getArgument(1).toString() : bound.toString(); // Try to make the error a bit prettier
+            throw new IllegalArgumentException("Expected -Infinity or a quoted string for left string range bound but got " + asString + ".");
+        }
+    }
+
+    private String getRightStringRangeBound(OperatorNode<ExpressionOperator> bound) {
+        if (isInfinity(bound)) {
+            return null;
+        } else if (bound.getOperator() == ExpressionOperator.LITERAL) { // String in quotes
+            return bound.getArgument(0).toString();
+        } else {
+            // Try to make the error a bit prettier
+            String asString = (bound.getOperator() == ExpressionOperator.NEGATE && isInfinity(bound.getArgument(0))) ? "-Infinity"
+                    : (bound.getArguments().length > 1 ? bound.getArgument(1).toString() : bound.toString());
+            throw new IllegalArgumentException("Expected Infinity or a quoted string for right string range bound but got " + asString + ".");
+        }
+    }
+
+    private boolean isInfinity(OperatorNode<ExpressionOperator> bound) {
+        return bound.getOperator() == ExpressionOperator.READ_FIELD
+                && bound.getArguments().length > 0
+                && bound.getArgument(1).toString().equals("Infinity");
+    }
+
+    private IntItem instantiateIntRangeItem(List<OperatorNode<ExpressionOperator>> args,
+                                         OperatorNode<ExpressionOperator> spec) {
+        // Pre-condition: args.size() == 3
         Number lowerArg = getRangeBound(args.get(1));
         Number upperArg = getRangeBound(args.get(2));
         String bounds = getAnnotation(spec, BOUNDS, String.class, null,

--- a/container-search/src/test/java/com/yahoo/prelude/query/ToProtobufTest.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/ToProtobufTest.java
@@ -681,7 +681,7 @@ public class ToProtobufTest {
 
     @Test
     void testConvertFromQueryWithStringRangeItem() {
-        assertConvertsToJson(new StringRangeItem("aaa", true, "zzz", true, "myindex", true), """
+        assertConvertsToJson(new StringRangeItem("aaa", true, "zzz", true, "myindex", true, null), """
             {
               "itemStringRangeTerm": {
                 "properties": {"index": "myindex"},
@@ -692,7 +692,7 @@ public class ToProtobufTest {
               }
             }
             """);
-        assertConvertsToJson(new StringRangeItem("", true, "zzz", true, "myindex", true), """
+        assertConvertsToJson(new StringRangeItem("", true, "zzz", true, "myindex", true, null), """
             {
               "itemStringRangeTerm": {
                 "properties": {"index": "myindex"},
@@ -703,7 +703,7 @@ public class ToProtobufTest {
               }
             }
             """);
-        assertConvertsToJson(new StringRangeItem(null, false, "zzz", true, "myindex", true), """
+        assertConvertsToJson(new StringRangeItem(null, false, "zzz", true, "myindex", true, null), """
             {
               "itemStringRangeTerm": {
                 "properties": {"index": "myindex"},
@@ -712,7 +712,7 @@ public class ToProtobufTest {
               }
             }
             """);
-        assertConvertsToJson(new StringRangeItem("aaa", false, null, false, "myindex", true), """
+        assertConvertsToJson(new StringRangeItem("aaa", false, null, false, "myindex", true, null), """
             {
               "itemStringRangeTerm": {
                 "properties": {"index": "myindex"},

--- a/container-search/src/test/java/com/yahoo/prelude/query/ToProtobufTest.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/ToProtobufTest.java
@@ -680,6 +680,49 @@ public class ToProtobufTest {
     }
 
     @Test
+    void testConvertFromQueryWithStringRangeItem() {
+        assertConvertsToJson(new StringRangeItem("aaa", true, "zzz", true, "myindex", true), """
+            {
+              "itemStringRangeTerm": {
+                "properties": {"index": "myindex"},
+                "lowerLimit": "aaa",
+                "upperLimit": "zzz",
+                "lowerInclusive": true,
+                "upperInclusive": true
+              }
+            }
+            """);
+        assertConvertsToJson(new StringRangeItem("", true, "zzz", true, "myindex", true), """
+            {
+              "itemStringRangeTerm": {
+                "properties": {"index": "myindex"},
+                "lowerLimit": "",
+                "upperLimit": "zzz",
+                "lowerInclusive": true,
+                "upperInclusive": true
+              }
+            }
+            """);
+        assertConvertsToJson(new StringRangeItem(null, false, "zzz", true, "myindex", true), """
+            {
+              "itemStringRangeTerm": {
+                "properties": {"index": "myindex"},
+                "upperLimit": "zzz",
+                "upperInclusive": true
+              }
+            }
+            """);
+        assertConvertsToJson(new StringRangeItem("aaa", false, null, false, "myindex", true), """
+            {
+              "itemStringRangeTerm": {
+                "properties": {"index": "myindex"},
+                "lowerLimit": "aaa"
+              }
+            }
+            """);
+    }
+
+    @Test
     void testConvertFromQueryWithNumericInItem() {
         NumericInItem numericIn = new NumericInItem("myindex");
         numericIn.addToken(42L);

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/StringRangeItemTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/StringRangeItemTestCase.java
@@ -3,6 +3,7 @@ package com.yahoo.prelude.query.test;
 
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.StringRangeItem;
+import com.yahoo.prelude.query.Substring;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -14,30 +15,37 @@ public class StringRangeItemTestCase {
 
     @Test
     void testStringRangeConstruction() {
-        StringRangeItem range = new StringRangeItem("aaa", true, "zzz", true, "index", true);
+        StringRangeItem range = new StringRangeItem("aaa", true, "zzz", true, "index", true, null);
         assertEquals("aaa", range.getFrom());
         assertTrue(range.isFromInclusive());
         assertEquals("zzz", range.getTo());
         assertTrue(range.isToInclusive());
         assertEquals("[\"aaa\";\"zzz\"]", range.getIndexedString());
-        assertEquals("[\"aaa\";\"zzz\"]", range.getRawWord());
+        assertEquals("[\"aaa\";\"zzz\"]", range.getRawWord()); // fallback when no origin provided
         assertEquals(Item.ItemType.STRING_RANGE, range.getItemType());
         assertEquals("STRING_RANGE", range.getName());
         assertEquals(1, range.getNumWords());
         assertTrue(range.isStemmed());
         assertFalse(range.isWords());
 
-        range = new StringRangeItem(null, true, null, false, "index", true);
+        range = new StringRangeItem(null, true, null, false, "index", true, null);
         assertNull(range.getFrom());
         assertFalse(range.isFromInclusive()); // Auto-corrected to false
         assertNull(range.getTo());
         assertFalse(range.isToInclusive());
         assertEquals("<-Infinity;Infinity>", range.getIndexedString());
-        assertEquals("<-Infinity;Infinity>", range.getRawWord());
+        assertEquals("<-Infinity;Infinity>", range.getRawWord()); // fallback when no origin provided
         assertEquals(Item.ItemType.STRING_RANGE, range.getItemType());
         assertEquals("STRING_RANGE", range.getName());
         assertEquals(1, range.getNumWords());
         assertTrue(range.isStemmed());
         assertFalse(range.isWords());
+    }
+
+
+    @Test
+    void testStringRemembersOrigin() {
+        StringRangeItem range = new StringRangeItem("aaa", true, "zzz", true, "index", true, new Substring("range(\"aaa\", \"zzz\")"));
+        assertEquals("range(\"aaa\", \"zzz\")", range.getRawWord());
     }
 }

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/StringRangeItemTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/StringRangeItemTestCase.java
@@ -1,0 +1,43 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.prelude.query.test;
+
+import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.StringRangeItem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StringRangeItemTestCase {
+
+    @Test
+    void testStringRangeConstruction() {
+        StringRangeItem range = new StringRangeItem("aaa", true, "zzz", true, "index", true);
+        assertEquals("aaa", range.getFrom());
+        assertTrue(range.isFromInclusive());
+        assertEquals("zzz", range.getTo());
+        assertTrue(range.isToInclusive());
+        assertEquals("[\"aaa\";\"zzz\"]", range.getIndexedString());
+        assertEquals("[\"aaa\";\"zzz\"]", range.getRawWord());
+        assertEquals(Item.ItemType.STRING_RANGE, range.getItemType());
+        assertEquals("STRING_RANGE", range.getName());
+        assertEquals(1, range.getNumWords());
+        assertTrue(range.isStemmed());
+        assertFalse(range.isWords());
+
+        range = new StringRangeItem(null, true, null, false, "index", true);
+        assertNull(range.getFrom());
+        assertFalse(range.isFromInclusive()); // Auto-corrected to false
+        assertNull(range.getTo());
+        assertFalse(range.isToInclusive());
+        assertEquals("<-Infinity;Infinity>", range.getIndexedString());
+        assertEquals("<-Infinity;Infinity>", range.getRawWord());
+        assertEquals(Item.ItemType.STRING_RANGE, range.getItemType());
+        assertEquals("STRING_RANGE", range.getName());
+        assertEquals(1, range.getNumWords());
+        assertTrue(range.isStemmed());
+        assertFalse(range.isWords());
+    }
+}

--- a/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
@@ -235,6 +235,19 @@ public class VespaSerializerTestCase {
     }
 
     @Test
+    void testStringRange() {
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+        parseAndConfirm("range(string, \"aaa\", \"zzz\")");
+        parseAndConfirm("{bounds: \"leftOpen\"}range(string, \"aaa\", \"zzz\")");
+        parseAndConfirm("{bounds: \"rightOpen\"}range(string, \"aaa\", \"zzz\")");
+        parseAndConfirm("{bounds: \"open\"}range(string, \"aaa\", \"zzz\")");
+        parseAndConfirm("{filter: true, bounds: \"open\"}range(string, \"aaa\", \"zzz\")");
+        parseAndConfirm("{filter: true}range(string, \"aaa\", \"zzz\")");
+        parseAndConfirm("{bounds: \"open\"}range(string, -Infinity, Infinity)");
+        parseAndConfirm("{bounds: \"open\"}range(string, -Infinity, Infinity)");
+    }
+
+    @Test
     void testOrderedNear() {
         parseAndConfirm("title contains onear(\"a\", \"b\")");
     }

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -869,6 +869,13 @@ public class YqlParserTestCase {
     }
 
     @Test
+    void testStringRangeProvidesOrigin() {
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+        var string_range = (StringRangeItem)parse("select foo from sources default where ({origin: {original:\"foo\", offset: 0, length: 3}}range(string, \"aaa\", \"zzz\"))").getRoot();
+        assertEquals("foo", string_range.getRawWord());
+    }
+
+    @Test
     void testNear() {
         assertParse("select foo from bar where description contains near(\"a\", \"b\")",
                 "NEAR(2) description:a description:b");

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -28,6 +28,7 @@ import com.yahoo.prelude.query.RegExpItem;
 import com.yahoo.prelude.query.SameElementItem;
 import com.yahoo.prelude.query.SegmentingRule;
 import com.yahoo.prelude.query.StringInItem;
+import com.yahoo.prelude.query.StringRangeItem;
 import com.yahoo.prelude.query.Substring;
 import com.yahoo.prelude.query.SubstringItem;
 import com.yahoo.prelude.query.SuffixItem;
@@ -842,6 +843,29 @@ public class YqlParserTestCase {
     void testRangeIllegalArguments() {
         assertParseFail("select foo from bar where range(baz,cox,8)",
                 new IllegalArgumentException("Expected a numerical argument (or 'Infinity') to range but got 'cox'"));
+    }
+
+    @Test
+    void testStringRange() {
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+        assertEquals("STRING_RANGE string:[\"aaa\";\"zzz\"]", parse("select foo from sources default where range(string,'aaa','zzz')").toString());
+        assertEquals("STRING_RANGE string:[\"aaa\";\"zzz\"]", parse("select foo from sources default where range(string,\"aaa\",\"zzz\")").toString());
+        assertEquals("STRING_RANGE string:<\"aaa\";\"zzz\"]", parse("select foo from sources default where ({bounds:\"leftOpen\"}range(string,\"aaa\",\"zzz\"))").toString());
+        assertEquals("STRING_RANGE string:[\"aaa\";\"zzz\">", parse("select foo from sources default where ({bounds:\"rightOpen\"}range(string,\"aaa\",\"zzz\"))").toString());
+        assertEquals("STRING_RANGE string:<\"aaa\";\"zzz\">", parse("select foo from sources default where ({bounds:\"open\"}range(string,\"aaa\",\"zzz\"))").toString());
+        assertEquals("STRING_RANGE string:<-Infinity;\"zzz\"]", parse("select foo from sources default where range(string,-Infinity,\"zzz\")").toString());
+        assertEquals("STRING_RANGE string:<-Infinity;Infinity>", parse("select foo from sources default where range(string,-Infinity,Infinity)").toString());
+    }
+
+    @Test
+    void testStringRangeIllegalArguments() {
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+        assertParseFail("select foo from sources default where ({bounds:\"foo\"}range(string,\"aaa\",\"zzz\"))", new IllegalArgumentException("Expected open, leftOpen or rightOpen, got foo."));
+        assertParseFail("select foo from sources default where range(string,aaa,\"zzz\")", new IllegalArgumentException("Expected -Infinity or a quoted string for left string range bound but got aaa."));
+        assertParseFail("select foo from sources default where range(string,\"aaa\",zzz)", new IllegalArgumentException("Expected Infinity or a quoted string for right string range bound but got zzz."));
+        assertParseFail("select foo from sources default where range(string,Infinity,\"zzz\")", new IllegalArgumentException("Expected -Infinity or a quoted string for left string range bound but got Infinity."));
+        assertParseFail("select foo from sources default where range(string,\"aaa\",-Infinity)", new IllegalArgumentException("Expected Infinity or a quoted string for right string range bound but got -Infinity."));
+        assertParseFail("select foo from sources default where range(string,\"aaa\")", new IllegalArgumentException("Expected 3 arguments, got 2."));
     }
 
     @Test


### PR DESCRIPTION
1. The `StringRangeItem` does not have a proper string representation at the moment. You cannot set it from a string and the string you get can be ambiguous. This seems fine for `getIndexedString()`, but might not be for `getRawWord()`. The docstring for it says:
```
/** Returns the raw form of the text leading to this term, exactly as received, including original casing */
```
You would need the proper parsing and escaping to achieve something like that in `StringRangeItem`. Any opinions on what to do here?

2. Is there a good way to hide the string ranges behind the feature flag for now? Passing the flag to the parser environment to prevent parsing might not be a good option since that is public API, I think.

@arnej27959 @johansolbakken Please review. Need your input on these two things. 🙏 