### PR TITLE
feat: requests metric to rate limiting searcher

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/searchers/RateLimitingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/RateLimitingSearcher.java
@@ -45,8 +45,9 @@ import java.util.concurrent.ThreadLocalRandom;
  * <p>
  * If either 'rate.id' or 'rate.quota' is not set in Query.properties this searcher will do nothing.
  * <p>
- * Metrics: This will emit the count metric requestsOverQuota with the dimension [rate.idDimension=rate.id]
- * counting rejected requests.
+ * Metrics: This will emit the count metrics requests and requestsOverQuota, both with the dimension
+ * [rate.idDimension=rate.id]. requests counts all requests checked by this searcher, and requestsOverQuota
+ * counts the subset of those that were rejected (or would have been rejected, in dryRun mode).
  * <p>
  * Ordering: This searcher Provides rateLimiting
  *
@@ -64,6 +65,7 @@ public class RateLimitingSearcher extends Searcher {
     public static final CompoundName idDimensionKey = CompoundName.from("rate.idDimension");
     public static final CompoundName dryRunKey = CompoundName.from("rate.dryRun");
 
+    private static final String requestsMetricName = ContainerMetrics.REQUESTS.baseName();
     private static final String requestsOverQuotaMetricName = ContainerMetrics.REQUESTS_OVER_QUOTA.baseName();
 
     /** Used to divide quota by nodes. Assumption: All nodes get the same share of traffic. */
@@ -78,6 +80,7 @@ public class RateLimitingSearcher extends Searcher {
     private final ThreadLocal<Map<String, Double>> allocatedCapacity = new ThreadLocal<>();
 
     /** For emitting metrics */
+    private final Counter requestsCounter;
     private final Counter overQuotaCounter;
 
     /**
@@ -106,6 +109,7 @@ public class RateLimitingSearcher extends Searcher {
 
         this.nodeCount = clusterInfoConfig.nodeCount();
 
+        this.requestsCounter = metric.declareCounter(requestsMetricName);
         this.overQuotaCounter = metric.declareCounter(requestsOverQuotaMetricName);
     }
 
@@ -117,6 +121,8 @@ public class RateLimitingSearcher extends Searcher {
             query.trace(false, 6, "Skipping rate limiting check. Need both " + idKey + " and " + quotaKey + " set");
             return execution.search(query);
         }
+
+        increaseMetric(requestsCounter, id, query);
 
         if ( ! localRate)
             rate = rate / nodeCount;
@@ -136,7 +142,7 @@ public class RateLimitingSearcher extends Searcher {
         boolean dryRun = query.properties().getBoolean(dryRunKey, false);
 
         if (reject)
-            increaseRejectMetric(id, query);
+            increaseMetric(overQuotaCounter, id, query);
 
         Result result;
         if (reject && !dryRun)
@@ -153,12 +159,12 @@ public class RateLimitingSearcher extends Searcher {
         return result;
     }
 
-    private void increaseRejectMetric(String id, Query query) {
+    private void increaseMetric(Counter counter, String id, Query query) {
         String idDimension = query.properties().getString(idDimensionKey, null);
         if (idDimension == null)
-            overQuotaCounter.add(1);
+            counter.add(1);
         else
-            overQuotaCounter.add(1, overQuotaCounter.builder().set(idDimension, id).build());
+            counter.add(1, counter.builder().set(idDimension, id).build());
     }
 
     private double getAllocatedCapacity(String id) {

--- a/container-search/src/test/java/com/yahoo/search/searchers/test/RateLimitingSearcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/test/RateLimitingSearcherTest.java
@@ -76,4 +76,16 @@ public class RateLimitingSearcherTest {
         assertEquals(9, tester.tryRequests("id1"), "'rate' request are available initially");
     }
 
+    @Test
+    void testRequestsMetric() {
+        var tester = new RateLimitingTester(false);
+        tester.executeWasAllowed("id1");
+        tester.executeWasAllowed("id1");
+        assertFalse(tester.executeWasAllowed("id2", 0), "This request is also counted, although rejected");
+
+        Map<Point, UntypedMetric> map = tester.metrics().getSnapshot().getMapForMetric("requests");
+        assertEquals(2, map.get(tester.metrics().point("id", "id1")).getCount());
+        assertEquals(1, map.get(tester.metrics().point("id", "id2")).getCount());
+    }
+
 }

--- a/metrics/src/main/java/ai/vespa/metrics/ContainerMetrics.java
+++ b/metrics/src/main/java/ai/vespa/metrics/ContainerMetrics.java
@@ -151,6 +151,7 @@ public enum ContainerMetrics implements VespaMetrics {
     
     TOTAL_HITS_PER_QUERY("totalhits_per_query", Unit.HIT_PER_QUERY, "The total number of documents found to match queries"),
     EMPTY_RESULTS("empty_results", Unit.OPERATION, "Number of queries matching no documents"),
+    REQUESTS("requests", Unit.OPERATION, "The number of requests processed by the rate limiter"),
     REQUESTS_OVER_QUOTA("requestsOverQuota", Unit.OPERATION, "The number of requests rejected due to exceeding quota"),
     
     RELEVANCE_AT_1("relevance.at_1", Unit.SCORE, "The relevance of hit number 1"),

--- a/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/Vespa9VespaMetricSet.java
@@ -260,6 +260,7 @@ public class Vespa9VespaMetricSet {
         addMetric(metrics, ContainerMetrics.DOCUMENTS_TARGET_TOTAL.count());
         addMetric(metrics, ContainerMetrics.TOTAL_HITS_PER_QUERY, EnumSet.of(sum, count, max, ninety_five_percentile, ninety_nine_percentile));
         addMetric(metrics, ContainerMetrics.EMPTY_RESULTS.rate());
+        addMetric(metrics, ContainerMetrics.REQUESTS, EnumSet.of(rate, count));
         addMetric(metrics, ContainerMetrics.REQUESTS_OVER_QUOTA, EnumSet.of(rate, count));
 
         addMetric(metrics, ContainerMetrics.RELEVANCE_AT_1, EnumSet.of(sum, count));

--- a/metrics/src/main/java/ai/vespa/metrics/set/VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/VespaMetricSet.java
@@ -326,6 +326,7 @@ public class VespaMetricSet {
         addMetric(metrics, ContainerMetrics.QUERY_ITEM_COUNT, EnumSet.of(max, sum, count));
         addMetric(metrics, ContainerMetrics.TOTAL_HITS_PER_QUERY, EnumSet.of(sum, count, max, ninety_five_percentile, ninety_nine_percentile));
         addMetric(metrics, ContainerMetrics.EMPTY_RESULTS.rate());
+        addMetric(metrics, ContainerMetrics.REQUESTS, EnumSet.of(rate, count));
         addMetric(metrics, ContainerMetrics.REQUESTS_OVER_QUOTA, EnumSet.of(rate, count));
 
         addMetric(metrics, ContainerMetrics.RELEVANCE_AT_1, EnumSet.of(sum, count));


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This will make it possible for users to compare how many requests are over quota vs. total requests to the rate limiting searcher.