### PR TITLE
Pass numeric values as typed terms through sameElement syntax sugar

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -875,16 +875,15 @@ public class SelectParser implements Parser {
     private Item buildSameElementWithElementFilter(EqualsParams params) {
         int elementIndex = YqlParser.convertToElementId(params.index.asLong());
         var value = params.value;
-        // Convert value to string — sameElement only supports string children (consistent with YqlParser).
-        String stringValue = switch (value.type()) {
-            case BOOL -> String.valueOf(value.asBool());
-            case LONG -> String.valueOf(value.asLong());
-            case DOUBLE -> String.valueOf(value.asDouble());
-            case STRING -> value.asString();
+        // Numbers become numeric equality terms, other values word terms (consistent with YqlParser).
+        Item valueItem = switch (value.type()) {
+            case LONG -> new IntItem(String.valueOf(value.asLong()), "", true);
+            case DOUBLE -> new IntItem(String.valueOf(value.asDouble()), "", true);
+            case BOOL -> new WordItem(String.valueOf(value.asBool()), "", true);
+            case STRING -> new WordItem(value.asString(), "", true);
             default -> throw new IllegalArgumentException("'value' in 'equals' should be a boolean, integer, double, " +
                                                           "or string but was " + value.type());
         };
-        Item valueItem = new WordItem(stringValue, "", true);
 
         SameElementItem sameElement = new SameElementItem(params.field.asString());
         sameElement.setElementFilter(List.of(elementIndex));

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -376,7 +376,10 @@ public class VespaSerializer {
         @Override
         boolean serialize(StringBuilder destination, IntItem intItem, Boolean includeField) {
             if (intItem.getFromLimit().number().equals(intItem.getToLimit().number())) {
-                destination.append(normalizeIndexName(intItem.getIndexName())).append(" = ");
+                String indexName = normalizeIndexName(intItem.getIndexName(), includeField);
+                if ( ! indexName.isEmpty()) {
+                    destination.append(indexName).append(" = ");
+                }
                 annotatedNumberImage(intItem, intItem.getFromLimit().number().toString(), destination);
             } else if (intItem.getFromLimit().isInfinite()) {
                 destination.append(normalizeIndexName(intItem.getIndexName()));

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -394,7 +394,7 @@ public class YqlParser implements Parser {
                 case CONTAINS -> buildTermSearch(ast);
                 case MATCHES -> buildRegExpSearch(ast);
                 case CALL -> buildFunctionCallOrCompositeLeaf(ast, currentField);
-                case LITERAL -> buildLiteralExpression(ast, currentField);
+                case LITERAL, NEGATE -> buildLiteralExpression(ast, currentField);
                 case NOT -> buildNot(ast);
                 case IN -> buildIn(ast);
                 default -> throw newUnexpectedArgumentException(ast.getOperator(),
@@ -477,7 +477,7 @@ public class YqlParser implements Parser {
 
         OperatorNode<ExpressionOperator> field = lhs.getArgument(0);
         OperatorNode<ExpressionOperator> key = lhs.getArgument(1);
-        if (key.getOperator() != ExpressionOperator.LITERAL) {
+        if (key.getOperator() != ExpressionOperator.LITERAL && !isNumberLiteral(key)) {
             throw newUnexpectedArgumentException(key.getOperator(), ExpressionOperator.LITERAL);
         }
 
@@ -509,6 +509,9 @@ public class YqlParser implements Parser {
 
     /** Returns true if ast is a number literal. */
     private static boolean isNumberLiteral(OperatorNode<ExpressionOperator> ast) {
+        if (ast.getOperator() == ExpressionOperator.NEGATE) {
+            return isNumberLiteral(ast.getArgument(0));
+        }
         return ast.getOperator() == ExpressionOperator.LITERAL && ast.getArgument(0) instanceof Number;
     }
 
@@ -673,22 +676,28 @@ public class YqlParser implements Parser {
      * When {@code currentField} is not null we are inside a sameElement.
      */
     private Item buildLiteralExpression(OperatorNode<ExpressionOperator> ast, String currentField) {
-        var literalOrNested = ast.getArgument(0);
         if (currentField != null) {
             // A bare literal inside sameElement is a term matching the element value:
-            // numbers become numeric equality terms, everything else word terms on string form.
-            if (literalOrNested instanceof Number number) {
-                return (Item)leafStyleSettings(ast, new IntItem(number.toString(), ""));
+            // numbers (possibly negated) become numeric equality terms, everything else word terms on string form.
+            if (isNumberLiteral(ast)) {
+                return (Item)leafStyleSettings(ast, new IntItem(getNumberAsString(ast), ""));
             }
-            return instantiateWordItem("", toLiteralString(ast), null);
+            if (ast.getOperator() == ExpressionOperator.LITERAL) {
+                return instantiateWordItem("", toLiteralString(ast), null);
+            }
+            throw newUnexpectedArgumentException(ast.getOperator(), ExpressionOperator.LITERAL);
         }
-        if (Boolean.TRUE.equals(literalOrNested)) {
+        if (ast.getOperator() != ExpressionOperator.LITERAL) {
+            throw newUnexpectedArgumentException(ast.getOperator(), ExpressionOperator.LITERAL);
+        }
+        var literal = ast.getArgument(0);
+        if (Boolean.TRUE.equals(literal)) {
             return new TrueItem();
         }
-        else if (Boolean.FALSE.equals(literalOrNested)) {
+        else if (Boolean.FALSE.equals(literal)) {
             return new FalseItem();
         }
-        throw newUnexpectedArgumentException(literalOrNested, ExpressionOperator.LITERAL);
+        throw newUnexpectedArgumentException(literal, ExpressionOperator.LITERAL);
     }
 
     @SuppressWarnings("deprecation")

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -394,7 +394,7 @@ public class YqlParser implements Parser {
                 case CONTAINS -> buildTermSearch(ast);
                 case MATCHES -> buildRegExpSearch(ast);
                 case CALL -> buildFunctionCallOrCompositeLeaf(ast, currentField);
-                case LITERAL -> buildLiteralOrNested(ast, currentField);
+                case LITERAL -> buildLiteralExpression(ast, currentField);
                 case NOT -> buildNot(ast);
                 case IN -> buildIn(ast);
                 default -> throw newUnexpectedArgumentException(ast.getOperator(),
@@ -669,7 +669,10 @@ public class YqlParser implements Parser {
         return item;
     }
 
-    private Item buildLiteralOrNested(OperatorNode<ExpressionOperator> ast, String currentField) {
+    /**
+     * When {@code currentField} is not null we are inside a sameElement.
+     */
+    private Item buildLiteralExpression(OperatorNode<ExpressionOperator> ast, String currentField) {
         var literalOrNested = ast.getArgument(0);
         if (currentField != null) {
             // A bare literal inside sameElement is a term matching the element value:

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -442,8 +442,6 @@ public class YqlParser implements Parser {
             throw newUnexpectedArgumentException(index, ExpressionOperator.LITERAL);
         }
 
-        // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
-        value = toLiteralString(value);
         int elementIndex = convertToElementId(index.getArgument(0));
         OperatorNode<ExpressionOperator> sameElement = OperatorNode.create(
                 ast.getLocation(),
@@ -461,6 +459,8 @@ public class YqlParser implements Parser {
      *      field{'key'} = value            (numeric values)
      * to:
      *      field contains sameElement(key contains 'key', value contains value)
+     * where a numeric key or value becomes an equality match (key = 'key', value = value)
+     * instead of a contains match, preserving its type.
      * <p>
      * Expected input: CONTAINS( MAPREF ( field_name, key ), value ) or EQ( MAPREF ( field_name, key ), value )
      */
@@ -481,20 +481,8 @@ public class YqlParser implements Parser {
             throw newUnexpectedArgumentException(key.getOperator(), ExpressionOperator.LITERAL);
         }
 
-        // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
-        key = toLiteralString(key);
-        value = toLiteralString(value);
-
-        OperatorNode<ExpressionOperator> keyMatch = OperatorNode.create(
-                ast.getLocation(),
-                ExpressionOperator.CONTAINS,
-                OperatorNode.create(lhs.getLocation(), ExpressionOperator.READ_FIELD, "", "key"),
-                key);
-        OperatorNode<ExpressionOperator> valueMatch = OperatorNode.create(
-                ast.getLocation(),
-                ExpressionOperator.CONTAINS,
-                OperatorNode.create(lhs.getLocation(), ExpressionOperator.READ_FIELD, "", "value"),
-                value);
+        OperatorNode<ExpressionOperator> keyMatch = makeMapComponentMatch("key", key);
+        OperatorNode<ExpressionOperator> valueMatch = makeMapComponentMatch("value", value);
         OperatorNode<ExpressionOperator> sameElement = OperatorNode.create(
                 ast.getLocation(),
                 ExpressionOperator.CALL,
@@ -504,7 +492,27 @@ public class YqlParser implements Parser {
         return OperatorNode.create(ast.getLocation(), ExpressionOperator.CONTAINS, field, sameElement);
     }
 
-    // TODO(johsol): Remove conversion to string when sameElement supports other values than strings.
+    /**
+     * Builds the match condition for the key or value component of a map entry.
+     * The map access sugar has no operator per component, so the literal's type must decide
+     * it here: numeric literals become equality matches (numeric terms), everything else
+     * becomes contains matches, on string form since contains requires a string literal.
+     */
+    private static OperatorNode<ExpressionOperator> makeMapComponentMatch(String component, OperatorNode<ExpressionOperator> term) {
+        OperatorNode<ExpressionOperator> componentField =
+                OperatorNode.create(term.getLocation(), ExpressionOperator.READ_FIELD, "", component);
+        if (isNumberLiteral(term)) {
+            return OperatorNode.create(term.getLocation(), ExpressionOperator.EQ, componentField, term);
+        }
+        return OperatorNode.create(term.getLocation(), ExpressionOperator.CONTAINS, componentField, toLiteralString(term));
+    }
+
+    /** Returns true if ast is a number literal. */
+    private static boolean isNumberLiteral(OperatorNode<ExpressionOperator> ast) {
+        return ast.getOperator() == ExpressionOperator.LITERAL && ast.getArgument(0) instanceof Number;
+    }
+
+    /** Converts non-string literals which have no typed item form, such as booleans, to string literals. */
     private static OperatorNode<ExpressionOperator> toLiteralString(OperatorNode<ExpressionOperator> ast) {
         if (ast.getOperator() == ExpressionOperator.LITERAL && !(ast.getArgument(0) instanceof String)) {
             return OperatorNode.create(ast.getLocation(), ExpressionOperator.LITERAL, ast.getArgument(0).toString());
@@ -663,14 +671,19 @@ public class YqlParser implements Parser {
 
     private Item buildLiteralOrNested(OperatorNode<ExpressionOperator> ast, String currentField) {
         var literalOrNested = ast.getArgument(0);
+        if (currentField != null) {
+            // A bare literal inside sameElement is a term matching the element value:
+            // numbers become numeric equality terms, everything else word terms on string form.
+            if (literalOrNested instanceof Number number) {
+                return (Item)leafStyleSettings(ast, new IntItem(number.toString(), ""));
+            }
+            return instantiateWordItem("", toLiteralString(ast), null);
+        }
         if (Boolean.TRUE.equals(literalOrNested)) {
             return new TrueItem();
         }
         else if (Boolean.FALSE.equals(literalOrNested)) {
             return new FalseItem();
-        }
-        else if (currentField != null) {
-            return instantiateWordItem("", ast, null);
         }
         throw newUnexpectedArgumentException(literalOrNested, ExpressionOperator.LITERAL);
     }

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -499,8 +499,7 @@ public class YqlParser implements Parser {
      * becomes contains matches, on string form since contains requires a string literal.
      */
     private static OperatorNode<ExpressionOperator> makeMapComponentMatch(String component, OperatorNode<ExpressionOperator> term) {
-        OperatorNode<ExpressionOperator> componentField =
-                OperatorNode.create(term.getLocation(), ExpressionOperator.READ_FIELD, "", component);
+        var componentField = OperatorNode.create(term.getLocation(), ExpressionOperator.READ_FIELD, "", component);
         if (isNumberLiteral(term)) {
             return OperatorNode.create(term.getLocation(), ExpressionOperator.EQ, componentField, term);
         }

--- a/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
@@ -346,6 +346,21 @@ public class VespaSerializerTestCase {
     }
 
     @Test
+    void testSameElementWithNumericChild() {
+        // The ints[1] = 2 sugar produces an IntItem child with empty index, which must serialize as a bare number
+        parseAndConfirm("ints contains ({elementFilter:[1]} sameElement(2))", "ints[1] = 2");
+        parseAndConfirm("doubles contains ({elementFilter:[0]} sameElement(1.5))", "doubles[0] = 1.5");
+        parseAndConfirm("bools contains ({elementFilter:[0]} sameElement(\"true\"))", "bools[0] = true");
+
+        // The serialized forms are stable: they parse back to themselves
+        parseAndConfirm("ints contains ({elementFilter:[1]} sameElement(2))");
+        parseAndConfirm("doubles contains ({elementFilter:[0]} sameElement(1.5))");
+
+        // Map sugar children keep their key/value indexes
+        parseAndConfirm("my_map contains sameElement(key contains \"foo\", value = 10)", "my_map{\"foo\"} = 10");
+    }
+
+    @Test
     void testAnnotatedAndSegment() {
         AndSegmentItem andSegment = new AndSegmentItem("abc", true, false);
         andSegment.addItem(new WordItem("a", "indexNamePlaceholder"));

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -497,6 +497,28 @@ public class YqlParserTestCase {
     }
 
     @Test
+    void testSameElementWithBareNumericChild() {
+        // A bare number inside sameElement is a numeric equality term on the element value.
+        assertParse("select * from sources * where ints contains sameElement(2)", "ints:{2}");
+        assertParse("select * from sources * where ints contains sameElement(-2)", "ints:{-2}");
+        assertParse("select * from sources * where doubles contains sameElement(-1.5)", "doubles:{-1.5}");
+        IntItem value = assertInstanceOf(IntItem.class,
+                ((SameElementItem) parse("select * from sources * where ints contains sameElement(-2)").getRoot()).getItem(0));
+        assertEquals("-2", value.getNumber());
+        assertCanonicalParse("select * from sources * where ints contains sameElement(-2)", "ints:{-2}");
+
+        // With a space the minus is a negation of a positive literal rather than part of the number.
+        assertParse("select * from sources * where ints contains sameElement(- 2)", "ints:{-2}");
+        assertParse("select * from sources * where doubles contains sameElement(- 1.5)", "doubles:{-1.5}");
+
+        // A negated literal is only meaningful as a number.
+        assertParseFail("select * from sources * where strings contains sameElement(-'a')",
+                        new IllegalArgumentException("Expected LITERAL, got NEGATE."));
+        assertParseFail("select * from sources * where strings contains sameElement(-true)",
+                        new IllegalArgumentException("Expected LITERAL, got NEGATE."));
+    }
+
+    @Test
     void testSameElementWithNestedAnd() {
         assertParse("select * from sources * where myStringArray contains sameElement('a' and 'b' and near('c', 'd'))",
                     "myStringArray:{(AND a b (NEAR(2) c d))}");
@@ -584,6 +606,28 @@ public class YqlParserTestCase {
         IntItem doubleValue = assertInstanceOf(IntItem.class, se.getItem(0));
         assertEquals("1.5", doubleValue.getNumber());
 
+        // Negative numbers are numeric equality terms with the sign preserved.
+        qt = parse("select * from sources * where ints[1] = -2");
+        se = (SameElementItem) qt.getRoot();
+        assertEquals(List.of(1), se.getElementFilter());
+        IntItem negativeValue = assertInstanceOf(IntItem.class, se.getItem(0));
+        assertEquals("-2", negativeValue.getNumber());
+        assertParse("select * from sources * where ints[1] = -2", "ints[1]:{-2}");
+        assertCanonicalParse("select * from sources * where ints[1] = -2", "ints[1]:{-2}");
+
+        qt = parse("select * from sources * where doubles[0] = -1.5");
+        se = (SameElementItem) qt.getRoot();
+        IntItem negativeDouble = assertInstanceOf(IntItem.class, se.getItem(0));
+        assertEquals("-1.5", negativeDouble.getNumber());
+        assertCanonicalParse("select * from sources * where doubles[0] = -1.5", "doubles[0]:{-1.5}");
+
+        // With a space the minus is a negation of a positive literal rather than part of the number.
+        assertParse("select * from sources * where ints[1] = - 2", "ints[1]:{-2}");
+        IntItem negatedValue = assertInstanceOf(IntItem.class,
+                ((SameElementItem) parse("select * from sources * where ints[1] = - 2").getRoot()).getItem(0));
+        assertEquals("-2", negatedValue.getNumber());
+        assertParse("select * from sources * where doubles[0] = - 1.5", "doubles[0]:{-1.5}");
+
         // Booleans have no typed item form and become word terms, not TrueItem/FalseItem.
         qt = parse("select * from sources * where bools[0] = true");
         se = (SameElementItem) qt.getRoot();
@@ -605,6 +649,40 @@ public class YqlParserTestCase {
                     "my_map:{key:foo value:10}");
         assertInstanceOf(IntItem.class,
                          ((SameElementItem) parse("select * from sources * where my_map{'foo'} = 10").getRoot()).getItem(1));
+
+        // Negative numeric values are also numeric equality terms, with the sign preserved.
+        assertParse("select * from sources * where my_map{'foo'} = -10",
+                    "my_map:{key:foo value:-10}");
+        IntItem negativeValue = assertInstanceOf(IntItem.class,
+                         ((SameElementItem) parse("select * from sources * where my_map{'foo'} = -10").getRoot()).getItem(1));
+        assertEquals("-10", negativeValue.getNumber());
+        assertCanonicalParse("select * from sources * where my_map{'foo'} = -10",
+                             "my_map:{key:foo value:-10}");
+        assertParse("select * from sources * where my_map{'foo'} = -1.5",
+                    "my_map:{key:foo value:-1.5}");
+        assertCanonicalParse("select * from sources * where my_map{'foo'} = -1.5",
+                             "my_map:{key:foo value:-1.5}");
+
+        // Negative numeric keys, for maps with numeric key types.
+        assertParse("select * from sources * where my_map{-1} contains 'bar'",
+                    "my_map:{key:-1 value:bar}");
+        IntItem negativeKey = assertInstanceOf(IntItem.class,
+                         ((SameElementItem) parse("select * from sources * where my_map{-1} contains 'bar'").getRoot()).getItem(0));
+        assertEquals("-1", negativeKey.getNumber());
+        assertCanonicalParse("select * from sources * where my_map{-1} = -10",
+                             "my_map:{key:-1 value:-10}");
+
+        // With a space the minus is a negation of a positive literal rather than part of the number.
+        assertParse("select * from sources * where my_map{'foo'} = - 10",
+                    "my_map:{key:foo value:-10}");
+        assertParse("select * from sources * where my_map{- 1} contains 'bar'",
+                    "my_map:{key:-1 value:bar}");
+        assertParse("select * from sources * where my_map{- 1} = - 1.5",
+                    "my_map:{key:-1 value:-1.5}");
+        assertInstanceOf(IntItem.class,
+                         ((SameElementItem) parse("select * from sources * where my_map{- 1} = - 10").getRoot()).getItem(0));
+        assertInstanceOf(IntItem.class,
+                         ((SameElementItem) parse("select * from sources * where my_map{- 1} = - 10").getRoot()).getItem(1));
 
         // Numeric keys become numeric equality terms, for maps with numeric key types.
         assertParse("select * from sources * where my_map{1} contains 'bar'",
@@ -631,6 +709,8 @@ public class YqlParserTestCase {
     void testMapAccessRequiresLiteralKey() {
         assertParseFail("select * from sources * where my_map{key_field} contains 'bar'",
                         new IllegalArgumentException("Expected LITERAL, got READ_FIELD."));
+        assertParseFail("select * from sources * where my_map{-'foo'} contains 'bar'",
+                        new IllegalArgumentException("Expected LITERAL, got NEGATE."));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -15,6 +15,7 @@ import com.yahoo.prelude.query.EquivItem;
 import com.yahoo.prelude.query.ExactStringItem;
 import com.yahoo.prelude.query.FuzzyItem;
 import com.yahoo.prelude.query.IndexedItem;
+import com.yahoo.prelude.query.IntItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.MarkerWordItem;
 import com.yahoo.prelude.query.NearItem;
@@ -571,12 +572,26 @@ public class YqlParserTestCase {
         assertEquals("ints", se.getFieldName());
         assertEquals(List.of(1), se.getElementFilter());
         assertEquals(1, se.getItemCount());
+        IntItem intValue = assertInstanceOf(IntItem.class, se.getItem(0));
+        assertEquals("2", intValue.getNumber());
 
+        // Doubles are also numeric equality terms.
+        qt = parse("select * from sources * where doubles[0] = 1.5");
+        se = (SameElementItem) qt.getRoot();
+        assertEquals("doubles", se.getFieldName());
+        assertEquals(List.of(0), se.getElementFilter());
+        assertEquals(1, se.getItemCount());
+        IntItem doubleValue = assertInstanceOf(IntItem.class, se.getItem(0));
+        assertEquals("1.5", doubleValue.getNumber());
+
+        // Booleans have no typed item form and become word terms, not TrueItem/FalseItem.
         qt = parse("select * from sources * where bools[0] = true");
         se = (SameElementItem) qt.getRoot();
         assertEquals("bools", se.getFieldName());
         assertEquals(List.of(0), se.getElementFilter());
         assertEquals(1, se.getItemCount());
+        WordItem boolValue = assertInstanceOf(WordItem.class, se.getItem(0));
+        assertEquals("true", boolValue.getWord());
     }
 
     @Test
@@ -585,17 +600,31 @@ public class YqlParserTestCase {
         assertParse("select * from sources * where my_map{'foo'} contains 'bar'",
                     "my_map:{key:foo value:bar}");
 
-        // Numeric values use '=', as for plain fields, and are converted to string as in the indexed access rewrite.
+        // Numeric values use '=', as for plain fields, and become numeric equality terms.
         assertParse("select * from sources * where my_map{'foo'} = 10",
                     "my_map:{key:foo value:10}");
+        assertInstanceOf(IntItem.class,
+                         ((SameElementItem) parse("select * from sources * where my_map{'foo'} = 10").getRoot()).getItem(1));
 
-        // Numeric keys are converted to string, for maps with numeric key types.
+        // Numeric keys become numeric equality terms, for maps with numeric key types.
         assertParse("select * from sources * where my_map{1} contains 'bar'",
                     "my_map:{key:1 value:bar}");
+        assertInstanceOf(IntItem.class,
+                         ((SameElementItem) parse("select * from sources * where my_map{1} contains 'bar'").getRoot()).getItem(0));
+
+        // Boolean values have no typed item form and become word terms.
+        assertParse("select * from sources * where my_map{'foo'} = true",
+                    "my_map:{key:foo value:true}");
+        assertInstanceOf(WordItem.class,
+                         ((SameElementItem) parse("select * from sources * where my_map{'foo'} = true").getRoot()).getItem(1));
 
         // The rewritten tree serializes and re-parses to the same tree.
         assertCanonicalParse("select * from sources * where my_map{'foo'} contains 'bar'",
                              "my_map:{key:foo value:bar}");
+        assertCanonicalParse("select * from sources * where my_map{'foo'} = 10",
+                             "my_map:{key:foo value:10}");
+        assertCanonicalParse("select * from sources * where my_map{'foo'} = true",
+                             "my_map:{key:foo value:true}");
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
@@ -470,6 +470,12 @@ public class SelectTestCase {
 
         assertParse("{ \"contains\": [ \"baz\", {\"sameElement\" : [ { \"contains\" : [\"key\", \"a\"] }, {\"range\":[\"value.f2\",{\"=\":10}] } ]} ] }",
                 "baz:{key:a value.f2:10}");
+
+        // Negative numbers inside sameElement keep their sign.
+        assertParse("{ \"contains\": [ \"baz\", {\"sameElement\" : [ { \"contains\" : [\"key\", \"a\"] }, {\"equals\":[\"value\", -10] } ]} ] }",
+                "baz:{key:a value:-10}");
+        assertParse("{ \"contains\": [ \"baz\", {\"sameElement\" : [ {\"range\":[\"value\",{\">=\":-8, \"<=\":-1}] } ]} ] }",
+                "baz:{value:[-8;-1]}");
     }
 
     @Test
@@ -790,6 +796,8 @@ public class SelectTestCase {
         assertParse("{\"equals\": [\"public\",5]}", "public:5");
         assertParse("{\"equals\": {\"field\": \"public\", \"value\": true}}", "public:true");
         assertParse("{\"equals\": {\"field\": \"public\", \"value\": 5}}", "public:5");
+        assertParse("{\"equals\": [\"public\",-5]}", "public:-5");
+        assertParse("{\"equals\": {\"field\": \"public\", \"value\": -5}}", "public:-5");
     }
 
     @Test
@@ -818,6 +826,17 @@ public class SelectTestCase {
         // Double value
         assertParse("{\"equals\": {\"field\": \"my_arr\", \"index\": 0, \"value\": 3.14 }}",
                     "my_arr[0]:{3.14}");
+
+        // Negative values keep their sign and are numeric equality terms, as in YQL.
+        assertParse("{\"equals\": {\"field\": \"my_arr\", \"index\": 0, \"value\": -42 }}",
+                    "my_arr[0]:{-42}");
+        var negativeTree = parseWhere("{\"equals\": {\"field\": \"my_arr\", \"index\": 0, \"value\": -42 }}");
+        var negativeSameElement = assertInstanceOf(SameElementItem.class, negativeTree.getRoot());
+        assertEquals(List.of(0), negativeSameElement.getElementFilter());
+        IntItem negativeValue = assertInstanceOf(IntItem.class, negativeSameElement.getItem(0));
+        assertEquals("-42", negativeValue.getNumber());
+        assertParse("{\"equals\": {\"field\": \"my_arr\", \"index\": 0, \"value\": -3.14 }}",
+                    "my_arr[0]:{-3.14}");
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
@@ -12,6 +12,7 @@ import com.yahoo.prelude.SearchDefinition;
 import com.yahoo.prelude.query.AndItem;
 import com.yahoo.prelude.query.ExactStringItem;
 import com.yahoo.prelude.query.FuzzyItem;
+import com.yahoo.prelude.query.IntItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.NumericInItem;
 import com.yahoo.prelude.query.PhraseItem;
@@ -808,6 +809,7 @@ public class SelectTestCase {
         var intTree = parseWhere("{\"equals\": {\"field\": \"my_arr\", \"index\": 0, \"value\": 42 }}");
         var intSameElement = assertInstanceOf(SameElementItem.class, intTree.getRoot());
         assertEquals(List.of(0), intSameElement.getElementFilter());
+        assertInstanceOf(IntItem.class, intSameElement.getItem(0));
 
         // String value
         assertParse("{\"equals\": {\"field\": \"my_arr\", \"index\": 1, \"value\": \"hello\" }}",


### PR DESCRIPTION
_🤖 LLMs have assisted in writing this PR._

The map/array access sugar (`my_map{'foo'} = 10`, `ints[1] = 2`) converted every value to a string, so numbers became word terms — text-matching semantics against numeric fields. This PR makes numeric literals survive as typed numeric terms (`IntItem`) end-to-end, in both the YQL and select (JSON) parsers, and fixes the YQL re-serialization this made reachable.

#### fix passing IntItem through syntax sugar

Numeric literals in the sugar now become numeric equality terms instead of stringified word terms:

- `rewriteIndexedAccess` passes the value literal through verbatim.
- The map rewrite choosing `=` vs `contains` per key/value component.

#### align select parser with yql parser for same element

The select parser had the same string flattening; `LONG`/`DOUBLE` values now build `IntItem` directly so both query languages produce the same query tree.

#### Fix YQL serialization of numeric sameElement child with empty index

`NumberSerializer` ignored its `includeField` parameter, so the empty-index `IntItem` from `ints[1] = 2` serialized as `sameElement(default = 2)`, which re-parses against the nonexistent field `ints.default` — breaking `yqlRepresentation()`, tracing, and serialize/re-parse round trips. It now honors the sameElement context like the word path and emits the bare number. Added round-trip tests for the int, double, and bool sugar forms.

