### PR TITLE
Wire put and update operations to quantized tensor attributes

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_test.cpp
@@ -20,6 +20,7 @@
 #include <vespa/eval/eval/tensor_spec.h>
 #include <vespa/eval/eval/test/value_compare.h>
 #include <vespa/eval/eval/value.h>
+#include <vespa/eval/eval/value_codec.h>
 #include <vespa/searchcommon/attribute/attributecontent.h>
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchcommon/attribute/iattributevector.h>
@@ -46,6 +47,7 @@
 #include <vespa/searchlib/tensor/tensor_attribute.h>
 #include <vespa/searchlib/test/directory_handler.h>
 #include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/test_quantization_params.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/util/destructor_callbacks.h>
 #include <vespa/vespalib/util/exceptions.h>
@@ -660,9 +662,9 @@ TEST_F(AttributeWriterTest, can_write_to_tensor_attribute) {
     put(1, *doc, 1);
     EXPECT_EQ(2u, a1->getNumDocs());
     auto* tensorAttribute = dynamic_cast<TensorAttribute*>(a1.get());
-    EXPECT_TRUE(tensorAttribute != nullptr);
+    ASSERT_TRUE(tensorAttribute != nullptr);
     auto tensor2 = tensorAttribute->getTensor(1);
-    EXPECT_TRUE(static_cast<bool>(tensor2));
+    ASSERT_TRUE(static_cast<bool>(tensor2));
     EXPECT_EQ(*tensor, *tensor2);
 }
 
@@ -675,9 +677,9 @@ TEST_F(AttributeWriterTest, handles_tensor_assign_update) {
     put(1, *doc, 1);
     EXPECT_EQ(2u, a1->getNumDocs());
     auto* tensorAttribute = dynamic_cast<TensorAttribute*>(a1.get());
-    EXPECT_TRUE(tensorAttribute != nullptr);
+    ASSERT_TRUE(tensorAttribute != nullptr);
     auto tensor2 = tensorAttribute->getTensor(1);
-    EXPECT_TRUE(static_cast<bool>(tensor2));
+    ASSERT_TRUE(static_cast<bool>(tensor2));
     EXPECT_EQ(*tensor, *tensor2);
 
     DocumentUpdate upd(builder.get_repo(), builder.get_document_type(), DocumentId("id:ns:searchdocument::1"));
@@ -690,9 +692,9 @@ TEST_F(AttributeWriterTest, handles_tensor_assign_update) {
     DummyFieldUpdateCallback onUpdate;
     update(2, upd, 1, onUpdate);
     EXPECT_EQ(2u, a1->getNumDocs());
-    EXPECT_TRUE(tensorAttribute != nullptr);
+    ASSERT_TRUE(tensorAttribute != nullptr);
     tensor2 = tensorAttribute->getTensor(1);
-    EXPECT_TRUE(static_cast<bool>(tensor2));
+    ASSERT_TRUE(static_cast<bool>(tensor2));
     EXPECT_FALSE(*tensor == *tensor2);
     EXPECT_EQ(*new_tensor, *tensor2);
 }
@@ -765,10 +767,10 @@ struct MockPrepareResult : public PrepareResult {
 
 class MockDenseTensorAttribute : public DenseTensorAttribute {
 public:
-    mutable size_t prepare_set_tensor_cnt;
-    mutable size_t complete_set_tensor_cnt;
-    size_t         clear_doc_cnt;
-    const Value*   exp_tensor;
+    mutable size_t         prepare_set_tensor_cnt;
+    mutable size_t         complete_set_tensor_cnt;
+    size_t                 clear_doc_cnt;
+    std::unique_ptr<Value> exp_tensor;
 
     MockDenseTensorAttribute(std::string_view name, const AVConfig& cfg)
         : DenseTensorAttribute(name, cfg),
@@ -784,6 +786,7 @@ public:
     }
     std::unique_ptr<PrepareResult> prepare_set_tensor(uint32_t docid, const Value& tensor) const override {
         ++prepare_set_tensor_cnt;
+        assert(exp_tensor);
         EXPECT_EQ(*exp_tensor, tensor);
         return std::make_unique<MockPrepareResult>(docid, tensor);
     }
@@ -801,16 +804,21 @@ public:
 
 const std::string dense_tensor = "tensor(x[2])";
 
-AVConfig get_tensor_config(bool multi_threaded_indexing) {
+AVConfig get_tensor_config(bool multi_threaded_indexing, bool quantized = false) {
     AVConfig cfg(AVBasicType::TENSOR);
-    cfg.setTensorType(ValueType::from_spec(dense_tensor));
+    if (!quantized) {
+        cfg.setTensorType(ValueType::from_spec(dense_tensor));
+    } else {
+        cfg.set_tensor_type_with_quantization(ValueType::from_spec(dense_tensor),
+                                              search::test::mse_4bit_quantization_params());
+    }
     cfg.set_hnsw_index_params(HnswIndexParams(4, 4, DistanceMetric::Euclidean, multi_threaded_indexing));
     return cfg;
 }
 
-std::shared_ptr<MockDenseTensorAttribute> make_mock_tensor_attribute(const std::string& name,
-                                                                     bool               multi_threaded_indexing) {
-    auto cfg = get_tensor_config(multi_threaded_indexing);
+std::shared_ptr<MockDenseTensorAttribute>
+make_mock_tensor_attribute(const std::string& name, bool multi_threaded_indexing, bool quantized = false) {
+    auto cfg = get_tensor_config(multi_threaded_indexing, quantized);
     return std::make_shared<MockDenseTensorAttribute>(name, cfg);
 }
 
@@ -835,7 +843,9 @@ TEST_F(AttributeWriterTest, tensor_attributes_using_two_phase_put_are_in_separat
     EXPECT_EQ("t2", ctx[2].getFields()[0].getAttribute().getName());
 }
 
-class TwoPhasePutTest : public AttributeWriterTest {
+using IsQuantized = bool;
+
+class TwoPhasePutTest : public AttributeWriterTest, public testing::WithParamInterface<IsQuantized> {
 public:
     DocBuilder                                builder;
     std::string                               doc_id;
@@ -848,14 +858,20 @@ public:
           doc_id("id:ns:searchdocument::1"),
           attr() {
         setup(2);
-        attr = make_mock_tensor_attribute("a1", true);
+        attr = make_mock_tensor_attribute("a1", true, is_quantized());
         add_attribute(attr);
         AttributeManager::padAttribute(*attr, 4);
         attr->clear_doc_cnt = 0;
-        tensor = make_tensor(TensorSpec(dense_tensor).add({{"x", 0}}, 3).add({{"x", 1}}, 5));
-        attr->exp_tensor = tensor.get();
+        auto tensor_spec = TensorSpec(dense_tensor).add({{"x", 0}}, 3).add({{"x", 1}}, 5);
+        tensor = make_tensor(tensor_spec);
+        if (!is_quantized()) {
+            attr->exp_tensor = make_tensor(tensor_spec);
+        } else {
+            attr->exp_tensor = attr->make_quantizer()->quantize(*tensor);
+        }
         allocAttributeWriter();
     }
+    [[nodiscard]] bool is_quantized() const noexcept { return GetParam(); }
     void expect_tensor_attr_calls(size_t exp_prepare_cnt, size_t exp_complete_cnt, size_t exp_clear_doc_cnt = 0) {
         EXPECT_EQ(exp_prepare_cnt, attr->prepare_set_tensor_cnt);
         EXPECT_EQ(exp_complete_cnt, attr->complete_set_tensor_cnt);
@@ -886,7 +902,7 @@ public:
     }
 };
 
-TEST_F(TwoPhasePutTest, handles_put_in_two_phases_when_specified_for_tensor_attribute) {
+TEST_P(TwoPhasePutTest, handles_put_in_two_phases_when_specified_for_tensor_attribute) {
     auto doc = make_doc();
 
     put(1, *doc, 1);
@@ -900,7 +916,7 @@ TEST_F(TwoPhasePutTest, handles_put_in_two_phases_when_specified_for_tensor_attr
     assertExecuteHistory({0, 0});
 }
 
-TEST_F(TwoPhasePutTest, put_is_ignored_when_serial_number_is_older_or_equal_to_attribute) {
+TEST_P(TwoPhasePutTest, put_is_ignored_when_serial_number_is_older_or_equal_to_attribute) {
     auto doc = make_doc();
     attr->commit(CommitParam(7, CommitParam::UpdateStats::SKIP));
     put(7, *doc, 1);
@@ -909,7 +925,7 @@ TEST_F(TwoPhasePutTest, put_is_ignored_when_serial_number_is_older_or_equal_to_a
     assertExecuteHistory({0});
 }
 
-TEST_F(TwoPhasePutTest, document_is_cleared_if_field_is_not_set) {
+TEST_P(TwoPhasePutTest, document_is_cleared_if_field_is_not_set) {
     auto doc = make_no_field_doc();
     put(1, *doc, 1);
     expect_tensor_attr_calls(0, 0, 1);
@@ -917,7 +933,7 @@ TEST_F(TwoPhasePutTest, document_is_cleared_if_field_is_not_set) {
     assertExecuteHistory({0});
 }
 
-TEST_F(TwoPhasePutTest, document_is_cleared_if_tensor_in_field_is_not_set) {
+TEST_P(TwoPhasePutTest, document_is_cleared_if_tensor_in_field_is_not_set) {
     auto doc = make_no_tensor_doc();
     put(1, *doc, 1);
     expect_tensor_attr_calls(0, 0, 1);
@@ -925,7 +941,7 @@ TEST_F(TwoPhasePutTest, document_is_cleared_if_tensor_in_field_is_not_set) {
     assertExecuteHistory({0});
 }
 
-TEST_F(TwoPhasePutTest, handles_assign_update_as_two_phase_put_when_specified_for_tensor_attribute) {
+TEST_P(TwoPhasePutTest, handles_assign_update_as_two_phase_put_when_specified_for_tensor_attribute) {
     auto upd = make_assign_update();
 
     DummyFieldUpdateCallback on_update;
@@ -939,6 +955,15 @@ TEST_F(TwoPhasePutTest, handles_assign_update_as_two_phase_put_when_specified_fo
     expect_shared_executor_tasks(2);
     assertExecuteHistory({0, 0});
 }
+
+struct QuantizedTestParamPrinter {
+    std::string operator()(const testing::TestParamInfo<IsQuantized>& info) const {
+        return info.param ? "quantized" : "unquantized";
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(FullPrecisionAndQuantizedTensors, TwoPhasePutTest, testing::Bool(),
+                         QuantizedTestParamPrinter());
 
 ImportedAttributeVector::SP createImportedAttribute(const std::string& name) {
     auto result = ImportedAttributeVectorFactory::create(name, {}, {}, {}, {}, true);

--- a/searchcore/src/tests/proton/common/attribute_updater_test.cpp
+++ b/searchcore/src/tests/proton/common/attribute_updater_test.cpp
@@ -37,6 +37,7 @@
 #include <vespa/searchlib/tensor/dense_tensor_attribute.h>
 #include <vespa/searchlib/tensor/serialized_fast_value_attribute.h>
 #include <vespa/searchlib/test/attribute_builder.h>
+#include <vespa/searchlib/test/test_quantization_params.h>
 #include <vespa/searchlib/test/weighted_type_test_utils.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
@@ -87,14 +88,15 @@ using WeightedString = AttributeVector::WeightedString;
 
 std::unique_ptr<DocumentTypeRepo> makeDocumentTypeRepo() {
     new_config_builder::NewConfigBuilder builder;
-    auto&                                doc = builder.document("testdoc", 222);
-    auto                                 bool_array = doc.createArray(builder.boolTypeRef()).ref();
-    auto                                 int_array = doc.createArray(builder.intTypeRef()).ref();
-    auto                                 float_array = doc.createArray(builder.floatTypeRef()).ref();
-    auto                                 string_array = doc.createArray(builder.stringTypeRef()).ref();
-    auto                                 int_wset = doc.createWset(builder.intTypeRef()).ref();
-    auto                                 float_wset = doc.createWset(builder.floatTypeRef()).ref();
-    auto                                 string_wset = doc.createWset(builder.stringTypeRef()).ref();
+
+    auto& doc = builder.document("testdoc", 222);
+    auto  bool_array = doc.createArray(builder.boolTypeRef()).ref();
+    auto  int_array = doc.createArray(builder.intTypeRef()).ref();
+    auto  float_array = doc.createArray(builder.floatTypeRef()).ref();
+    auto  string_array = doc.createArray(builder.stringTypeRef()).ref();
+    auto  int_wset = doc.createWset(builder.intTypeRef()).ref();
+    auto  float_wset = doc.createWset(builder.floatTypeRef()).ref();
+    auto  string_wset = doc.createWset(builder.stringTypeRef()).ref();
     // Create self-referencing type (reference to testdoc itself)
     auto ref_type = doc.referenceType(doc.idx());
     doc.addField("int", builder.intTypeRef())
@@ -109,7 +111,9 @@ std::unique_ptr<DocumentTypeRepo> makeDocumentTypeRepo() {
         .addField("wsfloat", float_wset)
         .addField("wsstring", string_wset)
         .addField("ref", ref_type);
-    doc.addTensorField("dense_tensor", "tensor(x[2])").addTensorField("sparse_tensor", "tensor(x{})");
+    doc.addTensorField("dense_tensor", "tensor(x[2])")
+        .addTensorField("quantized_tensor", "tensor(x[2])")
+        .addTensorField("sparse_tensor", "tensor(x{})");
     return std::make_unique<DocumentTypeRepo>(builder.config());
 }
 
@@ -448,9 +452,15 @@ TEST(AttributeUpdaterTest, require_that_weighted_set_attributes_are_updated) {
 }
 
 template <typename TensorAttributeType>
-std::unique_ptr<TensorAttributeType> makeTensorAttribute(const std::string& name, const std::string& tensorType) {
+std::unique_ptr<TensorAttributeType> makeTensorAttribute(const std::string& name, const std::string& tensorType,
+                                                         bool quantized) {
     Config cfg(BasicType::TENSOR, CollectionType::SINGLE);
-    cfg.setTensorType(ValueType::from_spec(tensorType));
+    if (!quantized) {
+        cfg.setTensorType(ValueType::from_spec(tensorType));
+    } else {
+        cfg.set_tensor_type_with_quantization(ValueType::from_spec(tensorType),
+                                              search::test::mse_4bit_quantization_params());
+    }
     auto result = std::make_unique<TensorAttributeType>(name, cfg);
     result->addReservedDoc();
     result->addDocs(1);
@@ -475,27 +485,38 @@ std::unique_ptr<TensorFieldValue> makeTensorFieldValue(const TensorSpec& spec) {
     return result;
 }
 
-template <typename TensorAttributeType> struct TensorFixture : public Fixture {
+template <typename TensorAttributeType>
+struct TensorFixture : public Fixture {
     std::string                          type;
     std::unique_ptr<TensorAttributeType> attribute;
 
-    TensorFixture(const std::string& type_, const std::string& name)
-        : type(type_), attribute(makeTensorAttribute<TensorAttributeType>(name, type)) {}
+    TensorFixture(const std::string& type_, const std::string& name, bool quantized = false)
+        : type(type_), attribute(makeTensorAttribute<TensorAttributeType>(name, type, quantized)) {}
     ~TensorFixture();
 
     void setTensor(const TensorSpec& spec) {
         auto tensor = makeTensor(spec);
-        attribute->setTensor(1, *tensor);
+        if (!attribute->is_quantized()) {
+            attribute->setTensor(1, *tensor);
+        } else {
+            attribute->setTensor(1, *attribute->make_quantizer()->quantize(*tensor));
+        }
         attribute->commit();
     }
 
     void assertTensor(const TensorSpec& expSpec) {
-        auto actual = spec_from_value(*attribute->getTensor(1));
+        auto tensor = attribute->getTensor(1);
+        ASSERT_TRUE(tensor);
+        if (attribute->is_quantized()) {
+            tensor = attribute->make_dequantizer()->dequantize(*tensor);
+        }
+        auto actual = spec_from_value(*tensor);
         EXPECT_EQ(expSpec, actual);
     }
 };
 
-template <typename TensorAttributeType> TensorFixture<TensorAttributeType>::~TensorFixture() = default;
+template <typename TensorAttributeType>
+TensorFixture<TensorAttributeType>::~TensorFixture() = default;
 
 TEST(AttributeUpdaterTest, require_that_tensor_modify_update_is_applied) {
     TensorFixture<DenseTensorAttribute> f("tensor(x[2])", "dense_tensor");
@@ -540,6 +561,29 @@ TEST(AttributeUpdaterTest, require_that_tensor_remove_update_is_applied) {
         *f.attribute, 1,
         std::make_unique<TensorRemoveUpdate>(makeTensorFieldValue(TensorSpec(f.type).add({{"x", "b"}}, 1))));
     f.assertTensor(TensorSpec(f.type).add({{"x", "a"}}, 2));
+}
+
+// The AttributeUpdater must not apply partial updates directly to quantized tensor attributes,
+// as the "read" part of a read-modify-write operation would operate on lossy information, thus
+// causing precision to go down for each subsequent operation. I.e. quantized attributes do not
+// contain source of truth information.
+// Instead, quantized tensors updates must be handled on a higher level (this only tests the
+// lower level) by converting them to _document store_-level read-modify-writes, followed by an
+// attribute _put_. This ensures the update takes in the full precision data and also ensures
+// the attribute is in sync with what's in the doc store.
+TEST(AttributeUpdaterTest, partial_updates_to_quantized_tensors_are_ignored) {
+    TensorFixture<DenseTensorAttribute> f("tensor(x[2])", "quantized_tensor", true);
+    auto                                orig_spec = TensorSpec(f.type).add({{"x", 0}}, 3).add({{"x", 1}}, 5);
+    f.setTensor(orig_spec);
+    f.applyValueUpdate(*f.attribute, 1,
+                       std::make_unique<TensorModifyUpdate>(
+                           TensorModifyUpdate::Operation::ADD,
+                           makeTensorFieldValue(TensorSpec("tensor(x[2])").add({{"x", 1}}, 3)), 0.0));
+    // Send orig_spec through the tumble drier to get the expected dequantized representation
+    // of the initially fed tensor (_not_ the one that that is updated).
+    auto quant_spec = spec_from_value(*f.attribute->make_dequantizer()->dequantize(
+        *f.attribute->make_quantizer()->quantize(*makeTensor(orig_spec))));
+    f.assertTensor(quant_spec);
 }
 
 } // namespace attribute_updater_test

--- a/searchcore/src/tests/proton/documentdb/feedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/feedview_test.cpp
@@ -29,6 +29,7 @@
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/searchlib/test/schema_builder.h>
+#include <vespa/searchlib/test/test_quantization_params.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/destructor_callbacks.h>
@@ -266,9 +267,11 @@ struct MySummaryAdapter : public test::MockSummaryAdapter {
           _removes() {}
     ~MySummaryAdapter() override;
     void put(SerialNum serialNum, DocumentIdT lid, const Document& doc) override {
+        LOG(info, "MySummaryAdapter::put(doc): serialNum(%" PRIu64 "), docId(%u)", serialNum, lid);
         _store.write(serialNum, lid, doc);
     }
     void put(SerialNum serialNum, DocumentIdT lid, const vespalib::nbostream& os) override {
+        LOG(info, "MySummaryAdapter::put(nbostream): serialNum(%" PRIu64 "), docId(%u)", serialNum, lid);
         _store.write(serialNum, lid, os);
     }
     void remove(SerialNum serialNum, const DocumentIdT lid) override {
@@ -292,11 +295,15 @@ struct MyAttributeWriter : public IAttributeWriter {
     SerialNum   _updateSerial;
     DocumentId  _updateDocId;
     DocumentIdT _updateLid;
+    SerialNum   _update_with_doc_serial;
+    DocumentId  _update_with_doc_doc_id;
+    DocumentIdT _update_with_doc_lid;
     SerialNum   _removeSerial;
     DocumentIdT _removeLid;
     int         _heartBeatCount;
     uint32_t    _commitCount;
     uint32_t    _wantedLidLimit;
+    bool        _has_non_authoritative_attr;
     using AttrMap = std::map<std::string, std::shared_ptr<AttributeVector>>;
     AttrMap                       _attrMap;
     std::set<std::string>         _attrs;
@@ -315,6 +322,7 @@ struct MyAttributeWriter : public IAttributeWriter {
         return ((itr == _attrMap.end()) ? nullptr : itr->second.get());
     }
     void put(SerialNum serialNum, const document::Document& doc, DocumentIdT lid, const OnWriteDoneType&) override {
+        LOG(info, "MyAttributeAdapter::put(): serialNum(%" PRIu64 "), docId(%u)", serialNum, lid);
         _putSerial = serialNum;
         _putDocId = doc.getId();
         _putLid = lid;
@@ -334,6 +342,7 @@ struct MyAttributeWriter : public IAttributeWriter {
     }
     void update(SerialNum serialNum, const document::DocumentUpdate& upd, DocumentIdT lid, const OnWriteDoneType&,
                 IFieldUpdateCallback& onUpdate) override {
+        LOG(info, "MyAttributeAdapter::update(DocumentUpdate): serialNum(%" PRIu64 "), docId(%u)", serialNum, lid);
         _updateSerial = serialNum;
         _updateDocId = upd.getId();
         _updateLid = lid;
@@ -344,9 +353,10 @@ struct MyAttributeWriter : public IAttributeWriter {
     }
     void update(SerialNum serialNum, const document::Document& doc, DocumentIdT lid,
                 const OnWriteDoneType&) override {
-        (void)serialNum;
-        (void)doc;
-        (void)lid;
+        LOG(info, "MyAttributeAdapter::update(Document): serialNum(%" PRIu64 "), docId(%u)", serialNum, lid);
+        _update_with_doc_serial = serialNum;
+        _update_with_doc_doc_id = doc.getId();
+        _update_with_doc_lid = lid;
     }
     void heartBeat(SerialNum, const OnWriteDoneType&) override { ++_heartBeatCount; }
     void compactLidSpace(uint32_t wantedLidLimit, SerialNum) override { _wantedLidLimit = wantedLidLimit; }
@@ -359,6 +369,7 @@ struct MyAttributeWriter : public IAttributeWriter {
 
     void onReplayDone(uint32_t) override {}
     bool hasStructFieldAttribute() const override { return false; }
+    bool has_non_authoritative_attribute() const noexcept override { return _has_non_authoritative_attr; }
 };
 
 MyAttributeWriter::MyAttributeWriter(MyTracer& tracer)
@@ -369,11 +380,15 @@ MyAttributeWriter::MyAttributeWriter(MyTracer& tracer)
       _updateSerial(0),
       _updateDocId(),
       _updateLid(0),
+      _update_with_doc_serial(0),
+      _update_with_doc_doc_id(),
+      _update_with_doc_lid(0),
       _removeSerial(0),
       _removeLid(0),
       _heartBeatCount(0),
       _commitCount(0),
       _wantedLidLimit(0),
+      _has_non_authoritative_attr(false),
       _attrMap(),
       _attrs(),
       _mgr(),
@@ -385,6 +400,10 @@ MyAttributeWriter::MyAttributeWriter(MyTracer& tracer)
     search::attribute::Config cfg3(search::attribute::BasicType::TENSOR);
     cfg3.setTensorType(ValueType::from_spec("tensor(x[10])"));
     _attrMap["a3"] = search::AttributeFactory::createAttribute("test3", cfg3);
+    search::attribute::Config cfg4(search::attribute::BasicType::TENSOR);
+    cfg4.set_tensor_type_with_quantization(ValueType::from_spec("tensor(x[10])"),
+                                           search::test::mse_4bit_quantization_params());
+    _attrMap["a4"] = search::AttributeFactory::createAttribute("test4", cfg4);
 }
 MyAttributeWriter::~MyAttributeWriter() = default;
 
@@ -420,10 +439,11 @@ SchemaContext::SchemaContext()
               .addField("a1", builder.stringTypeRef())
               .addField("a2", builder.predicateTypeRef())
               .addTensorField("a3", "")
+              .addTensorField("a4", "")
               .addField("s1", builder.stringTypeRef());
       }),
       _schema(std::make_shared<Schema>(
-          SchemaBuilder(_builder).add_indexes({"i1"}).add_attributes({"a1", "a2", "a3"}).build())) {
+          SchemaBuilder(_builder).add_indexes({"i1"}).add_attributes({"a1", "a2", "a3", "a4"}).build())) {
 }
 
 SchemaContext::~SchemaContext() = default;
@@ -725,6 +745,10 @@ void assertAttributeUpdate(SerialNum serialNum, const document::DocumentId& docI
     EXPECT_EQ(serialNum, adapter._updateSerial);
     EXPECT_EQ(docId, adapter._updateDocId);
     EXPECT_EQ(lid, adapter._updateLid);
+    // We should not get full Document-granularity updates to regular attributes
+    EXPECT_EQ(0, adapter._update_with_doc_serial);
+    EXPECT_EQ(DocumentId(), adapter._update_with_doc_doc_id);
+    EXPECT_EQ(0, adapter._update_with_doc_lid);
 }
 
 } // namespace
@@ -1025,6 +1049,23 @@ void requireThatUpdateUpdatesAttributeAndDocumentStore(Fixture& f, const std::st
     assertAttributeUpdate(2u, DocumentId("id:ns:searchdocument::1"), 1, f.maw);
 }
 
+template <typename Fixture>
+void check_update_writes_document_to_attribute_and_document_store(Fixture& f, const std::string& field_name) {
+    putDocumentAndUpdate(f, field_name);
+    EXPECT_EQ(2u, f.msa._store._lastSyncToken); // document store updated
+    // We shall have triggered a _Document_-granularity update
+    EXPECT_EQ(2, f.maw._update_with_doc_serial);
+    EXPECT_EQ(DocumentId("id:ns:searchdocument::1"), f.maw._update_with_doc_doc_id);
+    EXPECT_EQ(1, f.maw._update_with_doc_lid);
+    // Although this seemingly partially updates the attribute itself, the non-mock
+    // AttributeUpdater will explicitly _ignore_ partial updates to quantized tensors.
+    // So it's a no-op in practice, but we still test it here to cross-check that the
+    // wiring is as we expect it to be.
+    EXPECT_EQ(2, f.maw._updateSerial);
+    EXPECT_EQ(DocumentId("id:ns:searchdocument::1"), f.maw._updateDocId);
+    EXPECT_EQ(1, f.maw._updateLid);
+}
+
 } // namespace
 
 TEST(FeedViewTest, require_that_update_to_fast_access_attribute_only_updates_attribute_and_not_document_store) {
@@ -1067,6 +1108,20 @@ TEST(FeedViewTest, require_that_update_to_tensor_attribute_only_updates_attribut
     SearchableFeedViewFixture f;
     f.maw._attrs.insert("a3"); // mark a3 as attribute field
     requireThatUpdateOnlyUpdatesAttributeAndNotDocumentStore(f, "a3");
+}
+
+TEST(FeedViewTest, update_to_fast_access_quantized_tensor_attribute_updates_document_store_and_puts_to_attribute) {
+    FastAccessFeedViewFixture f;
+    f.maw._attrs.insert("a4"); // mark a4 as fast-access attribute field
+    f.maw._has_non_authoritative_attr = true;
+    check_update_writes_document_to_attribute_and_document_store(f, "a4");
+}
+
+TEST(FeedViewTest, update_to_quantized_tensor_attribute_updates_document_store_and_puts_to_attribute) {
+    SearchableFeedViewFixture f;
+    f.maw._attrs.insert("a4"); // mark a4 as attribute field
+    f.maw._has_non_authoritative_attr = true;
+    check_update_writes_document_to_attribute_and_document_store(f, "a4");
 }
 
 TEST(

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -44,7 +44,7 @@ using LidVector = LidVectorContext::LidVector;
 
 namespace {
 
-bool use_two_phase_put_for_attribute(const AttributeVector& attr) {
+[[nodiscard]] bool use_two_phase_put_for_attribute(const AttributeVector& attr) noexcept {
     const auto& cfg = attr.getConfig();
     if (cfg.basicType() == search::attribute::BasicType::Type::TENSOR && cfg.hnsw_index_params().has_value() &&
         cfg.hnsw_index_params().value().multi_threaded_indexing())
@@ -54,13 +54,19 @@ bool use_two_phase_put_for_attribute(const AttributeVector& attr) {
     return false;
 }
 
+[[nodiscard]] bool is_quantized_attribute(const AttributeVector& attr) noexcept {
+    const auto& cfg = attr.getConfig();
+    return (cfg.basicType() == search::attribute::BasicType::Type::TENSOR) && cfg.quantization_params().has_value();
+}
+
 } // namespace
 
 AttributeWriter::WriteField::WriteField(AttributeVector& attribute)
     : _fieldPath(),
       _attribute(attribute),
       _structFieldAttribute(false),
-      _use_two_phase_put(use_two_phase_put_for_attribute(attribute)) {
+      _use_two_phase_put(use_two_phase_put_for_attribute(attribute)),
+      _is_quantized(is_quantized_attribute(attribute)) {
     const std::string& name = attribute.getName();
     _structFieldAttribute = search::attribute::isStructFieldAttribute(name);
 }
@@ -86,7 +92,8 @@ AttributeWriter::WriteContext::WriteContext(ExecutorId executorId) noexcept
       _data_type(nullptr),
       _two_phase_put_field_path(),
       _hasStructFieldAttribute(false),
-      _use_two_phase_put(false) {
+      _use_two_phase_put(false),
+      _has_quantized_attribute(false) {
 }
 
 AttributeWriter::WriteContext::WriteContext(WriteContext&& rhs) noexcept = default;
@@ -99,6 +106,9 @@ void AttributeWriter::WriteContext::add(AttributeVector& attr) {
     _fields.emplace_back(attr);
     if (_fields.back().isStructFieldAttribute()) {
         _hasStructFieldAttribute = true;
+    }
+    if (_fields.back().is_quantized()) {
+        _has_quantized_attribute = true;
     }
     if (_fields.back().use_two_phase_put()) {
         // Only support for one field per context when this is true.
@@ -318,7 +328,7 @@ void PutTask::run() {
     DocumentFieldExtractor field_extractor(_doc);
     const auto&            fields = _wc.getFields();
     for (auto field : fields) {
-        if (_allAttributes || field.isStructFieldAttribute()) {
+        if (_allAttributes || field.is_non_authoritative()) {
             AttributeVector& attr = field.getAttribute();
             if (attr.getStatus().getLastSyncToken() < _serialNum) {
                 auto fv = field_extractor.getFieldValue(field.getFieldPath());
@@ -329,7 +339,6 @@ void PutTask::run() {
 }
 
 class PreparePutTask : public vespalib::Executor::Task {
-private:
     const SerialNum                          _serial_num;
     const uint32_t                           _docid;
     AttributeVector&                         _attr;
@@ -391,7 +400,6 @@ void PreparePutTask::run() {
 }
 
 class CompletePutTask : public vespalib::Executor::Task {
-private:
     const SerialNum                         _serial_num;
     const uint32_t                          _docid;
     AttributeVector&                        _attr;
@@ -451,7 +459,6 @@ void RemoveTask::run() {
 }
 
 class BatchRemoveTask : public vespalib::Executor::Task {
-private:
     const AttributeWriter::WriteContext&   _writeCtx;
     const SerialNum                        _serialNum;
     const LidVector                        _lidsToRemove;
@@ -532,6 +539,9 @@ void AttributeWriter::setupWriteContexts() {
         if (wc.hasStructFieldAttribute()) {
             _hasStructFieldAttribute = true;
         }
+        if (wc.has_quantized_attribute()) {
+            _has_quantized_attribute = true;
+        }
     }
 }
 
@@ -546,7 +556,7 @@ void AttributeWriter::internalPut(SerialNum serialNum, const Document& doc, Docu
             _shared_executor.execute(CpuUsage::wrap(std::move(prepare_task), CpuUsage::Category::WRITE));
             _attributeFieldWriter.executeTask(wc.getExecutorId(), std::move(complete_task));
         } else {
-            if (allAttributes || wc.hasStructFieldAttribute()) {
+            if (allAttributes || wc.has_non_authoritative_attribute()) {
                 auto putTask = std::make_unique<PutTask>(wc, serialNum, doc, lid, allAttributes, onWriteDone);
                 _attributeFieldWriter.executeTask(wc.getExecutorId(), std::move(putTask));
             }
@@ -567,6 +577,7 @@ AttributeWriter::AttributeWriter(proton::IAttributeManager::SP mgr)
       _shared_executor(_mgr->get_shared_executor()),
       _writeContexts(),
       _hasStructFieldAttribute(false),
+      _has_quantized_attribute(false),
       _attrMap() {
     setupWriteContexts();
     setupAttributeMapping();
@@ -586,7 +597,6 @@ AttributeWriter::~AttributeWriter() {
 }
 
 void AttributeWriter::drain(const OnWriteDoneType& onDone) {
-
     for (const auto& wc : _writeContexts) {
         _attributeFieldWriter.executeLambda(wc.getExecutorId(), [onDone]() { (void)onDone; });
     }
@@ -743,6 +753,10 @@ void AttributeWriter::compactLidSpace(uint32_t wantedLidLimit, SerialNum serialN
 
 bool AttributeWriter::hasStructFieldAttribute() const {
     return _hasStructFieldAttribute;
+}
+
+bool AttributeWriter::has_non_authoritative_attribute() const noexcept {
+    return _hasStructFieldAttribute || _has_quantized_attribute;
 }
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
@@ -39,6 +39,7 @@ public:
         AttributeVector&  _attribute;
         bool              _structFieldAttribute; // in array/map of struct
         bool              _use_two_phase_put;
+        bool              _is_quantized;
 
     public:
         WriteField(AttributeVector& attribute);
@@ -46,8 +47,13 @@ public:
         AttributeVector& getAttribute() const { return _attribute; }
         const FieldPath& getFieldPath() const { return _fieldPath; }
         void buildFieldPath(const DocumentType& docType) const;
-        bool isStructFieldAttribute() const { return _structFieldAttribute; }
-        bool use_two_phase_put() const { return _use_two_phase_put; }
+        [[nodiscard]] bool isStructFieldAttribute() const noexcept { return _structFieldAttribute; }
+        [[nodiscard]] bool use_two_phase_put() const noexcept { return _use_two_phase_put; }
+        [[nodiscard]] bool is_quantized() const noexcept { return _is_quantized; }
+        // Iff true, the attribute contents cannot be used to losslessly recreate the
+        // state of the document as it exists in the document store. I.e. the document
+        // store must be used as the source of truth for reads.
+        [[nodiscard]] bool is_non_authoritative() const noexcept { return _structFieldAttribute || _is_quantized; }
     };
 
     /**
@@ -61,6 +67,9 @@ public:
         bool                                     _hasStructFieldAttribute;
         // When this is true, the context only contains a single field.
         bool _use_two_phase_put;
+        // When this is true, the attribute requires doc store read+writeback, as the
+        // attribute itself does not have authoritative information
+        bool _has_quantized_attribute;
 
     public:
         WriteContext(ExecutorId executorId) noexcept;
@@ -71,9 +80,13 @@ public:
         void add(AttributeVector& attr);
         ExecutorId getExecutorId() const { return _executorId; }
         const std::vector<WriteField>& getFields() const { return _fields; }
-        bool hasStructFieldAttribute() const { return _hasStructFieldAttribute; }
-        bool use_two_phase_put() const { return _use_two_phase_put; }
-        std::shared_ptr<const FieldPath> get_two_phase_put_field_path() const noexcept {
+        [[nodiscard]] bool hasStructFieldAttribute() const noexcept { return _hasStructFieldAttribute; }
+        [[nodiscard]] bool use_two_phase_put() const noexcept { return _use_two_phase_put; }
+        [[nodiscard]] bool has_quantized_attribute() const noexcept { return _has_quantized_attribute; }
+        [[nodiscard]] bool has_non_authoritative_attribute() const noexcept {
+            return _hasStructFieldAttribute || _has_quantized_attribute;
+        }
+        [[nodiscard]] std::shared_ptr<const FieldPath> get_two_phase_put_field_path() const noexcept {
             return _two_phase_put_field_path;
         }
     };
@@ -91,6 +104,7 @@ private:
     using AttrMap = vespalib::hash_map<std::string, AttributeWithInfo>;
     std::vector<WriteContext> _writeContexts;
     bool                      _hasStructFieldAttribute;
+    bool                      _has_quantized_attribute;
     AttrMap                   _attrMap;
 
     void setupWriteContexts();
@@ -123,7 +137,8 @@ public:
     void forceCommit(const CommitParam& param, const OnWriteDoneType& onWriteDone) override;
 
     void onReplayDone(uint32_t docIdLimit) override;
-    bool hasStructFieldAttribute() const override;
+    [[nodiscard]] bool hasStructFieldAttribute() const override;
+    [[nodiscard]] bool has_non_authoritative_attribute() const noexcept override;
     void drain(const OnWriteDoneType& onWriteDone) override;
 
     // Should only be used for unit testing.

--- a/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_writer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_writer.h
@@ -68,7 +68,8 @@ public:
     virtual void forceCommit(const CommitParam& param, const OnWriteDoneType& onWriteDone) = 0;
 
     virtual void onReplayDone(uint32_t docIdLimit) = 0;
-    virtual bool hasStructFieldAttribute() const = 0;
+    [[nodiscard]] virtual bool hasStructFieldAttribute() const = 0;
+    [[nodiscard]] virtual bool has_non_authoritative_attribute() const noexcept = 0;
     virtual void drain(const OnWriteDoneType& onWriteDone) = 0;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/common/attribute_updater.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/attribute_updater.cpp
@@ -210,6 +210,11 @@ template <> void AttributeUpdater::handleUpdate(PredicateAttribute& vec, uint32_
 
 template <> void AttributeUpdater::handleUpdate(TensorAttribute& vec, uint32_t lid, const ValueUpdate& upd) {
     LOG(spam, "handleUpdate(%s, %u): %s", vec.getName().c_str(), lid, toString(upd).c_str());
+    if (vec.is_quantized()) {
+        LOG(debug, "Ignoring partial update to quantized tensor attribute '%s'; will be updated via setTensor",
+            vec.getName().c_str());
+        return;
+    }
     ValueUpdate::ValueUpdateType op = upd.getType();
     assert(!vec.hasMultiValue());
     if (op == ValueUpdate::Assign) {
@@ -489,7 +494,11 @@ void AttributeUpdater::updateValue(TensorAttribute& vec, uint32_t lid, const Fie
     validate_field_value_type(FieldValue::Type::TENSOR, val, "TensorAttribute", "TensorFieldValue");
     const auto* tensor = static_cast<const TensorFieldValue&>(val).getAsTensorPtr();
     if (tensor) {
-        vec.setTensor(lid, *tensor);
+        if (!vec.is_quantized()) {
+            vec.setTensor(lid, *tensor);
+        } else {
+            vec.setTensor(lid, *vec.make_quantizer()->quantize(*tensor));
+        }
     } else {
         vec.clearDoc(lid);
     }
@@ -557,13 +566,42 @@ void validate_tensor_attribute_type(AttributeVector& attr) {
     }
 }
 
+/*
+ * Quantized tensor attributes require input tensors to be pre-quantized for both
+ * the preparation and completion steps. To avoid having to re-quantize the original
+ * tensor upon completion, wrap the PrepareResult from the underlying attribute and
+ * remember the quantized result explicitly across the two calls.
+ */
+struct QuantizedPrepareResultWrapper : PrepareResult {
+    std::unique_ptr<PrepareResult>         _nested_prepare;
+    std::unique_ptr<vespalib::eval::Value> _quant_tensor;
+
+    QuantizedPrepareResultWrapper(std::unique_ptr<PrepareResult>         nested_prepare,
+                                  std::unique_ptr<vespalib::eval::Value> quant_tensor) noexcept
+        : _nested_prepare(std::move(nested_prepare)), _quant_tensor(std::move(quant_tensor)) {}
+    ~QuantizedPrepareResultWrapper() override;
+
+    [[nodiscard]] const vespalib::eval::Value& quantized_tensor() const noexcept { return *_quant_tensor; }
+    [[nodiscard]] std::unique_ptr<PrepareResult> steal_nested_prepare() noexcept {
+        return std::move(_nested_prepare);
+    }
+};
+
+QuantizedPrepareResultWrapper::~QuantizedPrepareResultWrapper() = default;
+
 std::unique_ptr<PrepareResult> prepare_set_tensor(TensorAttribute& attr, uint32_t docid, const FieldValue& val) {
     validate_field_value_type(FieldValue::Type::TENSOR, val, "TensorAttribute", "TensorFieldValue");
     const auto* tensor = static_cast<const TensorFieldValue&>(val).getAsTensorPtr();
     if (tensor) {
-        return attr.prepare_set_tensor(docid, *tensor);
+        if (!attr.is_quantized()) {
+            return attr.prepare_set_tensor(docid, *tensor);
+        } else {
+            auto quantized_tensor = attr.make_quantizer()->quantize(*tensor);
+            auto result = attr.prepare_set_tensor(docid, *quantized_tensor);
+            return std::make_unique<QuantizedPrepareResultWrapper>(std::move(result), std::move(quantized_tensor));
+        }
     }
-    return std::unique_ptr<PrepareResult>();
+    return {};
 }
 
 void complete_set_tensor(TensorAttribute& attr, uint32_t docid, const FieldValue& val,
@@ -571,7 +609,14 @@ void complete_set_tensor(TensorAttribute& attr, uint32_t docid, const FieldValue
     validate_field_value_type(FieldValue::Type::TENSOR, val, "TensorAttribute", "TensorFieldValue");
     const auto* tensor = static_cast<const TensorFieldValue&>(val).getAsTensorPtr();
     if (tensor) {
-        attr.complete_set_tensor(docid, *tensor, std::move(prepare_result));
+        if (!attr.is_quantized()) {
+            attr.complete_set_tensor(docid, *tensor, std::move(prepare_result));
+        } else {
+            auto* quantized_wrapper = dynamic_cast<QuantizedPrepareResultWrapper*>(prepare_result.get());
+            assert(quantized_wrapper != nullptr);
+            attr.complete_set_tensor(docid, quantized_wrapper->quantized_tensor(),
+                                     quantized_wrapper->steal_nested_prepare());
+        }
     } else {
         attr.clearDoc(docid);
     }

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_feed_view.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_feed_view.cpp
@@ -32,7 +32,7 @@ void FastAccessFeedView::updateAttributes(SerialNum serialNum, search::DocumentI
 
 void FastAccessFeedView::updateAttributes(SerialNum serialNum, Lid lid, FutureDoc futureDoc,
                                           const OnOperationDoneType& onWriteDone) {
-    if (_attributeWriter->hasStructFieldAttribute()) {
+    if (_attributeWriter->has_non_authoritative_attribute()) {
         const std::unique_ptr<const Document>& doc = futureDoc.get();
         if (doc) {
             _attributeWriter->update(serialNum, *doc, lid, onWriteDone);

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.cpp
@@ -143,12 +143,14 @@ class UpdateScope final : public IFieldUpdateCallback {
 private:
     const vespalib::hash_set<int32_t>& _indexedFields;
     bool                               _nonAttributeFields;
+    bool                               _hasIndexedFields;
 
 public:
-    bool _hasIndexedFields;
-
     UpdateScope(const vespalib::hash_set<int32_t>& indexedFields, const DocumentUpdate& upd);
-    bool hasIndexOrNonAttributeFields() const { return _hasIndexedFields || _nonAttributeFields; }
+    [[nodiscard]] bool has_indexed_fields() const noexcept { return _hasIndexedFields; }
+    [[nodiscard]] bool hasIndexOrNonAttributeFields() const noexcept {
+        return _hasIndexedFields || _nonAttributeFields;
+    }
     void onUpdateField(const document::Field& field, const search::AttributeVector* attr) override;
 };
 
@@ -159,6 +161,9 @@ UpdateScope::UpdateScope(const vespalib::hash_set<int32_t>& indexedFields, const
 }
 
 void UpdateScope::onUpdateField(const document::Field& field, const search::AttributeVector* attr) {
+    // Quantized tensor attributes are implicitly treated as non-attributes since they're not
+    // update-able in memory only.
+    // TODO avoid presenting non-authoritative attributes as non-attributes... Feels a bit fragile.
     if (!_nonAttributeFields && (attr == nullptr || !attr->isUpdateableInMemoryOnly())) {
         _nonAttributeFields = true;
     }
@@ -422,7 +427,7 @@ void StoreOnlyFeedView::internalUpdate(FeedToken token, const UpdateOperation& u
         FutureDoc   futureDoc = promisedDoc.get_future().share();
         onWriteDone->setDocument(futureDoc);
         _pendingLidsForDocStore.waitComplete(lid);
-        if (updateScope._hasIndexedFields) {
+        if (updateScope.has_indexed_fields()) {
             updateIndexedFields(serialNum, lid, futureDoc, onWriteDone);
         }
         PromisedStream promisedStream;


### PR DESCRIPTION
@toregge @arnej27959 please review and cross-check if my data flow assumptions are correct here. This is perhaps the most "controversial" change of the lot :eyes:

This tries to generalize the existing special handling of struct field attributes into  that of "non-authoritative" attributes that require updates to do a document store read-modify-write, followed by a logical Put to the attribute. I feel that the existing abstractions are a bit leaky, and they don't necessarily become more watertight with these changes. But hopefully not _less_.

Quantized tensor attributes are considered non-authoritative since the attribute content is inherently lossy and therefore cannot be used as input to partial update operations. Assign-updates that replace the entire field support using two-phase puts as with non-quantized tensors, as there is no need for a read-back.

All input tensors are explicitly pre-quantized prior to insertion, including for two-phase puts. The latter remembers the quantized tensor value between the `prepare` and `complete`-steps to avoid having to re-quantize the input tensor.

