### PR TITLE
Extend expiry of expired feature flags

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -182,7 +182,7 @@ public class Flags {
 
     public static final UnboundJacksonFlag<Sidecars> SIDECARS_FOR_TEST = defineJacksonFlag(
             "sidecars-for-test", Sidecars.DEFAULT, Sidecars.class,
-            List.of("glebashnik"), "2025-04-25", "2026-09-01",
+            List.of("glebashnik"), "2025-04-25", "2026-12-01",
             "Specifies configuration for sidecars to testing provisioning",
             "Takes effect at redeployment",
             __ -> true,
@@ -191,7 +191,7 @@ public class Flags {
 
     public static final UnboundBooleanFlag USE_TRITON = defineFeatureFlag(
             "use-triton", false,
-            List.of("glebashnik"), "2025-04-30", "2026-09-01",
+            List.of("glebashnik"), "2025-04-30", "2026-12-01",
             "Whether to use Triton as ONNX runtime",
             "Takes effect at redeployment",
             TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_TYPE, CLUSTER_ID, VESPA_VERSION
@@ -199,21 +199,21 @@ public class Flags {
 
     public static final UnboundIntFlag METRICS_PROXY_HEAP_SIZE_IN_MIB = defineIntFlag(
             "metrics-proxy-heap-size-in-mib", 0,
-            List.of("hmusum"), "2026-04-29", "2026-09-01",
+            List.of("hmusum"), "2026-04-29", "2026-12-01",
             "Amount of memory (in MiB) to use for metrics proxy JVM heap on non-admin nodes. 0 means use the default.",
             "Takes effect at redeployment",
             TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_TYPE, CLUSTER_ID, VESPA_VERSION);
 
     public static final UnboundIntFlag METRICS_PROXY_ADMIN_HEAP_SIZE_IN_MIB = defineIntFlag(
             "metrics-proxy-admin-heap-size-in-mib", 0,
-            List.of("hmusum"), "2026-04-29", "2026-09-01",
+            List.of("hmusum"), "2026-04-29", "2026-12-01",
             "Amount of memory (in MiB) to use for metrics proxy JVM heap on admin nodes. 0 means use the default.",
             "Takes effect at redeployment",
             TENANT_ID, APPLICATION, INSTANCE_ID);
 
     public static final UnboundBooleanFlag SEND_OLD_QUERY_STACK = defineFeatureFlag(
             "send-old-query-stack", false,
-            List.of("arnej"), "2026-05-07", "2026-09-01",
+            List.of("arnej"), "2026-05-07", "2026-12-01",
             "If true, send the old query stack format in addition to protobuf serialization.",
             "Takes effect at redeployment",
             TENANT_ID, APPLICATION, INSTANCE_ID);


### PR DESCRIPTION
## What

Extends the expiry date of five feature flags that expired on 2026-09-01 to 2026-12-01: `sidecars-for-test` and `use-triton` (@glebashnik), `metrics-proxy-heap-size-in-mib` and `metrics-proxy-admin-heap-size-in-mib` (@hmusum), and `send-old-query-stack` (@arnej27959).

## Why

The feature-flags-data expiry check (https://github.com/vespaai/feature-flags-data/actions/runs/33722485524) fails while these flags are past their expiry. This only buys time; owners tagged above, please remove the flag or set a real expiry when the flag is no longer needed.