### PR TITLE
Vekterli/use unquantized tensor type in distance calculator 2

### DIFF
--- a/searchlib/src/tests/features/closest/closest_test.cpp
+++ b/searchlib/src/tests/features/closest/closest_test.cpp
@@ -12,7 +12,10 @@
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 
+#include <format>
+
 using search::feature_t;
+using search::attribute::DistanceMetric;
 using search::features::ClosestBlueprint;
 using search::features::test::BlueprintFactoryFixture;
 using search::features::test::DistanceClosenessFixture;
@@ -53,20 +56,18 @@ TensorSpec get_spec(RankFixture& f, uint32_t docid) {
 }
 
 struct TestParam {
-    std::string _name;
-    bool        _direct_tensor;
-    uint32_t    _mapped_dimensions;
-    TestParam(std::string name, bool direct_tensor, uint32_t mapped_dimensions)
-        : _name(std::move(name)), _direct_tensor(direct_tensor), _mapped_dimensions(mapped_dimensions) {}
-    ~TestParam();
+    bool     _direct_tensor;
+    bool     _quantized_tensor;
+    uint32_t _mapped_dimensions;
+
+    constexpr TestParam(bool direct_tensor, bool quantized_tensor, uint32_t mapped_dimensions) noexcept
+        : _direct_tensor(direct_tensor), _quantized_tensor(quantized_tensor), _mapped_dimensions(mapped_dimensions) {}
+
+    [[nodiscard]] std::string to_test_name() const {
+        return std::format("{}_{}_mapped_dim{}{}", (_direct_tensor ? "Direct" : "Serialized"), _mapped_dimensions,
+                           (_mapped_dimensions != 1 ? "s" : ""), (_quantized_tensor ? "_quantized" : ""));
+    }
 };
-
-TestParam::~TestParam() = default;
-
-std::ostream& operator<<(std::ostream& os, const TestParam param) {
-    os << param._name;
-    return os;
-}
 
 void assert_setup(std::string field_name, bool exp_setup_result, std::optional<std::string> attr_type_spec,
                   std::optional<std::string> label) {
@@ -94,7 +95,9 @@ class ClosestTest : public ::testing::TestWithParam<TestParam> {
 protected:
     ClosestTest();
     ~ClosestTest() override;
-    bool direct_tensor() const noexcept { return GetParam()._direct_tensor; }
+    [[nodiscard]] uint32_t mapped_dimensions() const noexcept { return GetParam()._mapped_dimensions; }
+    [[nodiscard]] bool direct_tensor() const noexcept { return GetParam()._direct_tensor; }
+    [[nodiscard]] bool quantized_tensor() const noexcept { return GetParam()._quantized_tensor; }
     void assert_closest(const Labels& labels, const std::string& feature_name, const std::string& query_tensor,
                         const TensorSpec& exp_spec);
     void assert_closest(const Labels& labels, const std::string& feature_name,
@@ -108,12 +111,11 @@ ClosestTest::~ClosestTest() = default;
 
 void ClosestTest::assert_closest(const Labels& labels, const std::string& feature_name,
                                  const std::string& query_tensor, const TensorSpec& exp_spec) {
-    uint32_t    mapped_dimensions = GetParam()._mapped_dimensions;
-    RankFixture f(mixed_tensor_types[mapped_dimensions], direct_tensor(), 0, 1, labels, feature_name,
-                  dense_tensor_type + ":" + query_tensor);
+    RankFixture f(mixed_tensor_types[mapped_dimensions()], direct_tensor(), 0, 1, labels, feature_name,
+                  dense_tensor_type + ":" + query_tensor, DistanceMetric::Euclidean, quantized_tensor());
     ASSERT_FALSE(f.failed());
     SCOPED_TRACE(query_tensor);
-    f.set_attribute_tensor(9, doc_tensors[mapped_dimensions]);
+    f.set_attribute_tensor(9, doc_tensors[mapped_dimensions()]);
     EXPECT_EQ(exp_spec, get_spec(f, 9));
 }
 
@@ -123,12 +125,18 @@ void ClosestTest::assert_closest(const Labels& labels, const std::string& featur
     assert_closest(labels, feature_name, "[1,10]", exp_specs[1]);
 }
 
+namespace {
+struct MyPrintTestParams {
+    std::string operator()(const testing::TestParamInfo<TestParam>& info) const { return info.param.to_test_name(); }
+};
+} // namespace
+
 INSTANTIATE_TEST_SUITE_P(ClosestMultiTest, ClosestTest,
-                         testing::Values(TestParam("Serialized_1_mapped_dim", false, 1),
-                                         TestParam("Direct_1_mapped_dim", true, 1),
-                                         TestParam("Serialized_2_mapped_dims", false, 2),
-                                         TestParam("Direct_2_mapped_dims", true, 2)),
-                         testing::PrintToStringParamName());
+                         testing::Values(TestParam(false, false, 1), TestParam(true, false, 1),
+                                         TestParam(false, false, 2), TestParam(true, false, 2),
+                                         TestParam(false, true, 1), TestParam(true, true, 1),
+                                         TestParam(false, true, 2), TestParam(true, true, 2)),
+                         MyPrintTestParams());
 
 TEST_F(ClosestTest, require_that_blueprint_can_be_created_from_factory) {
     BlueprintFactoryFixture f;
@@ -145,8 +153,7 @@ TEST_F(ClosestTest, require_that_no_features_are_dumped) {
 }
 
 TEST_P(ClosestTest, require_that_setup_fails_for_unknown_field) {
-    uint32_t mapped_dimensions = this->GetParam()._mapped_dimensions;
-    assert_setup("random_field", false, mixed_tensor_types[mapped_dimensions], std::nullopt);
+    assert_setup("random_field", false, mixed_tensor_types[mapped_dimensions()], std::nullopt);
 }
 
 TEST_F(ClosestTest, require_that_setup_fails_if_field_type_is_not_attribute) {
@@ -158,8 +165,7 @@ TEST_F(ClosestTest, require_that_setup_fails_if_field_data_type_is_not_tensor) {
 }
 
 TEST_P(ClosestTest, require_that_setup_can_be_done_on_random_label) {
-    uint32_t mapped_dimensions = this->GetParam()._mapped_dimensions;
-    assert_setup("bar", true, mixed_tensor_types[mapped_dimensions], "random_label");
+    assert_setup("bar", true, mixed_tensor_types[mapped_dimensions()], "random_label");
 }
 
 TEST_F(ClosestTest, require_that_setup_fails_if_tensor_type_is_missing) {
@@ -175,29 +181,26 @@ TEST_F(ClosestTest, require_that_setup_fails_if_tensor_type_is_sparse) {
 }
 
 TEST_P(ClosestTest, require_that_no_label_gives_empty_result) {
-    NoLabel  f;
-    uint32_t mapped_dimensions = GetParam()._mapped_dimensions;
-    auto&    no_subspace = no_subspaces[mapped_dimensions];
+    NoLabel f;
+    auto&   no_subspace = no_subspaces[mapped_dimensions()];
     assert_closest(f, field_and_label_feature_name, {no_subspace, no_subspace});
 }
 
 TEST_P(ClosestTest, require_that_unrelated_label_gives_empty_result) {
     SingleLabel f("unrelated", 1);
-    uint32_t    mapped_dimensions = GetParam()._mapped_dimensions;
-    auto&       no_subspace = no_subspaces[mapped_dimensions];
+    auto&       no_subspace = no_subspaces[mapped_dimensions()];
     assert_closest(f, field_and_label_feature_name, {no_subspace, no_subspace});
 }
 
 TEST_P(ClosestTest, closest_using_field_setup) {
-    NoLabel  f;
-    uint32_t mapped_dimensions = GetParam()._mapped_dimensions;
-    assert_closest(f, field_feature_name, {subspace_bs[mapped_dimensions], subspace_as[mapped_dimensions]});
+    NoLabel f;
+    assert_closest(f, field_feature_name, {subspace_bs[mapped_dimensions()], subspace_as[mapped_dimensions()]});
 }
 
 TEST_P(ClosestTest, closest_using_field_and_label_setup) {
     SingleLabel f("nns", 1);
-    uint32_t    mapped_dimensions = GetParam()._mapped_dimensions;
-    assert_closest(f, field_and_label_feature_name, {subspace_bs[mapped_dimensions], subspace_as[mapped_dimensions]});
+    assert_closest(f, field_and_label_feature_name,
+                   {subspace_bs[mapped_dimensions()], subspace_as[mapped_dimensions()]});
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/features/closest/closest_test.cpp
+++ b/searchlib/src/tests/features/closest/closest_test.cpp
@@ -125,6 +125,13 @@ void ClosestTest::assert_closest(const Labels& labels, const std::string& featur
     assert_closest(labels, feature_name, "[1,10]", exp_specs[1]);
 }
 
+// This avoids GTest fallback printing trying to hex-dump all sizeof(TestParam) bytes,
+// which includes _padding bytes_ that by definition are not initialized. This causes
+// Valgrind to scream into the night. See https://github.com/google/googletest/issues/3805
+void PrintTo(const TestParam& p, std::ostream* os) {
+    *os << p.to_test_name();
+}
+
 namespace {
 struct MyPrintTestParams {
     std::string operator()(const testing::TestParamInfo<TestParam>& info) const { return info.param.to_test_name(); }

--- a/searchlib/src/tests/features/nns_closeness/nns_closeness_test.cpp
+++ b/searchlib/src/tests/features/nns_closeness/nns_closeness_test.cpp
@@ -10,6 +10,8 @@
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
+#include <format>
+
 using search::feature_t;
 using namespace search::features::test;
 using namespace search::features;
@@ -24,20 +26,28 @@ const std::string fieldFeatureName("closeness(bar)");
 
 using RankFixture = DistanceClosenessFixture;
 
-class NnsClosenessTest : public ::testing::TestWithParam<uint32_t> {
+using IsQuantized = bool;
+
+class NnsClosenessTest : public ::testing::TestWithParam<IsQuantized> {
 protected:
     NnsClosenessTest();
     ~NnsClosenessTest() override;
-    void expect_raw_score_calculated_on_the_fly(RankFixture& f);
+
+    [[nodiscard]] bool is_quantized() const noexcept { return GetParam(); }
 };
 
-NnsClosenessTest::NnsClosenessTest() : ::testing::TestWithParam<uint32_t>() {
-}
-
+NnsClosenessTest::NnsClosenessTest() = default;
 NnsClosenessTest::~NnsClosenessTest() = default;
 
-INSTANTIATE_TEST_SUITE_P(NnsClosenessMultiTest, NnsClosenessTest, testing::Values(0, 1, 2),
-                         testing::PrintToStringParamName());
+namespace {
+struct MyPrintTestParams {
+    std::string operator()(const testing::TestParamInfo<IsQuantized>& info) const {
+        return info.param ? "quantized" : "unquantized";
+    }
+};
+} // namespace
+
+INSTANTIATE_TEST_SUITE_P(NnsClosenessQuantTest, NnsClosenessTest, testing::Bool(), MyPrintTestParams());
 
 TEST_F(NnsClosenessTest, require_that_blueprint_can_be_created_from_factory) {
     BlueprintFactoryFixture f;
@@ -122,6 +132,29 @@ TEST_F(NnsClosenessTest, require_that_stale_data_is_ignored) {
     EXPECT_EQ(0, f2.getScore(10));
 }
 
+TEST_P(NnsClosenessTest, can_return_negative_values_with_dotproduct_distance_metric) {
+    NoLabel     f1;
+    RankFixture f2(0, 2, f1, fieldFeatureName, "tensor(x[2]):[2,3]", DistanceMetric::Dotproduct, is_quantized());
+    ASSERT_FALSE(f2.failed());
+
+    f2.set_bar_rawscore(0, 7, 5.0);
+    f2.set_bar_rawscore(1, 8, -5.0);
+    f2.set_attribute_tensor(9, TensorSpec::from_expr("tensor(x[2]):[4,5]"));
+    f2.set_attribute_tensor(10, TensorSpec::from_expr("tensor(x[2]):[-4,-5]"));
+
+    // For docids 9 and 10 the raw score is calculated on the fly
+    // using a distance calculator over the attribute and query tensors.
+    EXPECT_EQ(5.0, f2.getScore(7));
+    EXPECT_EQ(-5.0, f2.getScore(8));
+    if (!is_quantized()) {
+        EXPECT_EQ(23.0, f2.getScore(9));
+        EXPECT_EQ(-23.0, f2.getScore(10));
+    } else {
+        EXPECT_NEAR(23.0, f2.getScore(9), 0.35);
+        EXPECT_NEAR(-23.0, f2.getScore(10), 0.35);
+    }
+}
+
 namespace {
 
 const std::vector<TensorSpec> doc9_tensor{
@@ -141,51 +174,64 @@ const std::vector<TensorSpec> doc10_tensor{
 const std::vector<std::string> tensor_types{"tensor(x[2])", "tensor(a{},x[2])", "tensor(a{},b{},x[2])"};
 } // namespace
 
-void NnsClosenessTest::expect_raw_score_calculated_on_the_fly(RankFixture& f) {
+using MappedDimsAndQuantized = std::tuple<uint32_t, bool>;
+
+class NnsClosenessMultiTest : public ::testing::TestWithParam<MappedDimsAndQuantized> {
+protected:
+    NnsClosenessMultiTest();
+    ~NnsClosenessMultiTest() override;
+    void expect_raw_score_calculated_on_the_fly(RankFixture& f);
+};
+
+NnsClosenessMultiTest::NnsClosenessMultiTest() = default;
+NnsClosenessMultiTest::~NnsClosenessMultiTest() = default;
+
+void NnsClosenessMultiTest::expect_raw_score_calculated_on_the_fly(RankFixture& f) {
     f.setBarScore(0, 8, 13.0);
-    uint32_t mapped_dimensions = GetParam();
+    const auto [mapped_dimensions, quantized] = GetParam();
     f.set_attribute_tensor(9, doc9_tensor[mapped_dimensions]);
     f.set_attribute_tensor(10, doc10_tensor[mapped_dimensions]);
 
     // For docids 9 and 10 the raw score is calculated on the fly
     // using a distance calculator over the attribute and query tensors.
     EXPECT_EQ(1 / (1 + 13.0), f.getScore(8));
-    EXPECT_EQ(1 / (1 + (5.0 - 3.0)), f.getScore(9));
-    EXPECT_EQ(1 / (1 + (7.0 - 3.0)), f.getScore(10));
+    if (!quantized) {
+        EXPECT_EQ(1 / (1 + (5.0 - 3.0)), f.getScore(9));
+        EXPECT_EQ(1 / (1 + (7.0 - 3.0)), f.getScore(10));
+    } else {
+        EXPECT_NEAR(1 / (1 + (5.0 - 3.0)), f.getScore(9), 0.1);
+        EXPECT_NEAR(1 / (1 + (7.0 - 3.0)), f.getScore(10), 0.1);
+    }
 }
 
-TEST_P(NnsClosenessTest, raw_score_is_calculated_on_the_fly_using_field_setup) {
-    NoLabel     f1;
-    uint32_t    mapped_dimensions = GetParam();
-    RankFixture f2(tensor_types[mapped_dimensions], false, 0, 1, f1, fieldFeatureName, "tensor(x[2]):[3,11]");
+TEST_P(NnsClosenessMultiTest, raw_score_is_calculated_on_the_fly_using_field_setup) {
+    NoLabel f1;
+    const auto [mapped_dimensions, quantized] = GetParam();
+    RankFixture f2(tensor_types[mapped_dimensions], false, 0, 1, f1, fieldFeatureName, "tensor(x[2]):[3,11]",
+                   DistanceMetric::Euclidean, quantized);
     ASSERT_FALSE(f2.failed());
     expect_raw_score_calculated_on_the_fly(f2);
 }
 
-TEST_P(NnsClosenessTest, raw_score_is_calculated_on_the_fly_using_label_setup) {
+TEST_P(NnsClosenessMultiTest, raw_score_is_calculated_on_the_fly_using_label_setup) {
     SingleLabel f1("nns", 1);
-    uint32_t    mapped_dimensions = GetParam();
-    RankFixture f2(tensor_types[mapped_dimensions], false, 0, 1, f1, labelFeatureName, "tensor(x[2]):[3,11]");
+    const auto [mapped_dimensions, quantized] = GetParam();
+    RankFixture f2(tensor_types[mapped_dimensions], false, 0, 1, f1, labelFeatureName, "tensor(x[2]):[3,11]",
+                   DistanceMetric::Euclidean, quantized);
     ASSERT_FALSE(f2.failed());
     expect_raw_score_calculated_on_the_fly(f2);
 }
 
-TEST_F(NnsClosenessTest, can_return_negative_values_with_dotproduct_distance_metric) {
-    NoLabel     f1;
-    RankFixture f2(0, 2, f1, fieldFeatureName, "tensor(x[2]):[2,3]", DistanceMetric::Dotproduct);
-    ASSERT_FALSE(f2.failed());
+namespace {
+struct MyPrintMultiTestParams {
+    std::string operator()(const testing::TestParamInfo<MappedDimsAndQuantized>& info) const {
+        return std::format("{}_mapped_dims{}", std::get<0>(info.param), std::get<1>(info.param) ? "_quantized" : "");
+    }
+};
+} // namespace
 
-    f2.set_bar_rawscore(0, 7, 5.0);
-    f2.set_bar_rawscore(1, 8, -5.0);
-    f2.set_attribute_tensor(9, TensorSpec::from_expr("tensor(x[2]):[4,5]"));
-    f2.set_attribute_tensor(10, TensorSpec::from_expr("tensor(x[2]):[-4,-5]"));
-
-    // For docids 9 and 10 the raw score is calculated on the fly
-    // using a distance calculator over the attribute and query tensors.
-    EXPECT_EQ(5.0, f2.getScore(7));
-    EXPECT_EQ(-5.0, f2.getScore(8));
-    EXPECT_EQ(23.0, f2.getScore(9));
-    EXPECT_EQ(-23.0, f2.getScore(10));
-}
+// Instantiates with cartesian product of mapped dims {0, 1, 2} x quantization {true, false}
+INSTANTIATE_TEST_SUITE_P(NnsClosenessMultiDimAndQuantTest, NnsClosenessMultiTest,
+                         testing::Combine(testing::Values(0, 1, 2), testing::Bool()), MyPrintMultiTestParams());
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/vespa/searchlib/tensor/distance_calculator.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/distance_calculator.cpp
@@ -56,7 +56,7 @@ DistanceCalculator::make_with_validation(const search::attribute::IAttributeVect
     if (attr_tensor == nullptr) {
         throw IllegalArgumentException("Attribute is not a tensor");
     }
-    const auto& at_type = attr_tensor->getTensorType();
+    const auto& at_type = attr_tensor->unquantized_tensor_type();
     if (!supported_tensor_type(at_type)) {
         throw IllegalArgumentException(
             make_string("Attribute tensor type (%s) is not supported", at_type.to_spec().c_str()));

--- a/searchlib/src/vespa/searchlib/test/features/distance_closeness_fixture.cpp
+++ b/searchlib/src/vespa/searchlib/test/features/distance_closeness_fixture.cpp
@@ -10,6 +10,7 @@
 #include <vespa/searchlib/tensor/dense_tensor_attribute.h>
 #include <vespa/searchlib/tensor/direct_tensor_attribute.h>
 #include <vespa/searchlib/tensor/serialized_fast_value_attribute.h>
+#include <vespa/searchlib/test/test_quantization_params.h>
 #include <vespa/vespalib/objects/nbostream.h>
 
 using search::attribute::BasicType;
@@ -33,9 +34,14 @@ namespace {
 
 std::shared_ptr<TensorAttribute> create_tensor_attribute(const std::string& attr_name, const std::string& tensor_type,
                                                          DistanceMetric distance_metric, bool direct_tensor,
-                                                         uint32_t docid_limit) {
+                                                         bool quantized_tensor, uint32_t docid_limit) {
     Config cfg(BasicType::TENSOR, CollectionType::SINGLE);
-    cfg.setTensorType(ValueType::from_spec(tensor_type));
+    if (!quantized_tensor) {
+        cfg.setTensorType(ValueType::from_spec(tensor_type));
+    } else {
+        cfg.set_tensor_type_with_quantization(ValueType::from_spec(tensor_type),
+                                              ::search::test::mse_4bit_quantization_params());
+    }
     cfg.set_distance_metric(distance_metric);
     std::shared_ptr<TensorAttribute> result;
     if (cfg.tensorType().is_dense()) {
@@ -57,15 +63,15 @@ FeatureDumpFixture::~FeatureDumpFixture() = default;
 
 DistanceClosenessFixture::DistanceClosenessFixture(size_t fooCnt, size_t barCnt, const Labels& labels,
                                                    const std::string& featureName, const std::string& query_tensor,
-                                                   DistanceMetric distance_metric)
+                                                   DistanceMetric distance_metric, bool quantized_tensor)
     : DistanceClosenessFixture("tensor(x[2])", false, fooCnt, barCnt, labels, featureName, query_tensor,
-                               distance_metric) {
+                               distance_metric, quantized_tensor) {
 }
 
 DistanceClosenessFixture::DistanceClosenessFixture(const std::string& tensor_type, bool direct_tensor, size_t fooCnt,
                                                    size_t barCnt, const Labels& labels,
                                                    const std::string& featureName, const std::string& query_tensor,
-                                                   DistanceMetric distance_metric)
+                                                   DistanceMetric distance_metric, bool quantized_tensor)
     : queryEnv(&indexEnv),
       rankSetup(factory, indexEnv),
       mdl(),
@@ -75,6 +81,7 @@ DistanceClosenessFixture::DistanceClosenessFixture(const std::string& tensor_typ
       barHandles(),
       tensor_attr(),
       docid_limit(11),
+      _quantized(quantized_tensor),
       _failed(false) {
     for (size_t i = 0; i < fooCnt; ++i) {
         uint32_t fieldId = indexEnv.getFieldByName("foo")->id();
@@ -96,7 +103,8 @@ DistanceClosenessFixture::DistanceClosenessFixture(const std::string& tensor_typ
         queryEnv.getTerms().push_back(term);
     }
     if (!query_tensor.empty()) {
-        tensor_attr = create_tensor_attribute("bar", tensor_type, distance_metric, direct_tensor, docid_limit);
+        tensor_attr = create_tensor_attribute("bar", tensor_type, distance_metric, direct_tensor, quantized_tensor,
+                                              docid_limit);
         indexEnv.getAttributeMap().add(tensor_attr);
         search::fef::indexproperties::type::Attribute::set(indexEnv.getProperties(), "bar", tensor_type);
         set_query_tensor("qbar", "tensor(x[2])", TensorSpec::from_expr(query_tensor));
@@ -118,7 +126,11 @@ DistanceClosenessFixture::~DistanceClosenessFixture() = default;
 
 void DistanceClosenessFixture::set_attribute_tensor(uint32_t docid, const vespalib::eval::TensorSpec& spec) {
     auto tensor = SimpleValue::from_spec(spec);
-    tensor_attr->setTensor(docid, *tensor);
+    if (!_quantized) {
+        tensor_attr->setTensor(docid, *tensor);
+    } else {
+        tensor_attr->setTensor(docid, *tensor_attr->make_quantizer()->quantize(*tensor));
+    }
     tensor_attr->commit();
 }
 

--- a/searchlib/src/vespa/searchlib/test/features/distance_closeness_fixture.h
+++ b/searchlib/src/vespa/searchlib/test/features/distance_closeness_fixture.h
@@ -57,15 +57,17 @@ struct DistanceClosenessFixture : BlueprintFactoryFixture, IndexEnvironmentFixtu
     std::vector<TermFieldHandle>                     barHandles;
     std::shared_ptr<search::tensor::TensorAttribute> tensor_attr;
     uint32_t                                         docid_limit;
+    bool                                             _quantized;
     bool                                             _failed;
-    DistanceClosenessFixture(
-        size_t fooCnt, size_t barCnt, const Labels& labels, const std::string& featureName,
-        const std::string&                query_tensor = "",
-        search::attribute::DistanceMetric distance_metric = search::attribute::DistanceMetric::Euclidean);
-    DistanceClosenessFixture(
-        const std::string& tensor_type, bool direct_tensor, size_t fooCnt, size_t barCnt, const Labels& labels,
-        const std::string& featureName, const std::string& query_tensor = "",
-        search::attribute::DistanceMetric distance_metric = search::attribute::DistanceMetric::Euclidean);
+    DistanceClosenessFixture(size_t fooCnt, size_t barCnt, const Labels& labels, const std::string& featureName,
+                             const std::string&        query_tensor = "",
+                             attribute::DistanceMetric distance_metric = attribute::DistanceMetric::Euclidean,
+                             bool                      quantized_tensor = false);
+    DistanceClosenessFixture(const std::string& tensor_type, bool direct_tensor, size_t fooCnt, size_t barCnt,
+                             const Labels& labels, const std::string& featureName,
+                             const std::string&        query_tensor = "",
+                             attribute::DistanceMetric distance_metric = attribute::DistanceMetric::Euclidean,
+                             bool                      quantized_tensor = false);
     ~DistanceClosenessFixture();
     void set_attribute_tensor(uint32_t docid, const vespalib::eval::TensorSpec& spec);
     void set_query_tensor(const std::string& query_tensor_name, const std::string& tensor_type,


### PR DESCRIPTION
@arnej27959 please review. First commit is the same as #37732. The extra commit 851c01a19e1819fb5fc8e9619cb66552d0e309a3 works around some GTest silliness that makes Valgrind unhappy. I presume this was previously not an issue due to implicit ostream overload selection magic for `TestParam` printing... :confounded: