### PR TITLE
Add pyroscope-profiling feature flags

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags;
 
+import com.yahoo.vespa.flags.custom.ProfilingSettings;
 import com.yahoo.vespa.flags.custom.RoleList;
 import com.yahoo.vespa.flags.custom.SharedHost;
 
@@ -21,6 +22,7 @@ import static com.yahoo.vespa.flags.Dimension.INSTANCE_ID;
 import static com.yahoo.vespa.flags.Dimension.NODE_TYPE;
 import static com.yahoo.vespa.flags.Dimension.TENANT_ID;
 import static com.yahoo.vespa.flags.Dimension.VESPA_VERSION;
+import static com.yahoo.vespa.flags.Dimension.ZONE_ID;
 
 /**
  * Definition for permanent feature flags
@@ -57,6 +59,23 @@ public class PermanentFlags {
                     "node resources of the host, the maximum number of containers, etc.",
             "Takes effect on next iteration of HostCapacityMaintainer.",
             __ -> true);
+
+    public static final UnboundJacksonFlag<ProfilingSettings> PYROSCOPE_PROFILING = defineJacksonFlag(
+            "pyroscope-profiling", ProfilingSettings.createDisabled(), ProfilingSettings.class,
+            "Which of the application's services to continuously profile with host-level eBPF " +
+                    "(pyroscope.ebpf), e.g. {\"enabled\": true, \"services\": [\"CONTAINER\", \"PROTON\"]}. " +
+                    "Only the listed services are profiled, and only for the applications this flag " +
+                    "is enabled for, so a shared host profiles nothing belonging to other tenants.",
+            "Takes effect on the next host-admin tick",
+            __ -> true,
+            TENANT_ID, APPLICATION, INSTANCE_ID);
+
+    public static final UnboundBooleanFlag PYROSCOPE_PROFILING_DISABLED = defineFeatureFlag(
+            "pyroscope-profiling-disabled", false,
+            "Force-disable continuous profiling, overriding the 'pyroscope-profiling' flag. Dimensioned " +
+                    "to allow disabling for a whole zone, a tenant, an application or a single host.",
+            "Takes effect on the next host-admin tick",
+            ZONE_ID, TENANT_ID, APPLICATION, INSTANCE_ID, HOSTNAME, NODE_TYPE);
 
     public static final UnboundListFlag<String> INACTIVE_MAINTENANCE_JOBS = defineListFlag(
             "inactive-maintenance-jobs", List.of(), String.class,

--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/ProfiledService.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/ProfiledService.java
@@ -1,0 +1,48 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags.custom;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * A Vespa service that can be continuously profiled, as named in the {@code pyroscope-profiling}
+ * feature flag (see {@link com.yahoo.vespa.flags.PermanentFlags#PYROSCOPE_PROFILING}).
+ *
+ * <p>The enum names are the vocabulary used when setting the flag, and are deliberately the names
+ * people use for these services. The service type is what Vespa itself calls them: config-sentinel
+ * stamps it into every service's environment as {@code VESPA_SERVICE_NAME}, which is how a running
+ * process is matched back to one of these. Notably proton's service type is {@code searchnode}.</p>
+ *
+ * @author onur
+ */
+public enum ProfiledService {
+
+    /** The application container, i.e. the JVM running the tenant's components. */
+    CONTAINER("container"),
+
+    /** proton, the search core. Vespa names this service 'searchnode'. */
+    PROTON("searchnode"),
+
+    /** The distributor. */
+    DISTRIBUTOR("distributor"),
+
+    /** The metrics proxy. */
+    METRICS_PROXY("metricsproxy-container");
+
+    private final String serviceType;
+
+    ProfiledService(String serviceType) {
+        this.serviceType = serviceType;
+    }
+
+    /** The value config-sentinel sets as VESPA_SERVICE_NAME, without any instance number. */
+    public String serviceType() {
+        return serviceType;
+    }
+
+    /** Returns the service with the given Vespa service type, if it is one that can be profiled. */
+    public static Optional<ProfiledService> ofServiceType(String serviceType) {
+        return Stream.of(values()).filter(service -> service.serviceType.equals(serviceType)).findAny();
+    }
+
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/ProfilingSettings.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/ProfilingSettings.java
@@ -1,0 +1,64 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags.custom;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * JSON value of the {@code pyroscope-profiling} feature flag
+ * (see {@link com.yahoo.vespa.flags.PermanentFlags#PYROSCOPE_PROFILING}), which selects the services to
+ * continuously profile for one application. Missing fields fall back to the disabled defaults.
+ *
+ * <p>The flag is resolved per application, so on a shared host each tenant's nodes get their own
+ * value and only the listed services of the enabled applications are profiled.</p>
+ *
+ * @author onur
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProfilingSettings {
+
+    private final boolean enabled;
+    private final List<ProfiledService> services;
+
+    public static ProfilingSettings createDisabled() {
+        return new ProfilingSettings(false, null);
+    }
+
+    @JsonCreator
+    public ProfilingSettings(@JsonProperty("enabled") Boolean enabled,
+                             @JsonProperty("services") List<ProfiledService> services) {
+        this.enabled = enabled != null && enabled;
+        this.services = services == null ? List.of() : List.copyOf(services);
+    }
+
+    @JsonGetter("enabled")  public boolean enabled()                { return enabled; }
+    @JsonGetter("services") public List<ProfiledService> services() { return services; }
+
+    /**
+     * The services to profile: none unless the flag is both enabled and lists at least one service,
+     * so that neither switch alone starts profiling anything.
+     */
+    public Set<ProfiledService> profiledServices() {
+        return enabled ? Set.copyOf(services) : Set.of();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProfilingSettings that = (ProfilingSettings) o;
+        return enabled == that.enabled && services.equals(that.services);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, services);
+    }
+
+}

--- a/flags/src/test/java/com/yahoo/vespa/flags/custom/ProfiledServiceTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/custom/ProfiledServiceTest.java
@@ -1,0 +1,32 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags.custom;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ProfiledServiceTest {
+
+    /**
+     * The service types must match what config-sentinel stamps as VESPA_SERVICE_NAME, which is
+     * config-model's service type: ContainerServiceType for the containers, the lowercased class
+     * name for proton ('searchnode') and the distributor. A wrong string silently profiles nothing.
+     */
+    @Test
+    void service_types_match_vespa_service_names() {
+        assertEquals(Optional.of(ProfiledService.CONTAINER), ProfiledService.ofServiceType("container"));
+        assertEquals(Optional.of(ProfiledService.PROTON), ProfiledService.ofServiceType("searchnode"));
+        assertEquals(Optional.of(ProfiledService.DISTRIBUTOR), ProfiledService.ofServiceType("distributor"));
+        assertEquals(Optional.of(ProfiledService.METRICS_PROXY), ProfiledService.ofServiceType("metricsproxy-container"));
+    }
+
+    @Test
+    void unknown_service_types_are_not_profiled() {
+        assertEquals(Optional.empty(), ProfiledService.ofServiceType("config-sentinel"));
+        assertEquals(Optional.empty(), ProfiledService.ofServiceType("logd"));
+        assertEquals(Optional.empty(), ProfiledService.ofServiceType(""));
+    }
+
+}

--- a/flags/src/test/java/com/yahoo/vespa/flags/custom/ProfilingSettingsTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/custom/ProfilingSettingsTest.java
@@ -1,0 +1,54 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags.custom;
+
+import com.yahoo.test.json.Jackson;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ProfilingSettingsTest {
+
+    @Test
+    void serialization() throws IOException {
+        verifySerialization(ProfilingSettings.createDisabled());
+        verifySerialization(new ProfilingSettings(true, List.of(ProfiledService.CONTAINER)));
+        verifySerialization(new ProfilingSettings(true, List.of(ProfiledService.PROTON, ProfiledService.DISTRIBUTOR)));
+        verifySerialization(new ProfilingSettings(false, List.of(ProfiledService.METRICS_PROXY)));
+    }
+
+    @Test
+    void unknown_fields_are_ignored() throws IOException {
+        var settings = Jackson.mapper().readValue(
+                "{\"enabled\": true, \"services\": [\"CONTAINER\"], \"someFutureField\": 42}",
+                ProfilingSettings.class);
+        assertEquals(Set.of(ProfiledService.CONTAINER), settings.profiledServices());
+    }
+
+    @Test
+    void missing_fields_fall_back_to_disabled() throws IOException {
+        var settings = Jackson.mapper().readValue("{}", ProfilingSettings.class);
+        assertEquals(Set.of(), settings.profiledServices());
+    }
+
+    /** Neither switch alone profiles anything: both enabled and a non-empty list are required. */
+    @Test
+    void profiled_services_requires_both_switches() {
+        assertEquals(Set.of(), new ProfilingSettings(true, List.of()).profiledServices());
+        assertEquals(Set.of(), new ProfilingSettings(false, List.of(ProfiledService.CONTAINER)).profiledServices());
+        assertEquals(Set.of(), ProfilingSettings.createDisabled().profiledServices());
+        assertEquals(Set.of(ProfiledService.CONTAINER),
+                     new ProfilingSettings(true, List.of(ProfiledService.CONTAINER)).profiledServices());
+    }
+
+    private void verifySerialization(ProfilingSettings settings) throws IOException {
+        var mapper = Jackson.mapper();
+        String json = mapper.writeValueAsString(settings);
+        ProfilingSettings deserialized = mapper.readValue(json, ProfilingSettings.class);
+        assertEquals(settings, deserialized);
+    }
+
+}


### PR DESCRIPTION
Two permanent flags for continuous profiling of hosted Vespa services, plus their JSON model:

- **`pyroscope-profiling`** — per application: `{"enabled": true, "services": ["CONTAINER", "PROTON", ...]}`. Fail-closed: `enabled` and a non-empty service list are both required before anything is profiled.
- **`pyroscope-profiling-disabled`** — kill switch, dimensioned by zone / tenant / application / hostname / node type, overriding the opt-in at any granularity.
- **`ProfiledService`** maps the flag vocabulary (`CONTAINER`, `PROTON`, `DISTRIBUTOR`, `METRICS_PROXY`) to the service types config-sentinel stamps as `VESPA_SERVICE_NAME` — notably proton's `searchnode` and the metrics proxy's `metricsproxy-container` — verified against config-model's `ContainerServiceType` and `AbstractService.getServiceType()`.

Consumed by hosted host-admin, which resolves the flag per application and translates the selection into `pyroscope.ebpf` targets for the host's Alloy collector (companion PR in the hosted repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3BExNSeJMEZWjQQpPTMtR