### PR TITLE
Report whether an update found its target document

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1472,7 +1472,8 @@
       "public boolean protonResampleDiskCapacity()",
       "public boolean fastMapSearch()",
       "public boolean relaxStrictlyIncreasingClusterStateVersions()",
-      "public boolean commerceDiscovery()"
+      "public boolean commerceDiscovery()",
+      "public boolean documentV1ReportWasFound()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -138,6 +138,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"johsol", "boeker", "arnej"}) default boolean fastMapSearch() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean relaxStrictlyIncreasingClusterStateVersions() { return false; }
         @ModelFeatureFlag(owners = {"sebasabe"}) default boolean commerceDiscovery() { return false; }
+        @ModelFeatureFlag(owners = {"vekterli"}) default boolean documentV1ReportWasFound() { return false; }
     }
 
     /** Warning: As elsewhere in this package, do not make backwards incompatible changes that will break old config models! */

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -107,6 +107,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     private final int transport_events_before_wakeup;
     private final int transport_connections_per_target;
     private int maxDocumentOperationRequestSizeMib = new DocumentOperationExecutorConfig.Builder().build().maxDocumentOperationRequestSizeMib();
+    private final boolean documentV1ReportWasFound;
 
     /** The heap size % of total memory available to the JVM process. */
     private final int heapSizePercentageOfAvailableMemory;
@@ -157,6 +158,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
         onnxModelCostCalculator = deployState.onnxModelCost().newCalculator(
                 deployState.getApplicationPackage(), deployState.getProperties().applicationId(), ClusterSpec.Id.from(clusterId));
         logger = deployState.getDeployLogger();
+        documentV1ReportWasFound = deployState.featureFlags().documentV1ReportWasFound();
     }
 
     public ClusterSpec getSpec() { return spec; }
@@ -451,6 +453,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     @Override
     public void getConfig(DocumentOperationExecutorConfig.Builder builder) {
         builder.maxDocumentOperationRequestSizeMib(maxDocumentOperationRequestSizeMib);
+        builder.reportWasFound(documentV1ReportWasFound);
     }
 
     public static class MbusParams {

--- a/configdefinitions/src/vespa/document-operation-executor.def
+++ b/configdefinitions/src/vespa/document-operation-executor.def
@@ -19,3 +19,7 @@ maxThrottledBytes double default=-0.25
 
 # Maximum document POST or PUT request size in MiB, 
 maxDocumentOperationRequestSizeMib int default=100
+
+# Whether responses to document/v1 update operations include a "wasFound" field stating whether
+# the update had an existing document to apply itself to.
+reportWasFound bool default=false

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -265,6 +265,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean fastMapSearch() { return flag(Flags.FAST_MAP_SEARCH).value(); }
         @Override public boolean relaxStrictlyIncreasingClusterStateVersions() { return flag(Flags.RELAX_STRICTLY_INCREASING_CLUSTER_STATE_VERSIONS).value(); }
         @Override public boolean commerceDiscovery() { return flag(Flags.COMMERCE_DISCOVERY).value(); }
+        @Override public boolean documentV1ReportWasFound() { return flag(Flags.DOCUMENT_V1_REPORT_WAS_FOUND).value(); }
 
         private static OptionalInt toOptionalInt(int value) {
             return value > 0 ? OptionalInt.of(value) : OptionalInt.empty();

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -281,6 +281,16 @@ public class Flags {
             TENANT_ID
     );
 
+    public static final UnboundBooleanFlag DOCUMENT_V1_REPORT_WAS_FOUND = defineFeatureFlag(
+            "document-v1-report-was-found", false,
+            List.of("vekterli"), "2026-09-01", "2027-03-01",
+            "Whether the document/v1 API includes a 'wasFound' field in the JSON response to update " +
+            "operations, stating whether the update had an existing document to apply itself to. " +
+            "Gated since it adds a key to a response schema some clients may have hard-coded.",
+            "Takes effect at redeployment",
+            INSTANCE_ID
+    );
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,

--- a/vespa-feed-client-api/abi-spec.json
+++ b/vespa-feed-client-api/abi-spec.json
@@ -379,7 +379,8 @@
       "public abstract ai.vespa.feed.client.Result$Type type()",
       "public abstract ai.vespa.feed.client.DocumentId documentId()",
       "public abstract java.util.Optional resultMessage()",
-      "public abstract java.util.Optional traceMessage()"
+      "public abstract java.util.Optional traceMessage()",
+      "public java.util.Optional wasFound()"
     ],
     "fields" : [ ]
   },

--- a/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/Result.java
+++ b/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/Result.java
@@ -20,4 +20,16 @@ public interface Result {
     DocumentId documentId();
     Optional<String> resultMessage();
     Optional<String> traceMessage();
+
+    /**
+     * Whether the target document existed when an update was applied, as reported by the {@code wasFound}
+     * field of the document/v1 response. An update against a document which does not exist, and which does
+     * not specify that the document should be created if missing, is a no-op — such a result has
+     * {@code Optional.of(false)} here, while still being a {@link Type#success}.
+     *
+     * Empty when the server did not report this, i.e. for all non-update operations, and for updates against
+     * Vespa versions or configurations which do not include the field.
+     */
+    default Optional<Boolean> wasFound() { return Optional.empty(); }
+
 }

--- a/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliClient.java
+++ b/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliClient.java
@@ -155,7 +155,8 @@ public class CliClient {
         else {
             successes.incrementAndGet();
             if (args.showSuccesses()) synchronized (printMonitor) {
-                systemError.println(result.documentId() + ": " + result.type());
+                systemError.println(result.documentId() + ": " + result.type()
+                                    + (result.wasFound().orElse(true) ? "" : " (no such document)"));
                 result.traceMessage().ifPresent(systemError::println);
                 result.resultMessage().ifPresent(systemError::println);
             }

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/HttpFeedClient.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/HttpFeedClient.java
@@ -219,15 +219,18 @@ class HttpFeedClient implements FeedClient {
     private static class MessageAndTrace {
         final String message;
         final String trace;
-        MessageAndTrace(String message, String trace) {
+        final Boolean wasFound;
+        MessageAndTrace(String message, String trace, Boolean wasFound) {
             this.message = message;
             this.trace = trace;
+            this.wasFound = wasFound;
         }
     }
 
     static MessageAndTrace parse(DocumentId documentId, byte[] json) {
         String message = null;
         String trace = null;
+        Boolean wasFound = null;
         try (JsonParser parser = jsonParserFactory.createParser(json)) {
             if (parser.nextToken() != JsonToken.START_OBJECT)
                 throw new ResultParseException(
@@ -240,6 +243,9 @@ class HttpFeedClient implements FeedClient {
                 switch (name) {
                     case "message":
                         message = parser.nextTextValue();
+                        break;
+                    case "wasFound":
+                        wasFound = parser.nextBooleanValue();
                         break;
                     case "trace":
                         if (parser.nextToken() != JsonToken.START_ARRAY)
@@ -271,7 +277,7 @@ class HttpFeedClient implements FeedClient {
             throw new ResultParseException(documentId, e);
         }
 
-        return new MessageAndTrace(message, trace);
+        return new MessageAndTrace(message, trace, wasFound);
     }
 
     static Result toResult(HttpRequest request, HttpResponse response, DocumentId documentId) {
@@ -296,7 +302,7 @@ class HttpFeedClient implements FeedClient {
         if (outcome == Outcome.vespaFailure)
             throw new ResultException(documentId, mat.message, mat.trace);
 
-        return new ResultImpl(toResultType(outcome), documentId, mat.message, mat.trace);
+        return new ResultImpl(toResultType(outcome), documentId, mat.message, mat.trace, mat.wasFound);
     }
 
     static String getPath(DocumentId documentId) {

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/ResultImpl.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/ResultImpl.java
@@ -18,18 +18,21 @@ public class ResultImpl implements Result {
     private final DocumentId documentId;
     private final String resultMessage;
     private final String traceMessage;
+    private final Boolean wasFound;
 
-    ResultImpl(Type type, DocumentId documentId, String resultMessage, String traceMessage) {
+    ResultImpl(Type type, DocumentId documentId, String resultMessage, String traceMessage, Boolean wasFound) {
         this.type = type;
         this.documentId = documentId;
         this.resultMessage = resultMessage;
         this.traceMessage = traceMessage;
+        this.wasFound = wasFound;
     }
 
     @Override public Type type() { return type; }
     @Override public DocumentId documentId() { return documentId; }
     @Override public Optional<String> resultMessage() { return Optional.ofNullable(resultMessage); }
     @Override public Optional<String> traceMessage() { return Optional.ofNullable(traceMessage); }
+    @Override public Optional<Boolean> wasFound() { return Optional.ofNullable(wasFound); }
 
     @Override
     public String toString() {
@@ -38,6 +41,7 @@ public class ResultImpl implements Result {
                ", documentId=" + documentId +
                ", resultMessage='" + resultMessage + '\'' +
                ", traceMessage='" + traceMessage + '\'' +
+               ", wasFound=" + wasFound +
                '}';
     }
 

--- a/vespa-feed-client/src/test/java/ai/vespa/feed/client/impl/HttpFeedClientTest.java
+++ b/vespa-feed-client/src/test/java/ai/vespa/feed/client/impl/HttpFeedClientTest.java
@@ -82,6 +82,33 @@ class HttpFeedClientTest {
         assertEquals(id, result.documentId());
         assertEquals(Optional.empty(), result.resultMessage());
         assertEquals(Optional.empty(), result.traceMessage());
+        assertEquals(Optional.empty(), result.wasFound()); // Not reported by this response.
+
+        // An update against a document which does not exist is a success, but a no-op, which "wasFound" reports.
+        dispatch.set((documentId, request) -> CompletableFuture.completedFuture(
+                HttpResponse.of(200,
+                                ("""
+                                 {
+                                   "pathId": "/document/v1/ns/type/docid/0",
+                                   "id": "id:ns:type::0",
+                                   "wasFound": false
+                                 }""").getBytes(UTF_8))));
+        result = client.update(id, "json", OperationParameters.empty()).get();
+        assertEquals(Result.Type.success, result.type());
+        assertEquals(Optional.of(false), result.wasFound());
+
+        // ... and is true when the update did have a document to apply itself to.
+        dispatch.set((documentId, request) -> CompletableFuture.completedFuture(
+                HttpResponse.of(200,
+                                ("""
+                                 {
+                                   "pathId": "/document/v1/ns/type/docid/0",
+                                   "id": "id:ns:type::0",
+                                   "wasFound": true
+                                 }""").getBytes(UTF_8))));
+        result = client.update(id, "json", OperationParameters.empty()).get();
+        assertEquals(Result.Type.success, result.type());
+        assertEquals(Optional.of(true), result.wasFound());
 
         // Remove is a DELETE, and 412 OK is a conditionNotMet.
         dispatch.set((documentId, request) -> {

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -37,6 +37,7 @@ import com.yahoo.documentapi.DocumentResponse;
 import com.yahoo.documentapi.ProgressToken;
 import com.yahoo.documentapi.Response.Outcome;
 import com.yahoo.documentapi.Result;
+import com.yahoo.documentapi.UpdateResponse;
 import com.yahoo.documentapi.VisitorControlHandler;
 import com.yahoo.documentapi.VisitorControlSession;
 import com.yahoo.documentapi.VisitorDataHandler;
@@ -191,6 +192,7 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
     private final long maxThrottledAgeNS;
     private final long maxThrottledTotalBytes;
     private final long maxDocumentOperationRequestSizeBytes;
+    private final boolean reportWasFound;
     private final DocumentAccess access;
     private final AsyncSession asyncSession;
     private final Map<String, StorageCluster> clusters;
@@ -229,6 +231,7 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
         this.maxThrottledAgeNS = (long) (executorConfig.maxThrottledAge() * 1_000_000_000.0);
         this.maxThrottledTotalBytes = calculateMaxThrottledTotalBytes(executorConfig);
         this.maxDocumentOperationRequestSizeBytes = (long) executorConfig.maxDocumentOperationRequestSizeMib() * 1024 * 1024;
+        this.reportWasFound = executorConfig.reportWasFound();
 
         log.info(Text.format("Operation queue: max-items=%d, max-age=%d ms, max-bytes=%s",
                 maxThrottled, Duration.ofNanos(maxThrottledAgeNS).toMillis(), BytesQuantity.ofBytes(maxThrottledTotalBytes).asPrettyString()));
@@ -949,11 +952,11 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
         void onSuccess(Document document, JsonResponse response, boolean ignoredOperation) throws IOException;
     }
 
-    private static void handle(DocumentPath path,
-                               HttpRequest request,
-                               ResponseHandler handler,
-                               com.yahoo.documentapi.Response response,
-                               SuccessCallback callback) {
+    private void handle(DocumentPath path,
+                        HttpRequest request,
+                        ResponseHandler handler,
+                        com.yahoo.documentapi.Response response,
+                        SuccessCallback callback) {
         var tensorOptions = createTensorOptionsFromRequest(request); // request may be null; implies short form
         try (JsonResponse jsonResponse = JsonResponse.createWithPathAndId(path, handler, tensorOptions)) {
             jsonResponse.writeTrace(response.getTrace());
@@ -985,11 +988,17 @@ public final class DocumentV1ApiHandler extends AbstractRequestHandler {
         }
     }
 
-    private static void handleFeedOperation(DocumentPath path,
-                                            boolean fullyApplied,
-                                            ResponseHandler handler,
-                                            com.yahoo.documentapi.Response response) {
+    private void handleFeedOperation(DocumentPath path,
+                                     boolean fullyApplied,
+                                     ResponseHandler handler,
+                                     com.yahoo.documentapi.Response response) {
         handle(path, null, handler, response, (document, jsonResponse, ignoredOperation) -> {
+            // An update against a document which does not exist is a no-op, but still a success; tell the client
+            // whether the update actually had a document to apply itself to. Note that this is true also when the
+            // document was created as part of the update, since the operation then did take effect.
+            if (reportWasFound && response instanceof UpdateResponse update) {
+                jsonResponse.writeWasFound(update.wasFound());
+            }
             jsonResponse.commit(Status.OK, fullyApplied, ignoredOperation);
         });
     }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonNames.java
@@ -26,4 +26,5 @@ class JsonNames {
     static final SerializedString SEVERITY         = new SerializedString("severity");
     static final SerializedString TEXT             = new SerializedString("text");
     static final SerializedString TOKEN            = new SerializedString("token");
+    static final SerializedString WAS_FOUND        = new SerializedString("wasFound");
 }

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonResponse.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/JsonResponse.java
@@ -171,6 +171,12 @@ class JsonResponse implements StreamableJsonResponse {
         // Severity is not included in the legacy format
     }
 
+    /** Writes whether an update operation had an existing document to apply itself to. */
+    synchronized void writeWasFound(boolean wasFound) throws IOException {
+        json.writeFieldName(JsonNames.WAS_FOUND);
+        json.writeBoolean(wasFound);
+    }
+
     @Override
     public synchronized void writeDocumentCount(long count) throws IOException {
         json.writeFieldName(JsonNames.DOCUMENT_COUNT);

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -1173,6 +1173,57 @@ public class DocumentV1ApiTest {
         assertEquals("true", vals.get(0));
     }
 
+    /** Feeds an update against a document which the backing session reports as {@code wasFound}, and returns the response body. */
+    private String updateResponseBodyWithWasFoundReporting(boolean reportWasFound, boolean wasFound, String query) {
+        var handler = new DocumentV1ApiHandler(
+                clock, Duration.ofMillis(1), metric, metrics, access, docConfig,
+                new DocumentOperationExecutorConfig.Builder(executorConfig).reportWasFound(reportWasFound).build(),
+                clusterConfig, bucketConfig);
+        var driver = new RequestHandlerTestDriver(handler); // try-with-resources hangs the test on assertion failure, which isn't optimal
+        access.session.expect((update, parameters) -> {
+            parameters.responseHandler().get().handleResponse(new UpdateResponse(0, wasFound));
+            return new Result();
+        });
+        var response = driver.sendRequest("http://localhost/document/v1/space/music/docid/sonny" + query, PUT,
+                """
+                {
+                  "fields": {
+                    "artist": { "assign": "The Shivers" }
+                  }
+                }""");
+        assertEquals(200, response.getStatus());
+        return response.readAll();
+    }
+
+    @Test
+    void update_of_missing_document_reports_was_found_when_enabled() {
+        // A partial update against a document which does not exist is a no-op, and the response says so.
+        assertSameJson("""
+                {
+                  "pathId": "/document/v1/space/music/docid/sonny",
+                  "id": "id:space:music::sonny",
+                  "wasFound": false
+                }""", updateResponseBodyWithWasFoundReporting(true, false, ""));
+
+        // ... but not when the document was created as part of the update, since the operation then took effect.
+        assertSameJson("""
+                {
+                  "pathId": "/document/v1/space/music/docid/sonny",
+                  "id": "id:space:music::sonny",
+                  "wasFound": true
+                }""", updateResponseBodyWithWasFoundReporting(true, true, "?create=true"));
+    }
+
+    @Test
+    void update_does_not_report_was_found_unless_enabled() {
+        // The field is gated behind config, since it adds a key to a response schema clients may have hard-coded.
+        assertSameJson("""
+                {
+                  "pathId": "/document/v1/space/music/docid/sonny",
+                  "id": "id:space:music::sonny"
+                }""", updateResponseBodyWithWasFoundReporting(false, false, ""));
+    }
+
     @Test
     void visit_with_application_jsonl_accept_header_returns_json_lines() {
         var driver = new RequestHandlerTestDriver(handler); // try-with-resources hangs the test on assertion failure, which isn't optimal


### PR DESCRIPTION
Addresses #37132. Supersedes #37615, which took the rejected approach of reusing the `X-Vespa-Ignored-Operation` response header; opened fresh so the review starts clean.

## Background

A partial update against a document which does not exist, and which does not ask for the document to be created, is a no-op — but it comes back as a plain 200 OK. A client cannot tell it apart from an update that took effect without resorting to a dummy test-and-set condition and checking for 412, which adds per-operation overhead and changes the operation's semantics.

Per @vekterli's conclusion on the issue, this does **not** reuse `X-Vespa-Ignored-Operation` (whose "matched no cluster's document selection, never routed anywhere" meaning is legally distinct, and would become ambiguous for Puts), nor does it change the status code. It adds a `wasFound` key to the JSON response payload of update operations instead.

## Changes

**Server** — `document/v1` writes `"wasFound": <bool>` into the response body of update operations, read straight from `UpdateResponse.wasFound()`. No special-casing is needed for `create=true`: that already reports `true`, since the operation did take effect. `handle()`/`handleFeedOperation()` become instance methods to read the config field.

**Feature flag** — `document-v1-report-was-found`, default off, plumbed through `Flags` → `ModelContext.FeatureFlags` → `ModelContextImpl` → `ApplicationContainerCluster` → `document-operation-executor.def`, mirroring the `maxDocumentOperationRequestSizeMib` precedent. Gated because it adds a key to a response schema some clients may have hard-coded.

**Client** — `vespa-feed-client` parses the field and exposes it as `Result.wasFound()`.

## Two API choices worth a look

- **`Optional<Boolean>`, not `boolean`.** A bare `boolean` cannot distinguish "the server said false" from "the server said nothing" — a non-update operation, the flag off, or an older Vespa. Since a false-meaning-unknown is precisely the silent failure this issue is about, the absent case is modelled explicitly.
- **It is a `default` method.** `Result` is published API in `vespa-feed-client-api`, so an abstract method would break outside implementers at compile time. The three existing test implementors compile untouched, which is the practical demonstration.

## Testing

- `DocumentV1ApiTest` — new cases covering `wasFound` false, `wasFound` true via `create=true`, and the field's absence when the flag is off.
- `HttpFeedClientTest` — new cases for both polarities, plus asserting `Optional.empty()` on a response that does not carry the field.
- `vespa-feed-client{,-api,-cli}`, `vespaclient-container-plugin`, `config-model`, `flags`, `config-model-api` tests pass; `configserver` compiles. Both `abi-spec.json` updates verified by running the abicheck plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)