### PR TITLE
FastMapSearcher: refactor, add support for int

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
@@ -39,13 +39,11 @@ public class FastMapSearcher extends Searcher {
         return execution.search(query);
     }
 
-    /** Package-private for unit tests. */
-    class Rewriter {
+    private class Rewriter {
 
         private boolean hasRewritten;
 
-        /** Package-private for unit tests. */
-        Rewriter() {
+        private Rewriter() {
             hasRewritten = false;
         }
 
@@ -63,10 +61,8 @@ public class FastMapSearcher extends Searcher {
 
         /**
          * Rewrite sameElement for fast map search.
-         *
-         * Package-private for unit testing.
          */
-        Item rewriteFastMapSearchVisit(Item item, SchemaInfo.Session session) {
+        private Item rewriteFastMapSearchVisit(Item item, SchemaInfo.Session session) {
             if (item == null) {
                 return null;
             }

--- a/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
@@ -196,10 +196,7 @@ public class FastMapSearcher extends Searcher {
     /** Returns the map type of the given field if it has fast map search enabled, and null otherwise. */
     private static Field.MapFieldType fastMapSearchType(String fieldName, SchemaInfo.Session session) {
         FieldInfo info = session.fieldInfo(fieldName).orElse(null);
-        if (info == null || !info.hasFastMapSearch()) {
-            return null;
-        }
-        if (info.type() instanceof Field.MapFieldType mapType) {
+        if (info != null && info.hasFastMapSearch() && info.type() instanceof Field.MapFieldType mapType) {
             return mapType;
         }
         return null;

--- a/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
@@ -41,11 +41,7 @@ public class FastMapSearcher extends Searcher {
 
     private class Rewriter {
 
-        private boolean hasRewritten;
-
-        private Rewriter() {
-            hasRewritten = false;
-        }
+        private boolean hasRewritten = false;
 
         /** Entry point for rewriting a query */
         private void rewriteFastMapSearch(Query query, SchemaInfo.Session session) {

--- a/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
@@ -4,18 +4,23 @@ package com.yahoo.search.querytransform;
 import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.component.chain.dependencies.Before;
 import com.yahoo.prelude.query.CompositeItem;
+import com.yahoo.prelude.query.ExactStringItem;
+import com.yahoo.prelude.query.IntItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.QueryCanonicalizer;
 import com.yahoo.prelude.query.SameElementItem;
+import com.yahoo.prelude.query.TermItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
+import com.yahoo.search.schema.Field;
 import com.yahoo.search.schema.FieldInfo;
 import com.yahoo.search.schema.SchemaInfo;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.searchchain.PhaseNames;
 import com.yahoo.searchlib.document.FastMapSearch;
+import com.yahoo.text.Text;
 
 /**
  * When a field has fast map search enabled, this class transforms queries on
@@ -56,11 +61,11 @@ public class FastMapSearcher extends Searcher {
 
         // handle sameelement rewrite
         if (item instanceof SameElementItem sameElementItem) {
-            String fieldName = sameElementItem.getIndexName();
-            if (isFastMapSearch(fieldName, session)) {
-                var kv = KeyValue.parse(sameElementItem);
-                if (kv.hasKeyValue) {
-                    return makeFastMapSearchWordItem(kv.key, kv.value, fieldName);
+            Field.MapFieldType mapType = fastMapSearchType(sameElementItem.getFieldName(), session);
+            if (mapType != null) {
+                WordItem rewritten = tryMakeFastMapItem(sameElementItem, mapType);
+                if (rewritten != null) {
+                    return rewritten;
                 }
             }
         }
@@ -80,44 +85,91 @@ public class FastMapSearcher extends Searcher {
     }
 
     /**
-     * Parses key and value to string form.
+     * Returns the single fast map lookup term equivalent to the given sameElement,
+     * or null if the sameElement cannot be expressed as one.
      */
-    private record KeyValue(boolean hasKeyValue, String key, String value) {
+    private WordItem tryMakeFastMapItem(SameElementItem sameElementItem, Field.MapFieldType mapType) {
+        if (!sameElementItem.getElementFilter().isEmpty()) {
+            return null; // element filter used for arrays.
+        }
+        if (sameElementItem.getItemCount() != 2) {
+            return null;
+        }
 
-        /**
-         * Recognizes that same element has two elements called key and value, and
-         * that they are string items.
-         * TODO: extend to handle IntItem
-         */
-        static KeyValue parse(SameElementItem sameElementItem) {
-            if (sameElementItem.getItemCount() == 2) {
-                if (sameElementItem.getItem(0) instanceof WordItem item1
-                    && sameElementItem.getItem(1) instanceof WordItem item2) {
-                    if (isKeyValue(item1, item2)) {
-                        return new KeyValue(true, item1.getWord(), item2.getWord());
-                    } else if (isKeyValue(item2, item1)) {
-                        return new KeyValue(true,  item2.getWord(), item1.getWord());
-                    }
-                }
+        Item first = sameElementItem.getItem(0);
+        Item second = sameElementItem.getItem(1);
+        TermItem key = termWithIndex("key", first, second);
+        TermItem value = termWithIndex("value", first, second);
+        if (key == null || value == null) {
+            return null;
+        }
+
+        String encodedKey = encodeExactTerm(key, mapType.keyType().kind());
+        String encodedValue = encodeExactTerm(value, mapType.valueType().kind());
+        if (encodedKey == null || encodedValue == null) {
+            return null;
+        }
+
+        return makeFastMapSearchWordItem(encodedKey, encodedValue, sameElementItem.getFieldName());
+    }
+
+    /** Returns the first of the two items which is a term with the given index name, or null. */
+    private static TermItem termWithIndex(String indexName, Item first, Item second) {
+        if (first instanceof TermItem term && indexName.equals(term.getIndexName())) {
+            return term;
+        }
+        if (second instanceof TermItem term && indexName.equals(term.getIndexName())) {
+            return term;
+        }
+        return null;
+    }
+
+    /**
+     * Returns the encoded form of a term which matches exactly one key or value of the
+     * given kind, or null if the term cannot be part of a fast map lookup: A subclass of
+     * WordItem such as PrefixItem, or an int range, matches more than one exact value.
+     */
+    private static String encodeExactTerm(TermItem term, Field.Type.Kind kind) {
+        if (kind == Field.Type.Kind.STRING) {
+            if (term.getClass() == WordItem.class || term instanceof ExactStringItem) {
+                return ((WordItem) term).getWord();
             }
-
-            return new KeyValue(false, null, null);
+            return null;
         }
-
-        static boolean isKeyValue(WordItem key, WordItem value) {
-            return "key".equals(key.getIndexName()) && "value".equals(value.getIndexName());
+        if (kind == Field.Type.Kind.INT) {
+            String number;
+            if (term instanceof IntItem intItem) {
+                number = intItem.getNumber();
+            } else if (term.getClass() == WordItem.class) {
+                number = ((WordItem) term).getWord();
+            } else {
+                return null;
+            }
+            try {
+                return Text.toExcessHex8(Integer.parseInt(number.trim()));
+            } catch (NumberFormatException e) {
+                return null; // a range expression, or not an int: fall back to regular sameElement
+            }
         }
+        return null;
     }
 
     /** Package-private for unit testing. */
-    WordItem makeFastMapSearchWordItem(String key, String value, String fieldName) {
-        return new WordItem(key + FastMapSearch.keyValueSeparator() + value,
+    WordItem makeFastMapSearchWordItem(String encodedKey, String encodedValue, String fieldName) {
+        return new WordItem(FastMapSearch.toKeyValueTerm(encodedKey, encodedValue),
                 FastMapSearch.toKeyValueFieldName(fieldName), false);
     }
 
-    /** Returns whether the given field has fast map search enabled. */
-    private boolean isFastMapSearch(String fieldName, SchemaInfo.Session session) {
-        return session.fieldInfo(fieldName).map(FieldInfo::hasFastMapSearch).orElse(false);
+    /** Returns the map type of the given field if it has fast map search enabled, and null otherwise. */
+    private static Field.MapFieldType fastMapSearchType(String fieldName, SchemaInfo.Session session) {
+        FieldInfo info = session.fieldInfo(fieldName).orElse(null);
+        if (info == null || !info.hasFastMapSearch()) {
+            return null;
+        }
+        if (info.type() instanceof Field.MapFieldType mapType) {
+            return mapType;
+        }
+        return null;
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
@@ -31,62 +31,72 @@ import com.yahoo.searchlib.document.FastMapSearch;
 @After(PhaseNames.TRANSFORMED_QUERY)
 public class FastMapSearcher extends Searcher {
 
-    private boolean hasRewritten = false;
-
     @Override
     public Result search(Query query, Execution execution) {
         var schemaInfo = execution.context().schemaInfo();
         var session = schemaInfo.newSession(query);
-        rewriteFastMapSearch(query, session);
+        new Rewriter().rewriteFastMapSearch(query, session);
         return execution.search(query);
     }
 
-    private void rewriteFastMapSearch(Query query, SchemaInfo.Session session) {
-        hasRewritten = false;
-        Item root = query.getModel().getQueryTree().getRoot();
-        Item possibleNewRoot = rewriteFastMapSearchVisit(root, session);
-        if (root != possibleNewRoot) {
-            query.getModel().getQueryTree().setRoot(possibleNewRoot);
-        }
-        if (hasRewritten) {
-            query.trace("rewrote sameElement to fast-map lookup", true, 2);
-        }
-    }
+    /** Package-private for unit tests. */
+    class Rewriter {
 
-    /**
-     * Rewrite sameElement for fast map search.
-     *
-     * Package-private for unit testing.
-     */
-    Item rewriteFastMapSearchVisit(Item item, SchemaInfo.Session session) {
-        if (item == null) {
-            return null;
+        private boolean hasRewritten;
+
+        /** Package-private for unit tests. */
+        Rewriter() {
+            hasRewritten = false;
         }
 
-        // handle sameelement rewrite
-        if (item instanceof SameElementItem sameElementItem) {
-            Field.MapFieldType mapType = fastMapSearchType(sameElementItem.getFieldName(), session);
-            if (mapType != null) {
-                WordItem rewritten = tryMakeFastMapItem(sameElementItem, mapType);
-                if (rewritten != null) {
-                    hasRewritten = true;
-                    return rewritten;
-                }
+        /** Entry point for rewriting a query */
+        private void rewriteFastMapSearch(Query query, SchemaInfo.Session session) {
+            Item root = query.getModel().getQueryTree().getRoot();
+            Item possibleNewRoot = rewriteFastMapSearchVisit(root, session);
+            if (root != possibleNewRoot) {
+                query.getModel().getQueryTree().setRoot(possibleNewRoot);
+            }
+            if (hasRewritten) {
+                query.trace("rewrote sameElement to fast-map lookup", true, 2);
             }
         }
 
-        // recursively try rewrite children.
-        if (item instanceof CompositeItem composite) {
-            for (int i = 0; i < composite.getItemCount(); i++) {
-                Item child = composite.getItem(i);
-                Item newChild = rewriteFastMapSearchVisit(child, session);
-                if (newChild != child) {
-                    composite.setItem(i, newChild);
+        /**
+         * Rewrite sameElement for fast map search.
+         *
+         * Package-private for unit testing.
+         */
+        Item rewriteFastMapSearchVisit(Item item, SchemaInfo.Session session) {
+            if (item == null) {
+                return null;
+            }
+
+            // handle sameelement rewrite
+            if (item instanceof SameElementItem sameElementItem) {
+                Field.MapFieldType mapType = fastMapSearchType(sameElementItem.getFieldName(), session);
+                if (mapType != null) {
+                    WordItem rewritten = tryMakeFastMapItem(sameElementItem, mapType);
+                    if (rewritten != null) {
+                        hasRewritten = true;
+                        return rewritten;
+                    }
                 }
             }
+
+            // recursively try rewrite children.
+            if (item instanceof CompositeItem composite) {
+                for (int i = 0; i < composite.getItemCount(); i++) {
+                    Item child = composite.getItem(i);
+                    Item newChild = rewriteFastMapSearchVisit(child, session);
+                    if (newChild != child) {
+                        composite.setItem(i, newChild);
+                    }
+                }
+            }
+
+            return item;
         }
 
-        return item;
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
@@ -20,7 +20,6 @@ import com.yahoo.search.schema.SchemaInfo;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.searchchain.PhaseNames;
 import com.yahoo.searchlib.document.FastMapSearch;
-import com.yahoo.text.Text;
 
 /**
  * When a field has fast map search enabled, this class transforms queries on
@@ -32,6 +31,8 @@ import com.yahoo.text.Text;
 @After(PhaseNames.TRANSFORMED_QUERY)
 public class FastMapSearcher extends Searcher {
 
+    private boolean hasRewritten = false;
+
     @Override
     public Result search(Query query, Execution execution) {
         var schemaInfo = execution.context().schemaInfo();
@@ -41,10 +42,13 @@ public class FastMapSearcher extends Searcher {
     }
 
     private void rewriteFastMapSearch(Query query, SchemaInfo.Session session) {
+        hasRewritten = false;
         Item root = query.getModel().getQueryTree().getRoot();
         Item possibleNewRoot = rewriteFastMapSearchVisit(root, session);
         if (root != possibleNewRoot) {
             query.getModel().getQueryTree().setRoot(possibleNewRoot);
+        }
+        if (hasRewritten) {
             query.trace("rewrote sameElement to fast-map lookup", true, 2);
         }
     }
@@ -65,6 +69,7 @@ public class FastMapSearcher extends Searcher {
             if (mapType != null) {
                 WordItem rewritten = tryMakeFastMapItem(sameElementItem, mapType);
                 if (rewritten != null) {
+                    hasRewritten = true;
                     return rewritten;
                 }
             }
@@ -92,25 +97,46 @@ public class FastMapSearcher extends Searcher {
         if (!sameElementItem.getElementFilter().isEmpty()) {
             return null; // element filter used for arrays.
         }
+
         if (sameElementItem.getItemCount() != 2) {
             return null;
         }
 
+        // resolve which is key and which is value.
         Item first = sameElementItem.getItem(0);
         Item second = sameElementItem.getItem(1);
-        TermItem key = termWithIndex("key", first, second);
-        TermItem value = termWithIndex("value", first, second);
-        if (key == null || value == null) {
+        TermItem keyItem = termWithIndex("key", first, second);
+        TermItem valueItem = termWithIndex("value", first, second);
+        if (keyItem == null || valueItem == null) {
             return null;
         }
 
-        String encodedKey = encodeExactTerm(key, mapType.keyType().kind());
-        String encodedValue = encodeExactTerm(value, mapType.valueType().kind());
-        if (encodedKey == null || encodedValue == null) {
+        // only support string keys for now.
+        if (mapType.keyType().kind() != Field.Type.Kind.STRING) {
             return null;
         }
 
-        return makeFastMapSearchWordItem(encodedKey, encodedValue, sameElementItem.getFieldName());
+        String fieldName = sameElementItem.getFieldName();
+
+        if (mapType.valueType().kind() == Field.Type.Kind.STRING) {
+            var key = getString(keyItem);
+            var value = getString(valueItem);
+            if (key == null || value == null) {
+                return null;
+            }
+            return makeWord(key, value, fieldName);
+        }
+
+        if (mapType.valueType().kind() == Field.Type.Kind.INT) {
+            var key = getString(keyItem);
+            var value = getInteger(valueItem);
+            if (key == null || value == null) {
+                return null;
+            }
+            return makeWord(key, value, fieldName);
+        }
+
+        return null;
     }
 
     /** Returns the first of the two items which is a term with the given index name, or null. */
@@ -124,40 +150,41 @@ public class FastMapSearcher extends Searcher {
         return null;
     }
 
-    /**
-     * Returns the encoded form of a term which matches exactly one key or value of the
-     * given kind, or null if the term cannot be part of a fast map lookup: A subclass of
-     * WordItem such as PrefixItem, or an int range, matches more than one exact value.
-     */
-    private static String encodeExactTerm(TermItem term, Field.Type.Kind kind) {
-        if (kind == Field.Type.Kind.STRING) {
-            if (term.getClass() == WordItem.class || term instanceof ExactStringItem) {
-                return ((WordItem) term).getWord();
-            }
-            return null;
-        }
-        if (kind == Field.Type.Kind.INT) {
-            String number;
-            if (term instanceof IntItem intItem) {
-                number = intItem.getNumber();
-            } else if (term.getClass() == WordItem.class) {
-                number = ((WordItem) term).getWord();
-            } else {
-                return null;
-            }
-            try {
-                return Text.toExcessHex8(Integer.parseInt(number.trim()));
-            } catch (NumberFormatException e) {
-                return null; // a range expression, or not an int: fall back to regular sameElement
-            }
+    /** Gets value as string or null. */
+    private String getString(TermItem term) {
+        if (term.getClass() == WordItem.class || term instanceof ExactStringItem) {
+            return ((WordItem) term).getWord();
         }
         return null;
     }
 
+    /** Gets value as integer or null. */
+    private Integer getInteger(TermItem term) {
+       String number;
+       if (term instanceof IntItem intItem) {
+           number = intItem.getNumber();
+       } else if (term.getClass() == WordItem.class) {
+           number = ((WordItem) term).getWord();
+       } else {
+           return null;
+       }
+       try {
+           return Integer.parseInt(number.trim());
+       } catch (NumberFormatException e) {
+           return null; // a range expression, or not an int: fall back to regular sameElement
+       }
+    }
+
     /** Package-private for unit testing. */
-    WordItem makeFastMapSearchWordItem(String encodedKey, String encodedValue, String fieldName) {
-        return new WordItem(FastMapSearch.toKeyValueTerm(encodedKey, encodedValue),
-                FastMapSearch.toKeyValueFieldName(fieldName), false);
+    WordItem makeWord(String key, String value, String fieldName) {
+        return new WordItem(FastMapSearch.toKeyValueTerm(key, value),
+                            FastMapSearch.toKeyValueFieldName(fieldName), false);
+    }
+
+    /** Package-private for unit testing. */
+    WordItem makeWord(String key, Integer value, String fieldName) {
+        return new WordItem(FastMapSearch.toKeyValue8Term(key, value),
+                            FastMapSearch.toKeyValueFieldName(fieldName), false);
     }
 
     /** Returns the map type of the given field if it has fast map search enabled, and null otherwise. */

--- a/container-search/src/test/java/com/yahoo/search/querytransform/FastMapSearcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/FastMapSearcherTest.java
@@ -28,7 +28,7 @@ public class FastMapSearcherTest {
     @Test
     public void requireWordItemMadeCorrectly() {
         FastMapSearcher searcher = new FastMapSearcher();
-        var word = searcher.makeFastMapSearchWordItem("foo", "bar", "baz");
+        var word = searcher.makeWord("foo", "bar", "baz");
 
         var arr = word.getWord().toCharArray();
         assertEquals('f', arr[0]);
@@ -71,7 +71,7 @@ public class FastMapSearcherTest {
 
     @Test
     public void requireIntValueEncodedInExcessHex() {
-        String expected = "intvaluemap$keyvalue:foo" + FastMapSearch.keyValueSeparator() + FastMapSearch.encodeInt(10);
+        String expected = "intvaluemap$keyvalue:" + FastMapSearch.toKeyValue8Term("foo", 10);
 
         // The value arrives as an IntItem
         assertRewritten(expected, sameElement("intvaluemap", new WordItem("foo", "key"), new IntItem("10", "value")));
@@ -80,14 +80,8 @@ public class FastMapSearcherTest {
         assertRewritten(expected, sameElement("intvaluemap", new WordItem("foo", "key"), new WordItem("10", "value")));
 
         // Negative values encode across zero
-        assertRewritten("intvaluemap$keyvalue:foo" + FastMapSearch.keyValueSeparator() + FastMapSearch.encodeInt(-3),
+        assertRewritten("intvaluemap$keyvalue:" + FastMapSearch.toKeyValue8Term("foo", -3),
                         sameElement("intvaluemap", new WordItem("foo", "key"), new IntItem("-3", "value")));
-    }
-
-    @Test
-    public void requireIntKeyEncodedInExcessHex() {
-        assertRewritten("intkeymap$keyvalue:" + FastMapSearch.encodeInt(7) + FastMapSearch.keyValueSeparator() + "bar",
-                        sameElement("intkeymap", new IntItem("7", "key"), new WordItem("bar", "value")));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/querytransform/FastMapSearcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/FastMapSearcherTest.java
@@ -2,8 +2,11 @@
 package com.yahoo.search.querytransform;
 
 import com.yahoo.prelude.query.AndItem;
+import com.yahoo.prelude.query.IntItem;
 import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.PrefixItem;
 import com.yahoo.prelude.query.SameElementItem;
+import com.yahoo.prelude.query.TermItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.search.Query;
 import com.yahoo.search.schema.Field;
@@ -41,12 +44,7 @@ public class FastMapSearcherTest {
 
     @Test
     public void requireSameElementRewrittenForFastMapField() {
-        var schema = new Schema.Builder("test")
-                .add(new Field.Builder("mymap", "map<string,string>").setFastMapSearch(true).build())
-                .add(new Field.Builder("othermap", "map<string,string>").build())
-                .build();
-        var schemaInfo = new SchemaInfo(List.of(schema), List.of());
-        var execution = new Execution(Execution.Context.createContextStub(schemaInfo));
+        var execution = execution();
 
         String expectedWord = "mymap$keyvalue:foo" + FastMapSearch.keyValueSeparator() + "bar";
 
@@ -71,10 +69,81 @@ public class FastMapSearcherTest {
                 query.getModel().getQueryTree().getRoot().toString());
     }
 
+    @Test
+    public void requireIntValueEncodedInExcessHex() {
+        String expected = "intvaluemap$keyvalue:foo" + FastMapSearch.keyValueSeparator() + FastMapSearch.encodeInt(10);
+
+        // The value arrives as an IntItem
+        assertRewritten(expected, sameElement("intvaluemap", new WordItem("foo", "key"), new IntItem("10", "value")));
+
+        // The value arrives as a WordItem holding an int
+        assertRewritten(expected, sameElement("intvaluemap", new WordItem("foo", "key"), new WordItem("10", "value")));
+
+        // Negative values encode across zero
+        assertRewritten("intvaluemap$keyvalue:foo" + FastMapSearch.keyValueSeparator() + FastMapSearch.encodeInt(-3),
+                        sameElement("intvaluemap", new WordItem("foo", "key"), new IntItem("-3", "value")));
+    }
+
+    @Test
+    public void requireIntKeyEncodedInExcessHex() {
+        assertRewritten("intkeymap$keyvalue:" + FastMapSearch.encodeInt(7) + FastMapSearch.keyValueSeparator() + "bar",
+                        sameElement("intkeymap", new IntItem("7", "key"), new WordItem("bar", "value")));
+    }
+
+    @Test
+    public void requireFallbackWhenTermsDoNotMatchOneEntry() {
+        // A range matches more than one value
+        assertUntouched(sameElement("intvaluemap", new WordItem("foo", "key"), new IntItem("[5;10]", "value")));
+
+        // Not parseable as an int for an int-valued map
+        assertUntouched(sameElement("intvaluemap", new WordItem("foo", "key"), new WordItem("bar", "value")));
+
+        // A prefix term matches more than one string
+        assertUntouched(sameElement("mymap", new PrefixItem("fo", "key"), new WordItem("bar", "value")));
+
+        // An element filter constrains matching beyond a term lookup
+        SameElementItem filtered = sameElement("mymap");
+        filtered.setElementFilter(List.of(1));
+        assertUntouched(filtered);
+
+        // Missing value term
+        SameElementItem keyOnly = new SameElementItem("mymap");
+        keyOnly.addItem(new WordItem("foo", "key"));
+        assertUntouched(keyOnly);
+    }
+
+    private static void assertRewritten(String expected, SameElementItem sameElement) {
+        Query query = queryWith(sameElement);
+        new FastMapSearcher().search(query, execution());
+        assertEquals(expected, query.getModel().getQueryTree().getRoot().toString());
+    }
+
+    private static void assertUntouched(SameElementItem sameElement) {
+        String original = sameElement.toString();
+        Query query = queryWith(sameElement);
+        new FastMapSearcher().search(query, execution());
+        assertEquals(original, query.getModel().getQueryTree().getRoot().toString());
+    }
+
+    private static Execution execution() {
+        var schema = new Schema.Builder("test")
+                .add(new Field.Builder("mymap", "map<string,string>").setFastMapSearch(true).build())
+                .add(new Field.Builder("intvaluemap", "map<string,int>").setFastMapSearch(true).build())
+                .add(new Field.Builder("intkeymap", "map<int,string>").setFastMapSearch(true).build())
+                .add(new Field.Builder("othermap", "map<string,string>").build())
+                .build();
+        var schemaInfo = new SchemaInfo(List.of(schema), List.of());
+        return new Execution(Execution.Context.createContextStub(schemaInfo));
+    }
+
     private static SameElementItem sameElement(String field) {
+        return sameElement(field, new WordItem("foo", "key"), new WordItem("bar", "value"));
+    }
+
+    private static SameElementItem sameElement(String field, TermItem key, TermItem value) {
         SameElementItem sameElement = new SameElementItem(field);
-        sameElement.addItem(new WordItem("foo", "key"));
-        sameElement.addItem(new WordItem("bar", "value"));
+        sameElement.addItem(key);
+        sameElement.addItem(value);
         return sameElement;
     }
 


### PR DESCRIPTION
#### Fix trace
We only logged to the trace when the entire query tree was a sameElement that got transformed. I have now fixed it so it logs once at the end if any subtree is transformed.

#### Simplify transformation
Instead of the KeyValue class, now just assess the types and do the relevant transformations. Only string keys are supported now.

#### Int to excess hex

Added support for integers by transforming them to excess hex. I added only 8 characters to minimize the diff.

@arnej27959 please review
@boeker fyi