### PR TITLE
Add support for int values to CreateFastMapSearch

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
@@ -15,10 +15,12 @@ import com.yahoo.searchlib.document.FastMapSearch;
 import com.yahoo.vespa.indexinglanguage.expressions.AttributeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.CatExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ConstantExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.ExcessHex8EncodeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
 import com.yahoo.vespa.indexinglanguage.expressions.ForEachExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.GetFieldExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.InputExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.ParenthesisExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ScriptExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.StatementExpression;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
@@ -85,17 +87,24 @@ public class CreateFastMapSearch extends Processor {
                                       "Incompatible map attribute '" + fieldName + "' already created.");
         }
 
+        // Data type of inputField is guaranteed to be a MapDataType by shouldCreateFastMapAttribute
+        var valueType = ((MapDataType)inputField.getDataType()).getValueType();
+
         SDField field = new SDField(repo, fieldName, DataType.getArray(DataType.STRING));
         Attribute attribute = new Attribute(fieldName, Attribute.Type.STRING, Attribute.CollectionType.ARRAY);
         attribute.setFastSearch(true);
         field.addAttribute(attribute);
-        field.setIndexingScript(schema.getName(), keyValueScript(inputField, fieldName));
+        field.setIndexingScript(schema.getName(), keyValueScript(inputField, fieldName, valueType));
         field.setInternalField(true);
         return field;
     }
 
-    /** Builds "input mapField | for_each { get_field $key . separator . get_field $value } | attribute". */
-    private static ScriptExpression keyValueScript(SDField inputField, String fieldName) {
+    /**
+     * Builds "input mapField | for_each { get_field $key . separator . VALUE_EXP } | attribute",
+     * where VALUE_EXP is "(get_field $value | exhex8encode)" if the value type is int
+     * and "get_field $value" otherwise (if the value type is string).
+     * */
+    private static ScriptExpression keyValueScript(SDField inputField, String fieldName, DataType valueType) {
         return new ScriptExpression(
                 new StatementExpression(
                         new InputExpression(inputField.getName()),
@@ -106,8 +115,22 @@ public class CreateFastMapSearch extends Processor {
                                         new CatExpression(
                                                 new GetFieldExpression("$key"),
                                                 new ConstantExpression(new StringFieldValue(FastMapSearch.keyValueSeparator())),
-                                                new GetFieldExpression("$value")) })),
+                                                valueExpression(valueType)) })),
                         new AttributeExpression(fieldName)));
+    }
+
+    /**
+     * Builds "(get_field $value | exhex8encode)" if the value type is int and
+     * "get_field $value" otherwise.
+     * */
+    private static Expression valueExpression(DataType valueType) {
+        var field = new GetFieldExpression("$value");
+
+        if (valueType == DataType.INT) {
+            return new ParenthesisExpression(new StatementExpression(field, new ExcessHex8EncodeExpression()));
+        } else { // DataType.STRING
+            return field;
+        }
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
@@ -3,6 +3,7 @@ package com.yahoo.schema.processing;
 
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.document.DataType;
+import com.yahoo.language.process.ProcessingException;
 import com.yahoo.schema.ApplicationBuilder;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.document.Attribute;
@@ -24,52 +25,66 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author johsol
  */
 public class CreateFastMapSearchTest {
+    private static String[] supportedValueTypes = { "string", "int" };
 
     @Test
     void requireKeyValueFieldIsCreatedForFastSearchMap() throws ParseException {
-        var schema = build(fastSearchMap("map<string, string>"));
+        for (String valueType : supportedValueTypes) {
+            var schema = build(fastSearchMap("foo", "string", valueType));
 
-        SDField field = schema.getConcreteField("foo$keyvalue");
-        assertNotNull(field, "Expected a synthetic key-value field");
-        assertEquals(DataType.getArray(DataType.STRING), field.getDataType());
-    }
-
-    @Test
-    void requireKeyValueAttributeIsAFastSearchStringArray() throws ParseException {
-        var schema = build(fastSearchMap("map<string, string>"));
-
-        Attribute attribute = schema.getConcreteField("foo$keyvalue").getAttributes().get("foo$keyvalue");
-        assertNotNull(attribute);
-        assertEquals(Attribute.Type.STRING, attribute.getType());
-        assertEquals(Attribute.CollectionType.ARRAY, attribute.getCollectionType());
-        assertTrue(attribute.isFastSearch());
-    }
-
-    @Test
-    void requireKeyValueFieldIsCreatedForIntKeysAndValues() throws ParseException {
-        for (String type : new String[] { "map<int, string>", "map<string, int>", "map<int, int>" }) {
-            var schema = build(fastSearchMap(type));
-            assertNotNull(schema.getConcreteField("foo$keyvalue"), "Expected key-value field for " + type);
+            SDField field = schema.getConcreteField("foo$keyvalue");
+            assertNotNull(field, "Expected a synthetic key-value field");
+            assertEquals(DataType.getArray(DataType.STRING), field.getDataType());
         }
     }
 
     @Test
-    void requireKeyValueFieldIsAddedToTheInternalFieldSet() throws ParseException {
-        var schema = build(fastSearchMap("map<string, string>"));
+    void requireKeyValueAttributeIsAFastSearchStringArray() throws ParseException {
+        for (String valueType : supportedValueTypes) {
+            var schema = build(fastSearchMap("foo", "string", valueType));
 
-        var internal = schema.fieldSets().builtInFieldSets().get(BuiltInFieldSets.INTERNAL_FIELDSET_NAME);
-        assertNotNull(internal);
-        assertTrue(internal.getFieldNames().contains("foo$keyvalue"),
-                   "Expected foo$keyvalue in " + internal.getFieldNames());
+            Attribute attribute = schema.getConcreteField("foo$keyvalue").getAttributes().get("foo$keyvalue");
+            assertNotNull(attribute);
+            assertEquals(Attribute.Type.STRING, attribute.getType());
+            assertEquals(Attribute.CollectionType.ARRAY, attribute.getCollectionType());
+            assertTrue(attribute.isFastSearch());
+        }
+    }
+
+    @Test
+    void requireKeyValueAttributeHasCorrectIndexingScriptForStringValues() throws ParseException {
+        var schema = build(fastSearchMap("foo", "string", "string"));
+
+        String script = schema.getConcreteField("foo$keyvalue").getIndexingScript().toString();
+        assertEquals("{ input foo | for_each { get_field $key . \"\\x7f\" . get_field $value } | attribute \"foo$keyvalue\"; }", script);
+    }
+
+    @Test
+    void requireKeyValueAttributeHasCorrectIndexingScriptForIntValues() throws ParseException {
+        var schema = build(fastSearchMap("foo", "string", "int"));
+
+        String script = schema.getConcreteField("foo$keyvalue").getIndexingScript().toString();
+        assertEquals("{ input foo | for_each { get_field $key . \"\\x7f\" . (get_field $value | exhex8encode) } | attribute \"foo$keyvalue\"; }", script);
+    }
+
+    @Test
+    void requireKeyValueFieldIsAddedToTheInternalFieldSet() throws ParseException {
+        for (String valueType : supportedValueTypes) {
+            var schema = build(fastSearchMap("foo", "string", valueType));
+
+            var internal = schema.fieldSets().builtInFieldSets().get(BuiltInFieldSets.INTERNAL_FIELDSET_NAME);
+            assertNotNull(internal);
+            assertTrue(internal.getFieldNames().contains("foo$keyvalue"),
+                    "Expected foo$keyvalue in " + internal.getFieldNames());
+        }
     }
 
     @Test
     void requireNoKeyValueFieldWithoutFastSearch() throws ParseException {
-        var schema = build(joinLines("field foo type map<string, string> {",
-                                     "  indexing: summary",
-                                     "}"));
-
-        assertNull(schema.getConcreteField("foo$keyvalue"));
+        for (String valueType : supportedValueTypes) {
+            var schema = build(nonFastSearchMap("foo", "string", valueType));
+            assertNull(schema.getConcreteField("foo$keyvalue"));
+        }
     }
 
     @Test
@@ -83,21 +98,15 @@ public class CreateFastMapSearchTest {
 
     @Test
     void requireOneKeyValueFieldPerFastSearchMap() throws ParseException {
-        var schema = build(joinLines("field foo type map<string, string> {",
-                                     "  indexing: summary",
-                                     "  map: fast-search",
-                                     "}",
-                                     "field bar type map<string, string> {",
-                                     "  indexing: summary",
-                                     "  map: fast-search",
-                                     "}",
-                                     "field baz type map<string, string> {",
-                                     "  indexing: summary",
-                                     "}"));
+        for (String valueType : supportedValueTypes) {
+            var schema = build(joinLines(fastSearchMap("foo", "string", valueType),
+                                         fastSearchMap("bar", "string", valueType),
+                                         nonFastSearchMap("baz", "string", valueType)));
 
-        assertNotNull(schema.getConcreteField("foo$keyvalue"));
-        assertNotNull(schema.getConcreteField("bar$keyvalue"));
-        assertNull(schema.getConcreteField("baz$keyvalue"));
+            assertNotNull(schema.getConcreteField("foo$keyvalue"));
+            assertNotNull(schema.getConcreteField("bar$keyvalue"));
+            assertNull(schema.getConcreteField("baz$keyvalue"));
+        }
     }
 
     /**
@@ -112,16 +121,15 @@ public class CreateFastMapSearchTest {
 
     @Test
     void requireErrorWhenAnotherFieldCreatesTheKeyValueAttribute() {
-        var exception = assertThrows(IllegalArgumentException.class,
-                                     () -> build(joinLines("field foo type map<string, string> {",
-                                                           "  indexing: summary",
-                                                           "  map: fast-search",
-                                                           "}",
-                                                           "field other type array<string> {",
-                                                           "  indexing: attribute \"foo$keyvalue\"",
-                                                           "}")));
-        assertTrue(exception.getMessage().contains("Incompatible map attribute 'foo$keyvalue' already created"),
-                   "Unexpected message: " + exception.getMessage());
+        for (String valueType : supportedValueTypes) {
+            var exception = assertThrows(IllegalArgumentException.class,
+                    () -> build(joinLines(fastSearchMap("foo", "string", valueType),
+                                          "field other type array<string> {",
+                                          "  indexing: attribute \"foo$keyvalue\"",
+                                          "}")));
+            assertTrue(exception.getMessage().contains("Incompatible map attribute 'foo$keyvalue' already created"),
+                    "Unexpected message: " + exception.getMessage());
+        }
     }
 
     /**
@@ -130,39 +138,42 @@ public class CreateFastMapSearchTest {
      */
     @Test
     void requireInheritedFastSearchMapIsNotDerivedAgain() throws ParseException {
-        var builder = new ApplicationBuilder(new TestProperties().fastMapSearch(true));
-        builder.addSchema(joinLines("schema parent {",
-                                    "  document parent {",
-                                    fastSearchMap("foo", "string"),
-                                    "  }",
-                                    "}"));
-        builder.addSchema(joinLines("schema child inherits parent {",
-                                    "  document child inherits parent {",
-                                    fastSearchMap("bar", "string"),
-                                    "  }",
-                                    "}"));
-        builder.build(true);
-        Schema parent = builder.getSchema("parent");
-        Schema child = builder.getSchema("child");
+        for (String valueType : supportedValueTypes) {
+            var builder = new ApplicationBuilder(new TestProperties().fastMapSearch(true));
+            builder.addSchema(joinLines("schema parent {",
+                                        "  document parent {",
+                                        fastSearchMap("foo", "string", valueType),
+                                        "  }",
+                                        "}"));
+            builder.addSchema(joinLines("schema child inherits parent {",
+                                        "  document child inherits parent {",
+                                        fastSearchMap("bar", "string", valueType),
+                                        "  }",
+                                        "}"));
+            builder.build(true);
+            Schema parent = builder.getSchema("parent");
+            Schema child = builder.getSchema("child");
 
-        // The inherited key-value field is the parent's, not a copy made by the child. A copy would
-        // shadow the parent's field, since own extra fields are looked up before inherited ones.
-        SDField inherited = child.getConcreteField("foo$keyvalue");
-        assertNotNull(inherited, "Expected child to see the inherited key-value field");
-        assertSame(parent.getConcreteField("foo$keyvalue"), inherited);
+            // The inherited key-value field is the parent's, not a copy made by the child. A copy would
+            // shadow the parent's field, since own extra fields are looked up before inherited ones.
+            SDField inherited = child.getConcreteField("foo$keyvalue");
+            assertNotNull(inherited, "Expected child to see the inherited key-value field");
+            assertSame(parent.getConcreteField("foo$keyvalue"), inherited);
 
-        // The child's own fast-search map is still derived, and only in the child.
-        assertNotNull(child.getConcreteField("bar$keyvalue"), "Expected key-value field for the child's own map");
-        assertNull(parent.getConcreteField("bar$keyvalue"));
+            // The child's own fast-search map is still derived, and only in the child.
+            assertNotNull(child.getConcreteField("bar$keyvalue"), "Expected key-value field for the child's own map");
+            assertNull(parent.getConcreteField("bar$keyvalue"));
+        }
     }
-    private static String fastSearchMap(String name, String valueType) {
-        return joinLines("field " + name + " type map<string," + valueType + "> {",
-                         "  indexing: summary",
-                         "  map: fast-search",
-                         "}");
+
+    private static String nonFastSearchMap(String name, String keyType, String valueType) {
+        return joinLines("field " + name + " type map<" + keyType + ", " + valueType + "> {",
+                "  indexing: summary",
+                "}");
     }
-    private static String fastSearchMap(String type) {
-        return joinLines("field foo type " + type + " {",
+
+    private static String fastSearchMap(String name, String keyType, String valueType) {
+        return joinLines("field " + name + " type map<" + keyType + ", " + valueType + "> {",
                          "  indexing: summary",
                          "  map: fast-search",
                          "}");

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExcessHex8EncodeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExcessHex8EncodeExpression.java
@@ -1,0 +1,49 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage.expressions;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.datatypes.IntegerFieldValue;
+import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.text.Text;
+
+/**
+ * Converts an int into its 8-hex-digit string excess representation such that
+ * the string sort in the same order as the int values, cf. {@link Text#toExcessHex8(int)}.
+ *
+ * @author boeker
+ */
+public final class ExcessHex8EncodeExpression extends Expression {
+
+    @Override
+    public DataType setInputType(DataType inputType, TypeContext context) {
+        super.setInputType(inputType, DataType.INT, context);
+        return DataType.STRING;
+    }
+
+    @Override
+    public DataType setOutputType(DataType outputType, TypeContext context) {
+        super.setOutputType(DataType.STRING, outputType, null, context);
+        return DataType.INT;
+    }
+
+    @Override
+    protected void doExecute(ExecutionContext context) {
+        int input = ((IntegerFieldValue) context.getCurrentValue()).getInteger();
+        context.setCurrentValue(new StringFieldValue(Text.toExcessHex8(input)));
+    }
+
+    @Override
+    public String toString() { return "exhex8encode"; }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ExcessHex8EncodeExpression)) return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+}

--- a/indexinglanguage/src/main/javacc/IndexingParser.jj
+++ b/indexinglanguage/src/main/javacc/IndexingParser.jj
@@ -52,6 +52,7 @@ import com.yahoo.vespa.indexinglanguage.expressions.DocumentIdExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.EchoExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.EmbedExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExactExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.ExcessHex8EncodeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExecutionValueExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExpressionList;
@@ -260,6 +261,7 @@ TOKEN :
     <EMBED: "embed"> |
     <GENERATE: "generate"> |
     <EXACT: "exact"> |
+    <EXHEX8_ENCODE: "exhex8encode"> |
     <FLATTEN: "flatten"> |
     <FOR_EACH: "for_each"> |
     <GET_FIELD: "get_field"> |
@@ -417,6 +419,7 @@ Expression value() :
       val = generateExp()           |
       val = exactExp()              |
       val = executionValueExp()     |
+      val = exHex8EncodeExp()       |
       val = flattenExp()            |
       val = forEachExp()            |
       val = getFieldExp()           |
@@ -556,6 +559,12 @@ Expression exactExp() :
 {
     ( <EXACT> [ config = annotatorConfig() ] )
     { return new ExactExpression(config); }
+}
+
+Expression exHex8EncodeExp() : { }
+{
+    ( <EXHEX8_ENCODE> )
+    { return new ExcessHex8EncodeExpression(); }
 }
 
 Expression flattenExp() : { }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExcessHex8EncodeTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExcessHex8EncodeTestCase.java
@@ -1,0 +1,52 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage.expressions;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.datatypes.FieldValue;
+import com.yahoo.document.datatypes.IntegerFieldValue;
+import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
+import org.junit.Test;
+
+import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
+import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author boeker
+ */
+public class ExcessHex8EncodeTestCase {
+
+    @Test
+    public void requireThatHashCodeAndEqualsAreImplemented() {
+        Expression exp = new ExcessHex8EncodeExpression();
+        assertFalse(exp.equals(new Object()));
+        assertEquals(exp, new ExcessHex8EncodeExpression());
+        assertEquals(exp.hashCode(), new ExcessHex8EncodeExpression().hashCode());
+    }
+
+    @Test
+    public void requireThatExpressionCanBeVerified() {
+        Expression exp = new ExcessHex8EncodeExpression();
+        assertVerify(DataType.INT, exp, DataType.STRING);
+        assertVerifyThrows("Invalid expression 'exhex8encode': Expected int input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'exhex8encode': Expected int input, got string", DataType.STRING, exp);
+    }
+
+    @Test
+    public void requireThatInputIsEncoded() {
+        int[] values = new int[] { Integer.MIN_VALUE, -1, 0, 1, Integer.MAX_VALUE };
+        String[] strings = new String[] { "00000000", "7fffffff", "80000000", "80000001", "ffffffff" };
+        for (int i = 0; i < values.length; i++) {
+            ExecutionContext ctx = new ExecutionContext(new SimpleTestAdapter());
+            ctx.setCurrentValue(new IntegerFieldValue(values[i]));
+            new ExcessHex8EncodeExpression().execute(ctx);
+
+            FieldValue val = ctx.getCurrentValue();
+            assertTrue(val instanceof StringFieldValue);
+            assertEquals(strings[i], ((StringFieldValue)val).getString());
+        }
+    }
+}


### PR DESCRIPTION
Does so by adding an `ExcessHex8EncodeExpression` (used via `exhex8encode` in the indexing language). For `long`, we would need an `ExcessHex16EncodeExpression`. Or maybe we want an `ExcessHexEncodeExpression` that supports both depending on the type? But that could be quite confusing, is probably better to be explicit here about the length.