### PR TITLE
Optimize unpack_bits with LUT

### DIFF
--- a/eval/src/vespa/eval/instruction/unpack_bits_function.cpp
+++ b/eval/src/vespa/eval/instruction/unpack_bits_function.cpp
@@ -11,6 +11,8 @@
 #include <vespa/eval/eval/value.h>
 #include <vespa/eval/eval/wrap_param.h>
 
+#include <algorithm>
+#include <array>
 #include <cassert>
 
 namespace vespalib::eval {
@@ -26,21 +28,31 @@ namespace {
 
 //-----------------------------------------------------------------------------
 
+// Precomputed byte -> 8-element unpack pattern, generated at compile time.
+// One instantiation per (OCT, big) combination; each is 256 * 8 * sizeof(OCT) bytes
+// (e.g. 8KiB for float), small enough to stay resident in L1 across a whole scan.
+template <typename OCT, bool big> struct UnpackLut {
+    static constexpr std::array<std::array<OCT, 8>, 256> table = [] {
+        std::array<std::array<OCT, 8>, 256> t{};
+        for (int byte = 0; byte < 256; ++byte) {
+            for (int n = 0; n < 8; ++n) {
+                int bit_pos = big ? (7 - n) : n;
+                t[byte][n] = static_cast<OCT>(bool(byte & (1 << bit_pos)));
+            }
+        }
+        return t;
+    }();
+};
+
 template <typename OCT, bool big> void my_unpack_bits_op(InterpretedFunction::State& state, uint64_t param) {
     const ValueType& res_type = unwrap_param<ValueType>(param);
     auto             packed_cells = state.peek(0).cells().typify<Int8Float>();
     auto             unpacked_cells = state.stash.create_uninitialized_array<OCT>(packed_cells.size() * 8);
     OCT*             dst = unpacked_cells.data();
+    const auto&      lut = UnpackLut<OCT, big>::table;
     for (Int8Float cell : packed_cells) {
-        if constexpr (big) {
-            for (int n = 7; n >= 0; --n) {
-                *dst++ = (OCT) bool(cell.get_bits() & (1 << n));
-            }
-        } else {
-            for (int n = 0; n <= 7; ++n) {
-                *dst++ = (OCT) bool(cell.get_bits() & (1 << n));
-            }
-        }
+        const auto& row = lut[static_cast<uint8_t>(cell.get_bits())];
+        dst = std::copy(row.begin(), row.end(), dst);
     }
     Value& result_ref = state.stash.create<ValueView>(res_type, state.peek(0).index(), TypedCells(unpacked_cells));
     state.pop_push(result_ref);


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

In the the first-phase ranking we calculate closeness between the full-precision query embedding and the binary document embedding.

Relevant schema/rank-profile snippets:
```text
field embeddings_bin type tensor<int8>(x[16]) {
    indexing: attribute
    attribute {
        distance-metric: hamming
    }
}
...
inputs {
    query(query_truncated) tensor<float>(x[128])
}
function unpack_binary_representation() {
    expression: 2 * unpack_bits(attribute(embeddings_bin)) - 1
}
function closeness_score() {
    expression {
        (sum(query(query) * unpack_binary_representation()) + 1) / 2
    }
}
```

And in the query traces the `unpack_binary_representation` dominates:
```
first phase rank profiling for thread #0 (total time was 2000.421 ms)
┌─────────┬─────────┬────────────────────────────────────────────────────┐
│ count   │ self_ms │ component                                          │
├─────────┼─────────┼────────────────────────────────────────────────────┤
│ 3755976 │ 286.684 │ function unpack_binary_representation              │
│ 3755976 │ 232.789 │ function closeness_score                           │
```

The same unpack_bits function is significant in the layered-ranking type setup.
```
first phase rank profiling for thread #0 (total time was 689.152 ms)
┌────────┬─────────┬────────────────────────────────────────────────────┐
│ count  │ self_ms │ component                                          │
├────────┼─────────┼────────────────────────────────────────────────────┤
│ 913690 │ 164.410 │ function unpack_binary_representation              │
│ 913690 │  96.228 │ function closeness_score                           │
│ 913690 │  75.848 │ rank feature attribute(embeddings_bin)             │
```
Which in the dev instance had 4 chunks on average and max 5336.

Claude pointed that besides the ranking function call and the framework overhead the actual bit unpacking could be optimized a bit.

## Optimization

The LUT (look up table) approach was picked up because it is simple.
The idea is to pre-compute all possible values and in the hot loop copy looked up bytes into destination.

Alternatives considered were SIMD and bit multiplication hacks.

## Microbenchmark                                                                                                    
                                                                                                                    
Ran the code directly with g++ (13th Gen i9-13900K). 
Correctness: exhaustive check over all 256 byte values passed in both builds.                     
                                                                                                                    
  -O2 (no target tuning):                                                                                           
  single vector (x[128])   scalar=63.36ns (0.495ns/bit)   lut=6.22ns (0.049ns/bit)   speedup=10.19x                 
  avg chunked (cnum=4)      scalar=266.11ns (0.520ns/bit)  lut=24.44ns (0.048ns/bit)  speedup=10.89x                
  outlier (cnum=5336)       scalar=1,807,029ns (2.646ns/bit) lut=50,685ns (0.074ns/bit) speedup=35.65x              
                                                                                                                    
  -O3 -march=native:                                                                                                
  single vector (x[128])   scalar=26.48ns (0.207ns/bit)   lut=4.57ns (0.036ns/bit)   speedup=5.80x                  
  avg chunked (cnum=4)      scalar=100.03ns (0.195ns/bit)  lut=21.72ns (0.042ns/bit)  speedup=4.61x                 
  outlier (cnum=5336)       scalar=130,449ns (0.191ns/bit) lut=55,237ns (0.081ns/bit) speedup=2.36x

It is not a cure but a first step improving the common idiom of calculating the dot product between full precision query embedding and binarized document embedding.

  Full picture across compilers/flags

  ┌─────────────────────────────┬────────┬───────────────┬──────────┬─────────────────┐
  │                             │  gcc   │   gcc -O3     │  clang   │   clang -O3     │
  │                             │  -O2   │    native     │   -O2    │     native      │
  ├─────────────────────────────┼────────┼───────────────┼──────────┼─────────────────┤
  │ scalar ns/bit (single       │ 0.495  │ 0.207         │ 0.118    │ 0.129           │
  │ vector)                     │        │               │          │                 │
  ├─────────────────────────────┼────────┼───────────────┼──────────┼─────────────────┤
  │ scalar ns/bit (outlier)     │ 2.646  │ 0.191         │ 0.116    │ 0.129           │
  ├─────────────────────────────┼────────┼───────────────┼──────────┼─────────────────┤
  │ LUT ns/bit (single vector)  │ 0.049  │ 0.036         │ 0.037    │ 0.037           │
  ├─────────────────────────────┼────────┼───────────────┼──────────┼─────────────────┤
  │ LUT ns/bit (outlier)        │ 0.074  │ 0.081         │ 0.074    │ 0.082           │
  ├─────────────────────────────┼────────┼───────────────┼──────────┼─────────────────┤
  │ speedup, small              │ 10.2x  │ 5.8x          │ 3.2x     │ 3.5x            │
  ├─────────────────────────────┼────────┼───────────────┼──────────┼─────────────────┤
  │ speedup, outlier            │ 35.7x  │ 2.4x          │ 1.6x     │ 1.6x            │
  └─────────────────────────────┴────────┴───────────────┴──────────┴─────────────────┘

## Impact

Also the ColBERT case with asymetric embeddings should benefit from this work.