### PR TITLE
Remove overly-broad dot rejection from ParsedSummaryField [MERGEOK]

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedSummaryField.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedSummaryField.java
@@ -27,7 +27,6 @@ public class ParsedSummaryField extends ParsedBlock {
 
     public ParsedSummaryField(String name, ParsedType type) {
         super(name, "summary field");
-        verifyThat(! name.contains("."), "invalid name, must not contain '.'");
         this.type = type;
     }
 


### PR DESCRIPTION
verifyThat(!name.contains(".")) was added while removing dead code for the legacy v7 geo position feature, to close off the only remaining way to declare a "field.distance"/"field.position" summary field from a schema. But it also blocks the unrelated, in-use case of a document-summary field named after a struct field path, e.g. "summary structname.fieldname {}". The constructor is the wrong place to enforce this kind of naming rule, so drop the check here; validation of legal names should happen closer to where each specific syntax is handled.
