### PR TITLE
Avoid copying `WriteField`s during iteration

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -327,7 +327,7 @@ void PutTask::run() {
     _wc.consider_build_field_paths(_doc);
     DocumentFieldExtractor field_extractor(_doc);
     const auto&            fields = _wc.getFields();
-    for (auto field : fields) {
+    for (const auto& field : fields) {
         if (_allAttributes || field.is_non_authoritative()) {
             AttributeVector& attr = field.getAttribute();
             if (attr.getStatus().getLastSyncToken() < _serialNum) {


### PR DESCRIPTION
@toregge please review. I can't see any reason for why this was by-value.
