### PR TITLE
Remove usage of unused attribute services xml

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
@@ -125,7 +125,8 @@ public class NodesSpecification {
                                      ModelElement nodesElement, Optional<DockerImage> dockerImageRepo,
                                      CloudAccount cloudAccount,
                                      CloudResourceTags cloudResourceTags,
-                                     List<AzName> availabilityZones) {
+                                     List<AzName> availabilityZones,
+                                     DeployState deployState) {
         var resolvedElement = resolveElement(nodesElement);
         var resourceConstraints = toResourceConstraints(resolvedElement);
         var maxCostFactor = resolvedElement.optionalChild("resources")
@@ -141,7 +142,7 @@ public class NodesSpecification {
                                       resolvedElement.booleanAttribute("required", false),
                                       canFail,
                                       resolvedElement.booleanAttribute("exclusive", false),
-                                      dockerImageToUse(resolvedElement, dockerImageRepo),
+                                      dockerImageToUse(resolvedElement, dockerImageRepo, deployState),
                                       cloudAccount,
                                       cloudResourceTags,
                                       availabilityZones,
@@ -195,7 +196,8 @@ public class NodesSpecification {
                       context.getDeployState().getWantedDockerImageRepo(),
                       context.getDeployState().getProperties().getCloudAccount(),
                       context.getDeployState().getProperties().cloudResourceTags(),
-                      context.availabilityZones());
+                      context.availabilityZones(),
+                      context.getDeployState());
     }
 
     /**
@@ -215,7 +217,8 @@ public class NodesSpecification {
                                   context.getDeployState().getWantedDockerImageRepo(),
                                   context.getDeployState().getProperties().getCloudAccount(),
                                   context.getDeployState().getProperties().cloudResourceTags(),
-                                  context.availabilityZones()));
+                                  context.availabilityZones(),
+                                  context.getDeployState()));
     }
 
     /** Returns a requirement from <code>count</code> non-dedicated nodes in one group. */
@@ -290,6 +293,7 @@ public class NodesSpecification {
     public ClusterResources maxResources() { return max; }
     public IntRange groupSize() { return groupSize; }
     public double maxCostFactor() { return maxCostFactor; }
+    public Optional<DockerImage> dockerImageRepo() { return dockerImageRepo; }
 
     /**
      * Returns whether this requires dedicated nodes.
@@ -499,9 +503,13 @@ public class NodesSpecification {
         return new IllegalArgumentException("referenced service '" + referenceId + "' is not defined");
     }
 
-    private static Optional<DockerImage> dockerImageToUse(ModelElement nodesElement, Optional<DockerImage> dockerImage) {
+    private static Optional<DockerImage> dockerImageToUse(ModelElement nodesElement, Optional<DockerImage> dockerImage, DeployState deployState) {
         String dockerImageFromElement = nodesElement.stringAttribute("docker-image");
-        return dockerImageFromElement == null ? dockerImage : Optional.of(DockerImage.fromString(dockerImageFromElement));
+        if (dockerImageFromElement == null) return dockerImage;
+        var system = deployState.zone().system();
+        if (deployState.isHosted() && (system.isPublicCloudLike() || system.isKubernetesLike()))
+            throw new IllegalArgumentException("Specifying 'docker-image' on <nodes> is not supported in Vespa Cloud");
+        return Optional.of(DockerImage.fromString(dockerImageFromElement));
     }
 
     /** Parses a value ("value") or value range ("[min-value, max-value]") */

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -2765,4 +2765,36 @@ public class ModelProvisioningTest {
         assertEquals("large-storage", model.provisioned().clusters().get(ClusterSpec.Id.from("content1")).profile().get());
     }
 
+    @Test
+    public void test_docker_image_on_nodes_is_rejected_in_public_systems() {
+        String xml = """
+                <?xml version='1.0' encoding='utf-8' ?>
+                <services>
+                  <container version='1.0' id='container1'>
+                    <nodes count='2'/>
+                  </container>
+                  <content version='1.0' id='content1'>
+                    <redundancy>1</redundancy>
+                    <documents/>
+                    <nodes count='2' docker-image='example.com/vespa/custom'/>
+                  </content>
+                </services>
+                """;
+
+        VespaModelTester tester = new VespaModelTester();
+        tester.addHosts(9);
+
+        var e = assertThrows(IllegalArgumentException.class,
+                             () -> tester.createModel(new Zone(SystemName.Public, Environment.prod, RegionName.defaultName()),
+                                                      xml, true, deployStateWithClusterEndpoints("container1")));
+        assertTrue(Exceptions.toMessageString(e).contains("Specifying 'docker-image' on <nodes> is not supported in Vespa Cloud"),
+                   Exceptions.toMessageString(e));
+
+        // The attribute is still honored in non-public hosted systems
+        VespaModel model = tester.createModel(new Zone(SystemName.main, Environment.prod, RegionName.defaultName()),
+                                              xml, true, deployStateWithClusterEndpoints("container1"));
+        assertEquals(Optional.of(DockerImage.fromString("example.com/vespa/custom")),
+                     model.provisioned().clusters().get(ClusterSpec.Id.from("content1")).dockerImageRepo());
+    }
+
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecificationTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecificationTest.java
@@ -1,11 +1,18 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.builder.xml.dom;
 
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.CloudResourceTags;
+import com.yahoo.config.provision.DockerImage;
+import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.NodeResources.Architecture;
 import com.yahoo.config.provision.NodeResources.DiskSpeed;
 import com.yahoo.config.provision.NodeResources.StorageType;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.text.XML;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -242,12 +249,63 @@ public class NodesSpecificationTest {
         assertTrue(spec.profile().isEmpty());
     }
 
+    @Test
+    void testDockerImageNotSupportedInPublicCloudSystems() {
+        for (var system : List.of(SystemName.Public, SystemName.PublicCd, SystemName.kubernetes, SystemName.kubernetesCd)) {
+            var exception = assertThrows(IllegalArgumentException.class,
+                                         () -> nodesSpecification("<nodes count='3' docker-image='example.com/vespa/custom'/>",
+                                                                  hostedDeployState(system)));
+            assertEquals("Specifying 'docker-image' on <nodes> is not supported in Vespa Cloud", exception.getMessage());
+        }
+    }
+
+    @Test
+    void testDockerImageAllowedInNonPublicSystems() {
+        for (var system : List.of(SystemName.main, SystemName.cd, SystemName.Default)) {
+            var spec = nodesSpecification("<nodes count='3' docker-image='example.com/vespa/custom'/>",
+                                          hostedDeployState(system));
+            assertEquals(Optional.of(DockerImage.fromString("example.com/vespa/custom")), spec.dockerImageRepo());
+        }
+    }
+
+    @Test
+    void testDockerImageAllowedWhenNotHosted() {
+        var deployState = new DeployState.Builder().properties(new TestProperties())
+                                                    .zone(new Zone(SystemName.Public, Environment.prod, RegionName.defaultName()))
+                                                    .build();
+        var spec = nodesSpecification("<nodes count='3' docker-image='example.com/vespa/custom'/>", deployState);
+        assertEquals(Optional.of(DockerImage.fromString("example.com/vespa/custom")), spec.dockerImageRepo());
+    }
+
+    @Test
+    void testOperatorGivenDockerImageAllowedInPublicCloudSystems() {
+        Document nodesXml = XML.getDocument("<nodes count='3'/>");
+        var operatorImage = DockerImage.fromString("example.com/vespa/operator-selected");
+        var spec = NodesSpecification.create(false, false, Version.emptyVersion,
+                                             new ModelElement(nodesXml.getDocumentElement()),
+                                             Optional.of(operatorImage), CloudAccount.unspecified(),
+                                             CloudResourceTags.empty(), List.of(),
+                                             hostedDeployState(SystemName.Public));
+        assertEquals(Optional.of(operatorImage), spec.dockerImageRepo());
+    }
+
+    private static DeployState hostedDeployState(SystemName system) {
+        return new DeployState.Builder().properties(new TestProperties().setHostedVespa(true))
+                                        .zone(new Zone(system, Environment.prod, RegionName.defaultName()))
+                                        .build();
+    }
+
     private NodesSpecification nodesSpecification(String nodesElement) {
+        return nodesSpecification(nodesElement, new DeployState.Builder().build());
+    }
+
+    private NodesSpecification nodesSpecification(String nodesElement, DeployState deployState) {
         Document nodesXml = XML.getDocument(nodesElement);
         return NodesSpecification.create(false, false, Version.emptyVersion,
                                          new ModelElement(nodesXml.getDocumentElement()),
                                          Optional.empty(), CloudAccount.unspecified(),
-                                         CloudResourceTags.empty(), List.of());
+                                         CloudResourceTags.empty(), List.of(),
+                                         deployState);
 
     }
 


### PR DESCRIPTION
## What

- `NodesSpecification` now rejects the (undocumented) `docker-image` attribute on `<nodes>` with a clear validation error when deploying to Vespa Cloud systems (Public, PublicCd, kubernetes, kubernetesCd).
- The attribute keeps working in self-hosted deployments and in the main/cd systems, where it is in active use.
- The operator-provided `wantedDockerImageRepo` (deploy properties) path is unchanged.
- Tests: system matrix unit tests in `NodesSpecificationTest`, end-to-end model test in `ModelProvisioningTest` (rejected in Public, honored in main), and a test that the operator-provided image still applies in Public.

## Why

- This attribute is not part of the documented services.xml surface, and in Vespa Cloud the container image is managed by the platform. Letting an application package override it there is not supported, so failing with an explicit message beats accepting a setting that cannot work.

Built with AI Claude Code (Fable 5), supervised by human.