### PR TITLE
Support JSON objects and arrays as YQL parameter substitution values

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/yql/ParameterListParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/ParameterListParser.java
@@ -8,7 +8,8 @@ import com.yahoo.prelude.query.WeightedSetItem;
 import java.util.Arrays;
 
 /**
- * Parser of parameter lists on the form {key:value, key:value} or [[key,value], [key,value], ...]
+ * Parser of parameter lists on the form {key:value, key:value} or [[key,value], [key,value], ...],
+ * and of token lists on the form value, value, ... optionally enclosed in [ ].
  *
  * @author bratseth
  */
@@ -68,7 +69,8 @@ class ParameterListParser {
             return;
         }
         var s = new ParsableString(string);
-        while (!s.atEnd()) {
+        boolean array = s.passOptional('['); // A JSON array: ["a", "b"]
+        while (!s.atEnd() && !(array && s.peek() == ']')) {
             String token;
             if (s.passOptional('\'')) {
                 token = s.stringTo(s.position('\''));
@@ -79,11 +81,13 @@ class ParameterListParser {
                 s.pass('"');
             }
             else {
-                token = s.stringTo(s.positionOrEnd(',')).trim();
+                token = s.stringTo(array ? s.positionOrEnd(',', ']') : s.positionOrEnd(',')).trim();
             }
             out.addToken(token);
             s.passOptional(',');
         }
+        if (array)
+            s.pass(']');
     }
 
     public static void addNumericTokensFromString(String string, NumericInItem out) {
@@ -91,11 +95,14 @@ class ParameterListParser {
             return;
         }
         var s = new ParsableString(string);
-        while (!s.atEnd()) {
-            long token = s.longTo(s.positionOrEnd(','));
+        boolean array = s.passOptional('['); // A JSON array: [1, 2]
+        while (!s.atEnd() && !(array && s.peek() == ']')) {
+            long token = s.longTo(array ? s.positionOrEnd(',', ']') : s.positionOrEnd(','));
             out.addToken(token);
             s.passOptional(',');
         }
+        if (array)
+            s.pass(']');
     }
 
     private static class ParsableString {

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -2212,10 +2212,39 @@ public class YqlParser implements Parser {
             case ARRAY -> addLongItems(ast, out);
             case VARREF -> {
                 Preconditions.checkState(userQuery != null, "Query properties are not available");
-                ParameterListParser.addItemsFromString(userQuery.properties().getString(ast.getArgument(0, String.class)), out);
+                String name = ast.getArgument(0, String.class);
+                String value = userQuery.properties().getString(name);
+                if (value != null)
+                    ParameterListParser.addItemsFromString(value, out);
+                else
+                    addItemsFromSubProperties(name, out);
             }
             default -> throw newUnexpectedArgumentException(ast.getOperator(),
                                                             ExpressionOperator.ARRAY, ExpressionOperator.MAP);
+        }
+    }
+
+    /**
+     * Adds the items of a parameter which is passed as a JSON object. Such objects are flattened into
+     * dot-separated properties when the query is parsed, so the entries are read back as sub-properties
+     * of the parameter name.
+     */
+    private void addItemsFromSubProperties(String name, WeightedSetItem out) {
+        var entries = userQuery.properties().listProperties(name);
+        if (entries.isEmpty())
+            throw new IllegalArgumentException("No value found for query parameter '" + name + "'");
+        for (var entry : entries.entrySet())
+            out.addToken(entry.getKey(), toWeight(name, entry.getKey(), entry.getValue()));
+    }
+
+    private static int toWeight(String parameterName, String key, Object value) {
+        if (value instanceof Number number) return number.intValue();
+        try {
+            return Integer.parseInt(value.toString().trim());
+        }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Expected an integer weight of '" + key + "' in query parameter '" +
+                                               parameterName + "', but got '" + value + "'");
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/handler/Json2SinglelevelMapTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/Json2SinglelevelMapTestCase.java
@@ -1,6 +1,12 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.handler;
 
+import com.yahoo.component.chain.Chain;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.searchchain.Execution;
+import com.yahoo.search.yql.MinimalQueryInserter;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -8,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Json2SinglelevelMapTestCase {
@@ -37,4 +44,46 @@ public class Json2SinglelevelMapTestCase {
         assertTrue(m.containsKey("yql"));
         assertEquals("text", m.get("yql"));
     }
+
+    /** A parameter which is a JSON object is dotted out, and read back as sub-properties when substituted. */
+    @Test
+    void testParameterSubstitutionOfAJsonObject() {
+        Map<String, String> m = parse("""
+                                      {
+                                        "yql": "select * from sources * where wand(terms, @q_terms)",
+                                        "q_terms": { "7128": 34, "2622": 18 }
+                                      }
+                                      """);
+        assertEquals("34", m.get("q_terms.7128"));
+        assertEquals("18", m.get("q_terms.2622"));
+        assertEquals("select * from sources * where wand(terms, {\"2622\": 18, \"7128\": 34})",
+                     yqlOf(m));
+    }
+
+    /** A parameter which is a JSON array is kept verbatim, and parsed as an array when substituted. */
+    @Test
+    void testParameterSubstitutionOfAJsonArray() {
+        Map<String, String> m = parse("""
+                                      {
+                                        "yql": "select * from sources * where wand(terms, @q_terms)",
+                                        "q_terms": [ [7128, 34], [2622, 18] ]
+                                      }
+                                      """);
+        assertEquals("[ [7128, 34], [2622, 18] ]", m.get("q_terms"));
+        assertEquals("select * from sources * where wand(terms, {\"2622\": 18, \"7128\": 34})",
+                     yqlOf(m));
+    }
+
+    private static Map<String, String> parse(String json) {
+        return new Json2SingleLevelMap(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))).parse();
+    }
+
+    private static String yqlOf(Map<String, String> requestMap) {
+        Query query = new Query.Builder().setRequestMap(requestMap).build();
+        Result result = new Execution(new Chain<Searcher>(new MinimalQueryInserter()),
+                                      Execution.Context.createContextStub()).search(query);
+        assertNull(result.hits().getError());
+        return query.yqlRepresentation();
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/yql/ParameterListParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/ParameterListParserTestCase.java
@@ -1,12 +1,17 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.yql;
 
+import com.yahoo.prelude.query.NumericInItem;
+import com.yahoo.prelude.query.StringInItem;
 import com.yahoo.prelude.query.WeightedSetItem;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author bratseth
@@ -33,6 +38,59 @@ public class ParameterListParserTestCase {
         assertParsed("[[0,12],[1,13]]", Map.of(0L, 12, 1L, 13));
         assertParsed("[[0,12], [1,13]]", Map.of(0L, 12, 1L, 13));
         assertParsed("  [ [0,12], [ 1,13]] ", Map.of(0L, 12, 1L, 13));
+    }
+
+    @Test
+    void testStringTokenListParsing() {
+        assertStringTokens("", List.of());
+        assertStringTokens("a", List.of("a"));
+        assertStringTokens("a,b", List.of("a", "b"));
+        assertStringTokens("a, b", List.of("a", "b"));
+        assertStringTokens("'a', \"b\"", List.of("a", "b"));
+        assertStringTokens("'a,b', c", List.of("a,b", "c"));
+    }
+
+    /** A JSON array, as produced by passing the parameter as an array in a POSTed JSON query. */
+    @Test
+    void testStringTokenListParsingOfJsonArray() {
+        assertStringTokens("[]", List.of());
+        assertStringTokens("[ ]", List.of());
+        assertStringTokens("[a]", List.of("a"));
+        assertStringTokens("[a, b]", List.of("a", "b"));
+        assertStringTokens("[\"a\", \"b\"]", List.of("a", "b"));
+        assertStringTokens("[ \"a\" , 'b' ]", List.of("a", "b"));
+        assertStringTokens("[\"a,b\", c]", List.of("a,b", "c"));
+        assertThrows(IllegalArgumentException.class, () -> assertStringTokens("[a, b", List.of()));
+    }
+
+    @Test
+    void testNumericTokenListParsing() {
+        assertNumericTokens("1", List.of(1L));
+        assertNumericTokens("1,2", List.of(1L, 2L));
+        assertNumericTokens("1, 2", List.of(1L, 2L));
+    }
+
+    /** A JSON array, as produced by passing the parameter as an array in a POSTed JSON query. */
+    @Test
+    void testNumericTokenListParsingOfJsonArray() {
+        assertNumericTokens("[]", List.of());
+        assertNumericTokens("[ ]", List.of());
+        assertNumericTokens("[1]", List.of(1L));
+        assertNumericTokens("[1, 2]", List.of(1L, 2L));
+        assertNumericTokens("[ 1 , 2 ]", List.of(1L, 2L));
+        assertThrows(IllegalArgumentException.class, () -> assertNumericTokens("[1, 2", List.of()));
+    }
+
+    private void assertStringTokens(String string, List<String> expected) {
+        StringInItem item = new StringInItem("test");
+        ParameterListParser.addStringTokensFromString(string, item);
+        assertEquals(Set.copyOf(expected), Set.copyOf(item.getTokens()), "Tokens of '" + string + "'");
+    }
+
+    private void assertNumericTokens(String string, List<Long> expected) {
+        NumericInItem item = new NumericInItem("test");
+        ParameterListParser.addNumericTokensFromString(string, item);
+        assertEquals(Set.copyOf(expected), Set.copyOf(item.getTokens()), "Tokens of '" + string + "'");
     }
 
     private void assertParsed(String string, Map<?, Integer> expected) {

--- a/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
@@ -393,6 +393,55 @@ public class UserInputTestCase {
         assertEquals("select * from sources * where (foo contains \"bamse\" AND foo contains phrase(\"bamse\", \"syntactic\", \"bamse\"))", query.yqlRepresentation());
     }
 
+    /** Parameters which are JSON objects are flattened into dotted properties when the query is parsed. */
+    @Test
+    void testJsonObjectReferenceInWand() {
+        URIBuilder builder = searchUri();
+        builder.setParameter("q_terms.7128", "34");
+        builder.setParameter("q_terms.2622", "18");
+        builder.setParameter("yql", "select * from sources * where wand(terms, @q_terms)");
+        Query query = searchAndAssertNoErrors(builder);
+        assertEquals("select * from sources * where wand(terms, {\"2622\": 18, \"7128\": 34})",
+                     query.yqlRepresentation());
+    }
+
+    @Test
+    void testJsonObjectReferenceInDotProduct() {
+        URIBuilder builder = searchUri();
+        builder.setParameter("weights.a", "1");
+        builder.setParameter("weights.b", "2");
+        builder.setParameter("yql", "select * from sources * where dotProduct(terms, @weights)");
+        Query query = searchAndAssertNoErrors(builder);
+        assertEquals("select * from sources * where dotProduct(terms, {\"a\": 1, \"b\": 2})",
+                     query.yqlRepresentation());
+    }
+
+    /** Keys containing dots survive the flattening, as only the parameter name prefix is removed. */
+    @Test
+    void testJsonObjectReferenceWithDottedKeys() {
+        URIBuilder builder = searchUri();
+        builder.setParameter("weights.a.b", "1");
+        builder.setParameter("yql", "select * from sources * where dotProduct(terms, @weights)");
+        Query query = searchAndAssertNoErrors(builder);
+        assertEquals("select * from sources * where dotProduct(terms, {\"a.b\": 1})",
+                     query.yqlRepresentation());
+    }
+
+    @Test
+    void testMissingReferenceInWand() {
+        URIBuilder builder = searchUri();
+        builder.setParameter("yql", "select * from sources * where wand(terms, @q_terms)");
+        assertQueryFails(builder);
+    }
+
+    @Test
+    void testJsonObjectReferenceWithNonIntegerWeight() {
+        URIBuilder builder = searchUri();
+        builder.setParameter("q_terms.7128", "notANumber");
+        builder.setParameter("yql", "select * from sources * where wand(terms, @q_terms)");
+        assertQueryFails(builder);
+    }
+
     @Test
     void testReferenceInComparison() {
         URIBuilder builder = searchUri();

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -1594,6 +1594,25 @@ public class YqlParserTestCase {
                         "and string fields. The fieldset mixed has both"));
     }
 
+    /** Parameters passed as arrays in a POSTed JSON query are seen as JSON arrays here. */
+    @Test
+    void testInWithJsonArrayParameters() {
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+
+        var query = new Query.Builder().build();
+        query.properties().set("foonumeric", "[26, 25, -11, 24]");
+        query.properties().set("foostring", "['this', \"might\", work]");
+
+        parser.setUserQuery(query);
+        assertNumericInItem("field", new long[]{-11, 24, 25, 26, 42},
+                            parse("select * from sources * where field in (42, @foonumeric)"));
+
+        parser.setUserQuery(query);
+        assertStringInItem("string", new String[]{"a", "might", "this", "work"},
+                           parse("select * from sources * where string in ('a', @foostring)"));
+        parser.setUserQuery(null);
+    }
+
     // TODO: Put this in the documentation
     @Test
     public void testProgrammaticYqlParsing() {


### PR DESCRIPTION
Fixes #29636.

## Problem

When a query is POSTed as JSON, `Json2SingleLevelMap` dots nested objects out into single level properties, so a parameter whose value is a JSON object is no longer readable as one property. `YqlParser` then passed `null` on to `ParameterListParser`, and the query failed with a 400 carrying an NPE message:

```
Could not create query from YQL: Cannot invoke "String.length()" because "this.s" is null
```

So only the string form worked

```json
{ "yql": "select * from sources * where wand(terms, @q_terms)",
  "q_terms": "{7128: 34, 2622: 18}" }
```

while the natural JSON form did not:

```json
{ "yql": "select * from sources * where wand(terms, @q_terms)",
  "q_terms": { "7128": 34, "2622": 18 } }
```

The `in` operator has the same problem with the natural JSON form of its parameter, an array: `"ids": [1, 2, 3]` threw `Expected an integer between positions 0 and 2, but got [1` on an integer field, and on a string field `["a", "b"]` silently produced the mangled tokens `["a"`, `b` and `]`.

## Fix

`YqlParser`: when a weighted set parameter (`wand`, `dotProduct`, `weightedSet`) has no value of its own, read its entries back from its sub-properties. This also covers the same parameters passed as dotted request parameters on a GET. Missing parameters and non-integer weights now give a proper message instead of an NPE.

`ParameterListParser`: accept an optional enclosing `[ ]` in the token lists used by `in`, so a parameter passed as a JSON array works there too. Unbracketed lists parse exactly as before.

## Tests

- `Json2SinglelevelMapTestCase`: the JSON object and JSON array forms of the issue, from the POSTed body through to the parsed query.
- `UserInputTestCase`: `wand` and `dotProduct` with a JSON object parameter, keys containing dots, a missing parameter, and a non-integer weight.
- `YqlParserTestCase`: `in` with JSON array parameters on integer and string fields.
- `ParameterListParserTestCase`: token lists with and without the enclosing brackets, including unterminated ones.

Full `container-search` suite passes (3012 tests).
