### PR TITLE
Workaround for std::atomic_ref is still needed for libc++ 23.

### DIFF
--- a/vespalib/src/vespa/vespalib/util/atomic.h
+++ b/vespalib/src/vespa/vespalib/util/atomic.h
@@ -20,7 +20,7 @@
 
 namespace vespalib::atomic {
 
-#if _LIBCPP_VERSION >= 190000 && _LIBCPP_VERSION < 230000
+#if _LIBCPP_VERSION >= 190000 && _LIBCPP_VERSION < 240000
 /*
  * std::atomic_ref with constant template argument is broken with libc++ 19
  * and libc++ 20.


### PR DESCRIPTION
@vekterli : please review
