### PR TITLE
Deprecate batching max delay for ONNX

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/OnnxModelOptions.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/OnnxModelOptions.java
@@ -82,6 +82,18 @@ public record OnnxModelOptions(
         return toBuilder().batchingMaxSize(batchingMaxSize).build();
     }
 
+    /**
+     * @deprecated Retained for compatibility with old config models. ONNX runtimes ignore this value.
+     */
+    @Deprecated(forRemoval = true)
+    public Optional<Duration> batchingMaxDelay() {
+        return batchingMaxDelay;
+    }
+
+    /**
+     * @deprecated Retained for compatibility with old config models. ONNX runtimes ignore this value.
+     */
+    @Deprecated(forRemoval = true)
     public OnnxModelOptions withBatchingMaxDelay(Duration batchingMaxDelay) {
         return toBuilder().batchingMaxDelay(batchingMaxDelay).build();
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/OnnxEmbedder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/OnnxEmbedder.java
@@ -23,6 +23,7 @@ abstract class OnnxEmbedder extends TypedComponent implements OnnxEvaluatorConfi
     final protected OnnxModelOptions onnxModelOptions;
     private final boolean forceDisableOptimization;
 
+    @SuppressWarnings("removal") // Retain deprecated batching max delay in config models for compatibility.
     protected OnnxEmbedder(String className, String bundle, Element xml, DeployState state) {
         super(className, bundle, xml);
         this.forceDisableOptimization = state.featureFlags().forceDisableOnnxModelOptimization();
@@ -82,6 +83,7 @@ abstract class OnnxEmbedder extends TypedComponent implements OnnxEvaluatorConfi
     }
 
     @Override
+    @SuppressWarnings("removal") // Retain deprecated batching max delay in generated config for compatibility.
     public void getConfig(OnnxEvaluatorConfig.Builder builder) {
         onnxModelOptions
                 .executionMode()

--- a/configdefinitions/src/vespa/onnx-evaluator.def
+++ b/configdefinitions/src/vespa/onnx-evaluator.def
@@ -10,12 +10,12 @@ gpuDevice int default=0
 # Controls ONNX graph optimization. Default is on.
 optimizeModel bool default=true
 
-# Controls dynamic batching that combines up to `maxSize` requests within `maxDelayMillis` into a single inference call.
-# This increases throughput at the cost of latency.
+# Controls dynamic batching that combines up to `maxSize` requests into a single inference call.
+# This increases throughput.
 # This is especially effective for generating embeddings during feeding on GPU.
-# `maxDelayMillis` is specified in milliseconds.
 # The default settings disables dynamic batching.
 batching.maxSize int default=1
+# TODO: Deprecated and ignored. Remove in Vespa 9.
 batching.maxDelayMillis long default=0
 
 # Concurrency creates several model instances for concurrent inference.

--- a/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptions.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptions.java
@@ -6,7 +6,6 @@ import net.jpountz.xxhash.XXHashFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -25,7 +24,6 @@ public record OnnxEvaluatorOptions(
         boolean gpuDeviceRequired,
         boolean optimizeModel,
         int batchingMaxSize,
-        Optional<Duration> batchingMaxDelay,
         int numModelInstances,
         Optional<Path> modelConfigOverride,
         int availableProcessors
@@ -65,11 +63,9 @@ public record OnnxEvaluatorOptions(
         if (config.gpuDevice() >= 0) {
             builder.setGpuDevice(config.gpuDevice());
         }
-        
-        if (config.batching().maxDelayMillis() > 0) {
-            builder.setBatchingMaxDelay(Duration.ofMillis(config.batching().maxDelayMillis()));
-        }
-        
+
+        // batching.maxDelayMillis is deprecated and intentionally ignored by both ONNX runtimes.
+
         return builder.build();
     }
 
@@ -102,7 +98,6 @@ public record OnnxEvaluatorOptions(
         private boolean gpuDeviceRequired;
         private boolean optimizeModel;
         private int batchingMaxSize;
-        private Optional<Duration> batchingMaxDelay;
         private int numModelInstances;
         private Optional<Path> modelConfigOverride;
 
@@ -122,7 +117,6 @@ public record OnnxEvaluatorOptions(
             gpuDeviceRequired = false;
             optimizeModel = false;
             batchingMaxSize = 1;
-            batchingMaxDelay = Optional.empty();
             numModelInstances = 1;
             modelConfigOverride = Optional.empty();
             
@@ -137,7 +131,6 @@ public record OnnxEvaluatorOptions(
             this.gpuDeviceRequired = options.gpuDeviceRequired();
             this.optimizeModel = options.optimizeModel();
             this.batchingMaxSize = options.batchingMaxSize();
-            this.batchingMaxDelay = options.batchingMaxDelay;
             this.numModelInstances = options.numModelInstances();
             this.modelConfigOverride = options.modelConfigOverride;
         }
@@ -201,11 +194,6 @@ public record OnnxEvaluatorOptions(
             return this;
         }
         
-        public Builder setBatchingMaxDelay(Duration maxDelay) {
-            this.batchingMaxDelay = Optional.of(maxDelay);
-            return this;
-        }
-
         public Builder setConcurrency(double concurrencyFactor, ConcurrencyFactorType concurrencyFactorType) {
             this.numModelInstances = calculateNumModelInstances(concurrencyFactor, concurrencyFactorType);
             return this;
@@ -235,7 +223,6 @@ public record OnnxEvaluatorOptions(
                     gpuDeviceRequired,
                     optimizeModel,
                     batchingMaxSize,
-                    batchingMaxDelay,
                     numModelInstances,
                     modelConfigOverride,
                     availableProcessors

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -310,10 +310,7 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
                                 .build());
 
         if (options.batchingMaxSize() > 1) {
-            var dynamicBatchingBuilder = ModelConfigOuterClass.ModelDynamicBatching.newBuilder();
-            options.batchingMaxDelay()
-                    .ifPresent(delay -> dynamicBatchingBuilder.setMaxQueueDelayMicroseconds(delay.toMillis() * 1000L));
-            configBuilder.setDynamicBatching(dynamicBatchingBuilder.build());
+            configBuilder.setDynamicBatching(ModelConfigOuterClass.ModelDynamicBatching.newBuilder().build());
         }
 
         // Triton's ONNX Runtime backend enables all optimizations when the graph optimization level is unspecified,

--- a/model-integration/src/test/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptionsTest.java
+++ b/model-integration/src/test/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptionsTest.java
@@ -28,7 +28,6 @@ public class OnnxEvaluatorOptionsTest {
         assertEquals(2, options.intraOpThreads());
         assertEquals(2, options.gpuDeviceNumber());
         assertEquals(1, options.batchingMaxSize());
-        assertTrue(options.batchingMaxDelay().isEmpty());
         assertEquals(1, options.numModelInstances());
         assertTrue(options.modelConfigOverride().isEmpty());
     }
@@ -73,11 +72,13 @@ public class OnnxEvaluatorOptionsTest {
         assertEquals(8, options.intraOpThreads());
         assertEquals(2, options.gpuDeviceNumber());
         assertEquals(10, options.batchingMaxSize());
-        assertTrue(options.batchingMaxDelay().isPresent());
-        assertEquals(50, options.batchingMaxDelay().get().toMillis());
         assertEquals(3, options.numModelInstances());
         assertTrue(options.modelConfigOverride().isPresent());
         assertEquals(
                 "/path/to/config.pbtxt", options.modelConfigOverride().get().toString());
+
+        var configWithDifferentDelay = new OnnxEvaluatorConfig.Builder(config);
+        configWithDifferentDelay.batching.maxDelayMillis(100);
+        assertEquals(options, OnnxEvaluatorOptions.of(configWithDifferentDelay.build()));
     }
 }

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
@@ -17,7 +17,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
@@ -84,7 +83,6 @@ class TritonOnnxRuntimeTest {
     void load_model_with_batching() throws IOException {
         var opts = optsBuilder
                 .setBatchingMaxSize(10)
-                .setBatchingMaxDelay(Duration.ofMillis(100))
                 .build();
         assertLoadModel("src/test/triton/config_with_batching.pbtxt", opts);
     }

--- a/model-integration/src/test/triton/config_with_batching.pbtxt
+++ b/model-integration/src/test/triton/config_with_batching.pbtxt
@@ -6,7 +6,6 @@ instance_group {
   kind: KIND_CPU
 }
 dynamic_batching {
-  max_queue_delay_microseconds: 100000
 }
 parameters {
   key: "enable_mem_arena"


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Motivation:
- Vespa is designed for real-time so artificial delay doesn't fit the rest of pipeline, e.g. dynamic throttling.
- Max delay complicate queue-based autoscaling because it introducing queuing not associated with contention.
- Experiment show no benefit of batching delay

It is still important for remote embedders so it is kept as batching option in services.xml.
@hmusum Please check whether I did deprecation correctly.