### PR TITLE
Allow matches_for_labels without a field parameter

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/schema/MapEvaluationTypeContext.java
@@ -315,9 +315,14 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
                 throw new IllegalArgumentException(reference.name() + " must have one argument");
             return Optional.of(new TensorType.Builder(TensorType.Value.FLOAT).mapped("term").build());
         }
-        if (reference.name().equals("bm25_for_labels") || reference.name().equals("matches_for_labels")) {
+        if (reference.name().equals("bm25_for_labels")) {
             if (reference.arguments().size() != 1)
                 throw new IllegalArgumentException(reference.name() + " must have one argument");
+            return Optional.of(new TensorType.Builder(TensorType.Value.FLOAT).mapped("label").build());
+        }
+        if (reference.name().equals("matches_for_labels")) {
+            if (reference.arguments().size() > 1)
+                throw new IllegalArgumentException(reference.name() + " must have zero or one argument");
             return Optional.of(new TensorType.Builder(TensorType.Value.FLOAT).mapped("label").build());
         }
         if ( ! reference.name().equals("tensorFromLabels") &&

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/schemadocument/resolvers/RankExpression/BuiltInFunctions.java
@@ -199,12 +199,16 @@ public class BuiltInFunctions {
                 new IntegerArgument()
             ))
         )));
-        put("matches_for_labels", new GenericFunction("matches_for_labels",
+        put("matches_for_labels", new GenericFunction("matches_for_labels", List.of(
+            new FunctionSignature(List.of(), Set.of(
+                "",
+                "out"
+            )),
             new FunctionSignature(new FieldArgument(FieldArgument.AnyFieldType,
                                                     FieldArgument.IndexAttributeType, "field"), Set.of(
                 "",
                 "out"
-            ))));
+            )))));
         put("termDistance", new GenericFunction("termDistance", new FunctionSignature(List.of(
             new FieldArgument(),
             new ExpressionArgument("x"),

--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -201,6 +201,28 @@ std::string make_two_term_and_stack_dump(const std::string& field, const std::st
     return StackDumpCreator::create(*builder.build());
 }
 
+size_t feature_index(const std::vector<std::string>& names, const std::string& name) {
+    for (size_t i = 0; i < names.size(); ++i) {
+        if (names[i] == name) {
+            return i;
+        }
+    }
+    ADD_FAILURE() << "match feature '" << name << "' not found";
+    return names.size();
+}
+
+// Three labeled query items: a term in f1, a term in f2 and a label wrapper
+// (which searches no field of its own) around a term in f1.
+std::string make_labeled_terms_and_wrapper_stack_dump() {
+    QueryBuilder<ProtonNodeTypes> builder;
+    builder.addAnd(3);
+    builder.addStringTerm("foo", "f1", 1, Weight(1));
+    builder.addStringTerm("baz", "f2", 2, Weight(1));
+    builder.add_label_wrapper(3, 1.0);
+    builder.addStringTerm("bar", "f1", 4, Weight(1));
+    return StackDumpCreator::create(*builder.build());
+}
+
 std::string make_near_stack_dump(bool ordered, const std::string& term1, const std::string& term2) {
     QueryBuilder<ProtonNodeTypes> builder;
     constexpr int                 child_count = 2;
@@ -335,8 +357,14 @@ struct MyWorld {
 
     void setup_matches_for_labels_match_features() {
         config.add(indexproperties::match::Feature::NAME, "matches_for_labels(f1)");
-        config.add(indexproperties::match::Feature::NAME,
-                   "rankingExpression(\"matches_for_labels(f1){label:t1}\")");
+        config.add(indexproperties::match::Feature::NAME, "rankingExpression(\"matches_for_labels(f1){label:t1}\")");
+    }
+
+    void setup_matches_for_labels_any_field_match_features() {
+        config.add(indexproperties::match::Feature::NAME, "matches_for_labels");
+        config.add(indexproperties::match::Feature::NAME, "matches_for_labels(f1)");
+        config.add(indexproperties::match::Feature::NAME, "rankingExpression(\"matches_for_labels{label:t3}\")");
+        config.add(indexproperties::match::Feature::NAME, "itemRawScore(t3)");
     }
 
     void setup_feature_renames() {
@@ -780,20 +808,11 @@ TEST_F(MatchingTest, require_that_bm25_label_parameter_restricts_scoring_to_labe
     ASSERT_GT(reply->hits.size(), 0u);
     const auto& names = reply->match_features.names;
     ASSERT_EQ(names.size(), 5u);
-    auto feature_index = [&names](const std::string& name) {
-        for (size_t i = 0; i < names.size(); ++i) {
-            if (names[i] == name) {
-                return i;
-            }
-        }
-        ADD_FAILURE() << "match feature '" << name << "' not found";
-        return names.size();
-    };
-    size_t full_idx = feature_index("bm25(f1)");
-    size_t t1_idx = feature_index("bm25(\"field:f1\",\"label:t1\")");
-    size_t t2_idx = feature_index("bm25(f1,\"label:t2\")");
-    size_t tensor_idx = feature_index("bm25_for_labels(f1)");
-    size_t slice_idx = feature_index("rankingExpression(\"bm25_for_labels(f1){label:t1}\")");
+    size_t full_idx = feature_index(names, "bm25(f1)");
+    size_t t1_idx = feature_index(names, "bm25(\"field:f1\",\"label:t1\")");
+    size_t t2_idx = feature_index(names, "bm25(f1,\"label:t2\")");
+    size_t tensor_idx = feature_index(names, "bm25_for_labels(f1)");
+    size_t slice_idx = feature_index(names, "rankingExpression(\"bm25_for_labels(f1){label:t1}\")");
     ASSERT_EQ(reply->match_features.values.size(), names.size() * reply->hits.size());
     for (size_t i = 0; i < reply->hits.size(); ++i) {
         const auto* values = &reply->match_features.values[i * names.size()];
@@ -835,18 +854,9 @@ TEST_F(MatchingTest, require_that_matches_for_labels_reports_matching_labels_and
     ASSERT_GT(reply->hits.size(), 0u);
     const auto& names = reply->match_features.names;
     ASSERT_EQ(names.size(), 2u);
-    auto feature_index = [&names](const std::string& name) {
-        for (size_t i = 0; i < names.size(); ++i) {
-            if (names[i] == name) {
-                return i;
-            }
-        }
-        ADD_FAILURE() << "match feature '" << name << "' not found";
-        return names.size();
-    };
-    size_t tensor_idx = feature_index("matches_for_labels(f1)");
+    size_t tensor_idx = feature_index(names, "matches_for_labels(f1)");
     ASSERT_LT(tensor_idx, names.size());
-    size_t slice_idx = feature_index("rankingExpression(\"matches_for_labels(f1){label:t1}\")");
+    size_t slice_idx = feature_index(names, "rankingExpression(\"matches_for_labels(f1){label:t1}\")");
     ASSERT_LT(slice_idx, names.size());
     ASSERT_EQ(reply->match_features.values.size(), names.size() * reply->hits.size());
     for (size_t i = 0; i < reply->hits.size(); ++i) {
@@ -855,11 +865,66 @@ TEST_F(MatchingTest, require_that_matches_for_labels_reports_matching_labels_and
         {
             nbostream buf(values[tensor_idx].as_data().data, values[tensor_idx].as_data().size);
             // both labeled terms hit; cells are 1, not BM25 scores
-            TensorSpec expect = TensorSpec("tensor<float>(label{})").add({{"label", "t1"}}, 1).add({{"label", "t2"}}, 1);
+            TensorSpec expect =
+                TensorSpec("tensor<float>(label{})").add({{"label", "t1"}}, 1).add({{"label", "t2"}}, 1);
             EXPECT_EQ(spec_from_value(*SimpleValue::from_stream(buf)), expect);
         }
         // slicing a cell out of it evaluates in the backend
         EXPECT_DOUBLE_EQ(values[slice_idx].as_double(), 1.0);
+    }
+}
+
+TEST_F(MatchingTest, require_that_matches_for_labels_without_field_parameter_ignores_fields) {
+    MyWorld world(shared_state());
+    world.basicSetup();
+    // one labeled term per field, plus a labeled wrapper around a term in f1
+    world.searchContext.idx(0).getFake().addResult("f1", "foo", FakeResult().doc(10).doc(20).doc(30));
+    world.searchContext.idx(0).getFake().addResult("f2", "baz", FakeResult().doc(10).doc(20).doc(30));
+    world.searchContext.idx(0).getFake().addResult("f1", "bar", FakeResult().doc(10).doc(20).doc(30));
+    world.setup_matches_for_labels_any_field_match_features();
+    SearchRequest::SP request = MyWorld::createRequest(make_labeled_terms_and_wrapper_stack_dump());
+    auto&             rankProperties = request->propertiesMap.lookupCreate(MapNames::RANK);
+    rankProperties.add("vespa.label.t1.id", "1");
+    rankProperties.add("vespa.label.t2.id", "2");
+    rankProperties.add("vespa.label.t3.id", "3");
+    SearchReply::UP reply = world.performSearch(*request, 1);
+    ASSERT_GT(reply->hits.size(), 0u);
+    const auto& names = reply->match_features.names;
+    ASSERT_EQ(names.size(), 4u);
+    size_t any_field_idx = feature_index(names, "matches_for_labels");
+    ASSERT_LT(any_field_idx, names.size());
+    size_t f1_idx = feature_index(names, "matches_for_labels(f1)");
+    ASSERT_LT(f1_idx, names.size());
+    size_t slice_idx = feature_index(names, "rankingExpression(\"matches_for_labels{label:t3}\")");
+    ASSERT_LT(slice_idx, names.size());
+    size_t wrapper_score_idx = feature_index(names, "itemRawScore(t3)");
+    ASSERT_LT(wrapper_score_idx, names.size());
+    ASSERT_EQ(reply->match_features.values.size(), names.size() * reply->hits.size());
+    for (size_t i = 0; i < reply->hits.size(); ++i) {
+        const auto* values = &reply->match_features.values[i * names.size()];
+        ASSERT_TRUE(values[any_field_idx].is_data());
+        {
+            nbostream buf(values[any_field_idx].as_data().data, values[any_field_idx].as_data().size);
+            // without a field parameter every label hits, including the wrapper
+            // that searches no field at all
+            TensorSpec expect = TensorSpec("tensor<float>(label{})")
+                                    .add({{"label", "t1"}}, 1)
+                                    .add({{"label", "t2"}}, 1)
+                                    .add({{"label", "t3"}}, 1);
+            EXPECT_EQ(spec_from_value(*SimpleValue::from_stream(buf)), expect);
+        }
+        ASSERT_TRUE(values[f1_idx].is_data());
+        {
+            nbostream buf(values[f1_idx].as_data().data, values[f1_idx].as_data().size);
+            // with a field parameter only the term searching f1 hits; the f2 term
+            // and the field-less wrapper are left out
+            TensorSpec expect = TensorSpec("tensor<float>(label{})").add({{"label", "t1"}}, 1);
+            EXPECT_EQ(spec_from_value(*SimpleValue::from_stream(buf)), expect);
+        }
+        // slicing the wrapper label out of the field-less feature evaluates in the backend
+        EXPECT_DOUBLE_EQ(values[slice_idx].as_double(), 1.0);
+        // the wrapper is unpacked, so its constant score is available as well
+        EXPECT_DOUBLE_EQ(values[wrapper_score_idx].as_double(), 1.0);
     }
 }
 

--- a/searchlib/src/tests/features/matches_for_labels/matches_for_labels_test.cpp
+++ b/searchlib/src/tests/features/matches_for_labels/matches_for_labels_test.cpp
@@ -50,11 +50,20 @@ struct MatchesForLabelsBlueprintFixture {
 
 TEST(MatchesForLabelsBlueprintTest, setup_fails_for_invalid_parameter_lists) {
     MatchesForLabelsBlueprintFixture f;
-    EXPECT_FALSE(f.try_setup({}));
     EXPECT_FALSE(f.try_setup({"foo", "bar"}));
     // wrong parameter number; unlike matches, there is no term-index overload
     EXPECT_FALSE(f.try_setup({"foo", "0"}));
     EXPECT_FALSE(f.try_setup({"unknown"}));
+}
+
+TEST(MatchesForLabelsBlueprintTest, setup_succeeds_without_parameters) {
+    MatchesForLabelsBlueprintFixture f;
+    MatchesForLabelsBlueprint        bp;
+    DummyDependencyHandler           deps(bp);
+    bp.setName("matches_for_labels");
+    EXPECT_TRUE(((Blueprint&)bp).setup(f.index_env, Blueprint::StringVector()));
+    EXPECT_EQ(0, deps.input.size());
+    EXPECT_EQ(std::vector<std::string>{"out"}, deps.output);
 }
 
 TEST(MatchesForLabelsBlueprintTest, setup_succeeds_for_index_attribute_and_virtual_fields) {
@@ -74,7 +83,8 @@ struct MatchesForLabelsFixture {
     FtFeatureTest              test;
     test::MatchDataBuilder::UP match_data;
 
-    MatchesForLabelsFixture() : factory(), test(factory, "matches_for_labels(foo)"), match_data() {
+    explicit MatchesForLabelsFixture(const std::string& feature = "matches_for_labels(foo)")
+        : factory(), test(factory, feature), match_data() {
         setup_search_features(factory);
         test.getIndexEnv().getBuilder().addField(FieldType::INDEX, CollectionType::SINGLE, "foo");
         test.getIndexEnv().getBuilder().addField(FieldType::INDEX, CollectionType::SINGLE, "bar");
@@ -86,7 +96,7 @@ struct MatchesForLabelsFixture {
         auto* t2 = test.getQueryEnv().getBuilder().addIndexNode({"bar"});
         t2->setUniqueId(13);
     }
-    ~MatchesForLabelsFixture();
+    virtual ~MatchesForLabelsFixture();
 
     void add_label(const std::string& label, const std::vector<uint32_t>& uids) {
         MultiLabel(label, uids).inject(test.getQueryEnv().getProperties());
@@ -155,7 +165,7 @@ TEST(MatchesForLabelsExecutorTest, label_whose_terms_search_another_field_is_abs
 
 TEST(MatchesForLabelsExecutorTest, label_whose_term_is_on_no_field_is_absent) {
     MatchesForLabelsFixture f;
-    auto& query_env = f.test.getQueryEnv();
+    auto&                   query_env = f.test.getQueryEnv();
     query_env.getTerms().push_back(SimpleTermData());
     SimpleTermData& term = query_env.getTerms().back();
     term.setUniqueId(14);
@@ -179,6 +189,57 @@ TEST(MatchesForLabelsExecutorTest, hidden_from_ranking_gives_empty_tensor) {
     ASSERT_TRUE(tfmd != nullptr);
     tfmd->set_hidden_from_ranking();
     EXPECT_EQ(empty_spec(), f.execute());
+}
+
+// Without a field parameter every field searched by the labeled terms counts.
+struct MatchesForLabelsAnyFieldFixture : MatchesForLabelsFixture {
+    MatchesForLabelsAnyFieldFixture() : MatchesForLabelsFixture("matches_for_labels") {}
+    ~MatchesForLabelsAnyFieldFixture() override;
+};
+
+MatchesForLabelsAnyFieldFixture::~MatchesForLabelsAnyFieldFixture() = default;
+
+TEST(MatchesForLabelsAnyFieldTest, label_matching_in_any_field_gives_one_cell) {
+    MatchesForLabelsAnyFieldFixture f;
+    f.add_label("x", {11});
+    f.add_label("y", {13});
+    f.setup();
+    f.prepare_term(0, 1); // term 11 in field foo
+    f.prepare_term(2, 2); // term 13 in field bar
+    EXPECT_EQ(empty_spec().add(label_addr("x"), 1).add(label_addr("y"), 1), f.execute());
+}
+
+TEST(MatchesForLabelsAnyFieldTest, label_not_matching_the_document_is_absent) {
+    MatchesForLabelsAnyFieldFixture f;
+    f.add_label("x", {11});
+    f.add_label("y", {13});
+    f.setup();
+    f.prepare_term(2, 2); // only term 13 matches
+    EXPECT_EQ(empty_spec().add(label_addr("y"), 1), f.execute());
+}
+
+TEST(MatchesForLabelsAnyFieldTest, query_without_labels_gives_empty_tensor) {
+    MatchesForLabelsAnyFieldFixture f;
+    f.setup();
+    f.prepare_term(0, 1);
+    EXPECT_EQ(empty_spec(), f.execute());
+}
+
+// A label wrapper searches no field of its own, but is still a labeled query
+// item that can match; the field-less feature must pick it up.
+TEST(MatchesForLabelsAnyFieldTest, label_on_term_searching_no_field_gives_one_cell) {
+    MatchesForLabelsAnyFieldFixture f;
+    auto&                           query_env = f.test.getQueryEnv();
+    query_env.getTerms().push_back(SimpleTermData());
+    SimpleTermData& term = query_env.getTerms().back();
+    term.setUniqueId(14);
+    auto& term_field = term.addField(FieldInfo::no_field().id()); // field id 0
+    term_field.setHandle(query_env.getLayout().allocTermField(term_field.getFieldId()));
+    ASSERT_NE(term_field.getHandle(), IllegalHandle);
+    f.add_label("x", {14});
+    f.setup();
+    f.prepare_term(3, 0);
+    EXPECT_EQ(empty_spec().add(label_addr("x"), 1), f.execute());
 }
 
 struct MatchesForLabelsAttributeFixture {

--- a/searchlib/src/vespa/searchlib/features/matches_for_labels_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/matches_for_labels_feature.cpp
@@ -28,6 +28,7 @@ using fef::FeatureType;
 using fef::IllegalHandle;
 using fef::ITermData;
 using fef::ITermFieldData;
+using fef::ITermFieldRangeAdapter;
 using fef::MatchDataDetails;
 using fef::TermFieldHandle;
 using search::tensor::FastValueView;
@@ -39,8 +40,10 @@ using vespalib::eval::ValueType;
 namespace {
 
 /**
- * Executor returning 1 for each query item label whose terms matched the given field,
- * as a tensor<float>(label{}) with one cell per label that matched the document.
+ * Executor returning 1 for each query item label whose terms matched, as a
+ * tensor<float>(label{}) with one cell per label that matched the document.
+ * Which handles are considered per label is decided by the blueprint; the
+ * executor itself does not care about fields.
  */
 class MatchesForLabelsExecutor : public fef::FeatureExecutor {
     std::vector<std::vector<TermFieldHandle>> _handles_per_label; // in label order
@@ -91,7 +94,8 @@ void MatchesForLabelsExecutor::execute(uint32_t doc_id) {
         if (std::any_of(_handles_per_label[i].begin(), _handles_per_label[i].end(),
                         [this, doc_id](TermFieldHandle handle) {
                             return _md->resolveTermField(handle)->has_ranking_data(doc_id);
-                        })) {
+                        }))
+        {
             _view_labels.push_back(labels[i]);
             _view_cells.push_back(1.0f);
         }
@@ -105,19 +109,34 @@ void MatchesForLabelsExecutor::execute(uint32_t doc_id) {
     outputs().set_object(0, *_output);
 }
 
-std::vector<TermFieldHandle> collect_field_handles(const std::vector<const ITermData*>& terms, uint32_t field_id) {
+// Only the document ID is needed, so request the cheaper Interleaved details.
+// SimpleTermFieldData discards the requested detail level, so tests cannot
+// distinguish this from Normal.
+void add_handle(const ITermFieldData& tfd, std::vector<TermFieldHandle>& handles) {
+    TermFieldHandle handle = tfd.getHandle(MatchDataDetails::Interleaved);
+    if (handle != IllegalHandle) {
+        handles.push_back(handle);
+    }
+}
+
+/**
+ * Collect the handles to look at for one label. With a field id only the handle
+ * for that field is used; without one every field searched by the term counts,
+ * including the reserved "no field" used by query items searching no field.
+ */
+std::vector<TermFieldHandle> collect_handles(const std::vector<const ITermData*>& terms,
+                                             std::optional<uint32_t>              field_id) {
     std::vector<TermFieldHandle> handles;
     for (const ITermData* term : terms) {
-        const ITermFieldData* tfd = term->lookupField(field_id);
-        if (tfd == nullptr) {
-            continue;
-        }
-        // Only the document ID is needed, so request the cheaper Interleaved details.
-        // SimpleTermFieldData discards the requested detail level, so tests cannot
-        // distinguish this from Normal.
-        TermFieldHandle handle = tfd->getHandle(MatchDataDetails::Interleaved);
-        if (handle != IllegalHandle) {
-            handles.push_back(handle);
+        if (field_id.has_value()) {
+            const ITermFieldData* tfd = term->lookupField(field_id.value());
+            if (tfd != nullptr) {
+                add_handle(*tfd, handles);
+            }
+        } else {
+            for (ITermFieldRangeAdapter fields(*term); fields.valid(); fields.next()) {
+                add_handle(fields.get(), handles);
+            }
         }
     }
     return handles;
@@ -127,7 +146,7 @@ std::vector<TermFieldHandle> collect_field_handles(const std::vector<const ITerm
 
 MatchesForLabelsBlueprint::MatchesForLabelsBlueprint()
     : Blueprint("matches_for_labels"),
-      _field_id(0),
+      _field_id(),
       _value_type(ValueType::from_spec("tensor<float>(label{})")),
       _empty_output() {
 }
@@ -142,16 +161,22 @@ Blueprint::UP MatchesForLabelsBlueprint::createInstance() const {
 }
 
 fef::ParameterDescriptions MatchesForLabelsBlueprint::getDescriptions() const {
-    return fef::ParameterDescriptions().desc().field();
+    return fef::ParameterDescriptions().desc().field().desc();
 }
 
 bool MatchesForLabelsBlueprint::setup(const fef::IIndexEnvironment&, const fef::ParameterList& params) {
-    _field_id = params[0].asField()->id();
+    if (!params.empty()) {
+        _field_id = params[0].asField()->id();
+    }
     _empty_output = vespalib::eval::value_from_spec(_value_type.to_spec(), FastValueBuilderFactory::get());
     describeOutput("out",
-                   "1 for each query item label whose terms matched the given field, as a "
-                   "tensor<float>(label{}) with the labels as cell labels. Labels that did not "
-                   "match have no cell.",
+                   _field_id.has_value()
+                       ? "1 for each query item label whose terms matched the given field, as a "
+                         "tensor<float>(label{}) with the labels as cell labels. Labels that did not "
+                         "match have no cell."
+                       : "1 for each query item label whose terms matched the document in any field, as a "
+                         "tensor<float>(label{}) with the labels as cell labels. Labels that did not "
+                         "match have no cell.",
                    FeatureType::object(_value_type));
     return true;
 }
@@ -160,7 +185,7 @@ FeatureExecutor& MatchesForLabelsBlueprint::createExecutor(const fef::IQueryEnvi
                                                            vespalib::Stash&              stash) const {
     std::vector<std::pair<std::string, std::vector<TermFieldHandle>>> labeled_handles;
     for (auto& [label, terms] : util::getTermsByAllLabels(env)) {
-        auto handles = collect_field_handles(terms, _field_id);
+        auto handles = collect_handles(terms, _field_id);
         if (!handles.empty()) {
             labeled_handles.emplace_back(std::move(label), std::move(handles));
         }

--- a/searchlib/src/vespa/searchlib/features/matches_for_labels_feature.h
+++ b/searchlib/src/vespa/searchlib/features/matches_for_labels_feature.h
@@ -7,20 +7,22 @@
 #include <vespa/searchlib/fef/blueprint.h>
 
 #include <memory>
+#include <optional>
 
 namespace search::features {
 
 /**
- * Blueprint for matches_for_labels(field).
+ * Blueprint for matches_for_labels(field) and matches_for_labels().
  *
- * Output is a mapped tensor<float>(label{}) of match bits for one field.
- * A query item label gets a cell (value 1) only if at least one term carrying
- * that label searched this field and matched the document. Other labels are
- * omitted.
+ * Output is a mapped tensor<float>(label{}) of match bits. A query item label
+ * gets a cell (value 1) only if at least one term carrying that label matched
+ * the document; other labels are omitted. With a field parameter only terms
+ * searching that field are considered, without it all fields searched by the
+ * labeled terms count (including terms searching no field at all).
  */
 class MatchesForLabelsBlueprint : public fef::Blueprint {
 private:
-    uint32_t                               _field_id;
+    std::optional<uint32_t>                _field_id;
     vespalib::eval::ValueType              _value_type;
     std::unique_ptr<vespalib::eval::Value> _empty_output;
 

--- a/searchlib/src/vespa/searchlib/queryeval/label_wrapper_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/label_wrapper_blueprint.cpp
@@ -76,6 +76,13 @@ FieldSpecBaseList LabelWrapperBlueprint::exposeFields() const {
     return {};
 }
 
+bool LabelWrapperBlueprint::always_needs_unpack() const {
+    // The raw score is set during unpack, and the handle is for the reserved
+    // "no field", so it is not exposed as a field. Without this, a parent may
+    // skip unpacking this child and the score would never be set.
+    return true;
+}
+
 void LabelWrapperBlueprint::sort(Children&, InFlow) const {
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/label_wrapper_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/label_wrapper_blueprint.h
@@ -31,6 +31,7 @@ public:
     FlowStats calculate_flow_stats(uint32_t docid_limit) const final;
     HitEstimate combine(const std::vector<HitEstimate>& data) const override;
     FieldSpecBaseList exposeFields() const override;
+    bool always_needs_unpack() const override;
     void sort(Children& children, InFlow in_flow) const override;
     SearchIterator::UP createIntermediateSearch(MultiSearch::Children subSearches, fef::MatchData& md) const override;
     SearchIterator::UP createFilterSearchImpl(FilterConstraint constraint) const override;


### PR DESCRIPTION
Without a field parameter the feature reports every query item label whose terms matched the document, regardless of which field they search. This also covers labeled query items searching no field of their own, such as a subtree wrapped by the labeled() query operator.

LabelWrapperBlueprint now always needs unpack: it sets its raw score during unpack, but exposes no fields, so a parent could skip unpacking it and the score would never be set (which also left itemRawScore of a wrapper label at 0).
