### PR TITLE
fix yql serialization of numeric sameElement range/comparison with em…

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -327,8 +327,7 @@ public class VespaSerializer {
         boolean serialize(StringBuilder destination, UriItem uriItem, Scope scope) {
             String annotations = uriAnnotations(uriItem);
 
-            if (scope == Scope.ROOT) // A function argument is named by its function, and uri() has no sameElement form
-                destination.append(uriItem.getIndexName()).append(" contains ");
+            serializeField(uriItem, scope, destination);
             if (!annotations.isEmpty())
                 destination.append('(').append(annotations);
             destination.append(URI).append("(\"");
@@ -732,7 +731,7 @@ public class VespaSerializer {
                 destination.append("]} ");
             }
             destination.append(SAME_ELEMENT);
-            if (item.getItemCount() == 1 && item.getItem(0) instanceof AndItem || item.getItem(0) instanceof OrItem) {
+            if (item.getItemCount() == 1 && (item.getItem(0) instanceof AndItem || item.getItem(0) instanceof OrItem)) {
                 // serialize nested content without extra parenthesis
                 VespaSerializer.serialize(item.getItem(0), Scope.SAME_ELEMENT, destination);
             }

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -427,7 +427,6 @@ public class VespaSerializer {
             boolean leftOpen = !intItem.getFromLimit().isInclusive();
             boolean rightOpen = !intItem.getToLimit().isInclusive();
             String boundsAnnotation = "";
-            int initLen;
 
             if (leftOpen && rightOpen) {
                 boundsAnnotation = BOUNDS + ": " + "\"" + BOUNDS_OPEN + "\"";
@@ -440,12 +439,10 @@ public class VespaSerializer {
             if (hasLeafAnnotation) {
                 destination.append("({");
             }
-            initLen = destination.length();
-            if (!annotations.isEmpty()) {
-                destination.append(annotations);
-            }
-            comma(destination, initLen);
+            int initLen = destination.length();
+            destination.append(annotations);
             if (!boundsAnnotation.isEmpty()) {
+                comma(destination, initLen); // Only if the leaf annotations above wrote something
                 destination.append(boundsAnnotation);
             }
             if (hasLeafAnnotation) {

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -14,6 +14,7 @@ import static com.yahoo.search.yql.YqlParser.CONNECTIVITY;
 import static com.yahoo.search.yql.YqlParser.DISTANCE;
 import static com.yahoo.search.yql.YqlParser.DOT_PRODUCT;
 import static com.yahoo.search.yql.YqlParser.ELEMENT_FILTER;
+import static com.yahoo.search.yql.YqlParser.ELEMENT_VALUE;
 import static com.yahoo.search.yql.YqlParser.END_ANCHOR;
 import static com.yahoo.search.yql.YqlParser.EQUIV;
 import static com.yahoo.search.yql.YqlParser.FILTER;
@@ -133,6 +134,33 @@ import com.yahoo.search.query.QueryTree;
  */
 public class VespaSerializer {
 
+    /** The syntactic scope an item is serialized into, which decides how it writes the name of its field. */
+    private enum Scope {
+
+        /** The top level of the query, where each item names the field it applies to. */
+        ROOT,
+        /** An argument of a function such as phrase() or near(), which names the field on behalf of its arguments. */
+        FUNCTION_ARGUMENT,
+        /** Inside a sameElement, where a field name is a subfield and an unset one is the value of the element itself. */
+        SAME_ELEMENT;
+
+        /** Returns the field name to write in a syntax which also has a form without one, or "" to write none. */
+        String optionalIndexName(String indexName) {
+            return switch (this) {
+                case ROOT -> defaultedIndexName(indexName);
+                case FUNCTION_ARGUMENT -> "";
+                case SAME_ELEMENT -> indexName;
+            };
+        }
+
+        /** Returns the field name to write in a syntax which has no form without one, such as a range or comparison. */
+        String requiredIndexName(String indexName) {
+            if (this == SAME_ELEMENT && indexName.isEmpty()) return ELEMENT_VALUE; // On the element value itself
+            return defaultedIndexName(indexName); // No function argument is such a syntax, so this covers those too
+        }
+
+    }
+
     // TODO: Refactor, too much copy/paste
     private static abstract class Serializer<ITEM extends Item> {
 
@@ -143,7 +171,7 @@ public class VespaSerializer {
                                                     this.getClass().getSimpleName() + ", not yet implemented.");
         }
 
-        abstract boolean serialize(StringBuilder destination, ITEM item, Boolean includeField);
+        abstract boolean serialize(StringBuilder destination, ITEM item, Scope scope);
 
     }
 
@@ -169,7 +197,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, AndSegmentItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, AndSegmentItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, AndSegmentItem item, Scope scope) {
             Substring origin = item.getOrigin();
             String image;
             int offset;
@@ -185,7 +213,7 @@ public class VespaSerializer {
                 length = origin.end - origin.start;
             }
 
-            serializeField(item, includeField, destination);
+            serializeField(item, scope, destination);
             destination.append("({");
             serializeOrigin(destination, image, offset, length);
             destination.append(", ").append(AND_SEGMENTING).append(": true");
@@ -213,7 +241,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, AndItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, AndItem item, Scope scope) {
             destination.append("(");
             return true;
         }
@@ -225,7 +253,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, WeightedSetItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, WeightedSetItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, WeightedSetItem item, Scope scope) {
             serializeWeightedSetContents(destination, DOT_PRODUCT, item);
             return false;
         }
@@ -238,9 +266,9 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, EquivItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, EquivItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, EquivItem item, Scope scope) {
             String annotations = leafAnnotations(item);
-            serializeField(item.getItem(0), includeField, destination);
+            serializeField(item.getItem(0), scope, destination);
             if (!annotations.isEmpty()) {
                 destination.append("({").append(annotations).append("}");
             }
@@ -252,7 +280,7 @@ public class VespaSerializer {
                     destination.append(", ");
                 }
                 if (x instanceof PhraseItem) {
-                    new PhraseSerializer().serialize(destination, (PhraseItem)x, false);
+                    new PhraseSerializer().serialize(destination, (PhraseItem)x, Scope.FUNCTION_ARGUMENT);
                 } else {
                     destination.append('"');
                     escape(((IndexedItem) x).getIndexedString(), destination);
@@ -274,8 +302,8 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, NearItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, NearItem item, Boolean includeField) {
-            serializeField(item.getItem(0), includeField, destination);
+        boolean serialize(StringBuilder destination, NearItem item, Scope scope) {
+            serializeField(item.getItem(0), scope, destination);
             serializeItemListWithoutField(NEAR, item, nearAnnotations(item), destination);
             return false;
         }
@@ -296,10 +324,10 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, UriItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, UriItem uriItem, Boolean includeField) {
+        boolean serialize(StringBuilder destination, UriItem uriItem, Scope scope) {
             String annotations = uriAnnotations(uriItem);
 
-            if (includeField)
+            if (scope == Scope.ROOT) // A function argument is named by its function, and uri() has no sameElement form
                 destination.append(uriItem.getIndexName()).append(" contains ");
             if (!annotations.isEmpty())
                 destination.append('(').append(annotations);
@@ -349,7 +377,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, NotItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, NotItem item, Scope scope) {
             destination.append("(");
             return true;
         }
@@ -361,7 +389,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, NullItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, NullItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, NullItem item, Scope scope) {
             throw new NullItemException("NullItem encountered in query tree. This is usually a symptom of an invalid " +
                                         "query or an error in a query transformer.");
         }
@@ -374,28 +402,28 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, IntItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, IntItem intItem, Boolean includeField) {
+        boolean serialize(StringBuilder destination, IntItem intItem, Scope scope) {
             if (intItem.getFromLimit().number().equals(intItem.getToLimit().number())) {
-                String indexName = normalizeIndexName(intItem.getIndexName(), includeField);
+                String indexName = scope.optionalIndexName(intItem.getIndexName());
                 if ( ! indexName.isEmpty()) {
                     destination.append(indexName).append(" = ");
                 }
                 annotatedNumberImage(intItem, intItem.getFromLimit().number().toString(), destination);
             } else if (intItem.getFromLimit().isInfinite()) {
-                destination.append(normalizeIndexName(intItem.getIndexName()));
+                destination.append(scope.requiredIndexName(intItem.getIndexName()));
                 destination.append(intItem.getToLimit().isInclusive() ? " <= " : " < ");
                 annotatedNumberImage(intItem, intItem.getToLimit().number().toString(), destination);
             } else if (intItem.getToLimit().isInfinite()) {
-                destination.append(normalizeIndexName(intItem.getIndexName()));
+                destination.append(scope.requiredIndexName(intItem.getIndexName()));
                 destination.append(intItem.getFromLimit().isInclusive() ? " >= " : " > ");
                 annotatedNumberImage(intItem, intItem.getFromLimit().number().toString(), destination);
             } else {
-                serializeAsRange(destination, intItem);
+                serializeAsRange(destination, intItem, scope);
             }
             return false;
         }
 
-        private void serializeAsRange(StringBuilder destination, IntItem intItem) {
+        private void serializeAsRange(StringBuilder destination, IntItem intItem, Scope scope) {
             String annotations = leafAnnotations(intItem);
             boolean leftOpen = !intItem.getFromLimit().isInclusive();
             boolean rightOpen = !intItem.getToLimit().isInclusive();
@@ -409,7 +437,8 @@ public class VespaSerializer {
             } else if (rightOpen) {
                 boundsAnnotation = BOUNDS + ": " + "\"" + BOUNDS_RIGHT_OPEN + "\"";
             }
-            if (!annotations.isEmpty() || !boundsAnnotation.isEmpty()) {
+            boolean hasLeafAnnotation = !annotations.isEmpty() || !boundsAnnotation.isEmpty();
+            if (hasLeafAnnotation) {
                 destination.append("({");
             }
             initLen = destination.length();
@@ -420,15 +449,15 @@ public class VespaSerializer {
             if (!boundsAnnotation.isEmpty()) {
                 destination.append(boundsAnnotation);
             }
-            if (initLen != annotations.length()) {
+            if (hasLeafAnnotation) {
                 destination.append("}");
             }
             destination.append(RANGE).append('(')
-                    .append(normalizeIndexName(intItem.getIndexName()))
+                    .append(scope.requiredIndexName(intItem.getIndexName()))
                     .append(", ").append(intItem.getFromLimit().number())
                     .append(", ").append(intItem.getToLimit().number())
                     .append(")");
-            if (!annotations.isEmpty() || !boundsAnnotation.isEmpty()) {
+            if (hasLeafAnnotation) {
                 destination.append(")");
             }
         }
@@ -474,8 +503,8 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, BoolItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, BoolItem item, Boolean includeField) {
-            destination.append(normalizeIndexName(item.getIndexName())).append(" = ");
+        boolean serialize(StringBuilder destination, BoolItem item, Scope scope) {
+            destination.append(scope.requiredIndexName(item.getIndexName())).append(" = ");
             destination.append(item.stringValue());
             return false;
         }
@@ -486,7 +515,7 @@ public class VespaSerializer {
         @Override
         void onExit(StringBuilder destination, TrueItem item) { }
         @Override
-        boolean serialize(StringBuilder destination, TrueItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, TrueItem item, Scope scope) {
             destination.append("true");
             return false;
         }
@@ -496,7 +525,7 @@ public class VespaSerializer {
         @Override
         void onExit(StringBuilder destination, FalseItem item) { }
         @Override
-        boolean serialize(StringBuilder destination, FalseItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, FalseItem item, Scope scope) {
             destination.append("false");
             return false;
         }
@@ -508,9 +537,9 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, RegExpItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, RegExpItem regexp, Boolean includeField) {
+        boolean serialize(StringBuilder destination, RegExpItem regexp, Scope scope) {
             String annotations = leafAnnotations(regexp);
-            destination.append(normalizeIndexName(regexp.getIndexName())).append(" matches ");
+            destination.append(scope.requiredIndexName(regexp.getIndexName())).append(" matches ");
             annotatedTerm(destination, regexp, annotations);
             return false;
         }
@@ -522,10 +551,10 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, FuzzyItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, FuzzyItem fuzzy, Boolean includeField) {
+        boolean serialize(StringBuilder destination, FuzzyItem fuzzy, Scope scope) {
             String annotations = fuzzyAnnotations(fuzzy);
 
-            serializeField(fuzzy, includeField, destination);
+            serializeField(fuzzy, scope, destination);
 
             if (!annotations.isEmpty()) {
                 destination.append('(').append(annotations);
@@ -581,8 +610,8 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, ONearItem item, Boolean includeField) {
-            serializeField(item.getItem(0), includeField, destination);
+        boolean serialize(StringBuilder destination, ONearItem item, Scope scope) {
+            serializeField(item.getItem(0), scope, destination);
             serializeItemListWithoutField(ONEAR, item, NearSerializer.nearAnnotations(item), destination);
             return false;
         }
@@ -602,7 +631,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, OrItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, OrItem item, Scope scope) {
             destination.append("(");
             return true;
         }
@@ -620,7 +649,7 @@ public class VespaSerializer {
                     destination.append('"');
                     escape(word.getIndexedString(), destination).append('"');
                 } else if (current instanceof WordAlternativesItem alternatives) {
-                    new WordAlternativesSerializer().serialize(destination, alternatives, false);
+                    new WordAlternativesSerializer().serialize(destination, alternatives, Scope.FUNCTION_ARGUMENT);
                 } else {
                     throw new IllegalArgumentException("Serializing of " + current.getClass().getSimpleName() +
                                                        " in phrases not implemented, please report this as a bug.");
@@ -632,13 +661,13 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, PhraseSegmentItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, PhraseSegmentItem phrase, Boolean includeField) {
+        boolean serialize(StringBuilder destination, PhraseSegmentItem phrase, Scope scope) {
             Substring origin = phrase.getOrigin();
             String image;
             int offset;
             int length;
 
-            serializeField(phrase, includeField, destination);
+            serializeField(phrase, scope, destination);
             if (origin == null) {
                 image = phrase.getRawWord();
                 offset = 0;
@@ -672,8 +701,8 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, PhraseItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, PhraseItem phrase, Boolean includeField) {
-            serializeField(phrase, includeField, destination);
+        boolean serialize(StringBuilder destination, PhraseItem phrase, Scope scope) {
+            serializeField(phrase, scope, destination);
             serializeItemListWithoutField(PHRASE, phrase, leafAnnotations(phrase), destination);
             return false;
         }
@@ -686,8 +715,8 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, SameElementItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, SameElementItem item, Boolean includeField) {
-            serializeField(item, includeField, destination);
+        boolean serialize(StringBuilder destination, SameElementItem item, Scope scope) {
+            serializeField(item, scope, destination);
 
             boolean hasFilter = !item.getElementFilter().isEmpty();
             if (hasFilter) {
@@ -705,14 +734,14 @@ public class VespaSerializer {
             destination.append(SAME_ELEMENT);
             if (item.getItemCount() == 1 && item.getItem(0) instanceof AndItem || item.getItem(0) instanceof OrItem) {
                 // serialize nested content without extra parenthesis
-                VespaSerializer.serialize(item.getItem(0), null, destination);
+                VespaSerializer.serialize(item.getItem(0), Scope.SAME_ELEMENT, destination);
             }
             else {
                 destination.append('(');
                 for (int i = 0; i < item.getItemCount(); ++i) {
                     if (i > 0)
                         destination.append(", ");
-                    VespaSerializer.serialize(item.getItem(i), null, destination);
+                    VespaSerializer.serialize(item.getItem(i), Scope.SAME_ELEMENT, destination);
                 }
                 destination.append(')');
             }
@@ -732,7 +761,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, GeoLocationItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, GeoLocationItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, GeoLocationItem item, Scope scope) {
             String annotations = leafAnnotations(item);
             if (!annotations.isEmpty()) {
                 destination.append("({").append(annotations).append("}");
@@ -760,7 +789,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, NearestNeighborItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, NearestNeighborItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, NearestNeighborItem item, Scope scope) {
             destination.append("{");
             int initLen = destination.length();
             destination.append(leafAnnotations(item));
@@ -842,7 +871,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, PredicateQueryItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, PredicateQueryItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, PredicateQueryItem item, Scope scope) {
             destination.append("predicate(").append(item.getIndexName()).append(',');
             appendFeatures(destination, item.getFeatures());
             destination.append(',');
@@ -897,13 +926,13 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, RangeItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, RangeItem range, Boolean includeField) {
+        boolean serialize(StringBuilder destination, RangeItem range, Scope scope) {
             String annotations = leafAnnotations(range);
             if (!annotations.isEmpty()) {
                 destination.append("{").append(annotations).append("}");
             }
             destination.append(RANGE).append('(')
-                    .append(normalizeIndexName(range.getIndexName()))
+                    .append(scope.requiredIndexName(range.getIndexName()))
                     .append(", ");
             appendNumberImage(destination, range.getFrom()); // TODO: Serialize
                                                              // inclusive/exclusive
@@ -927,7 +956,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, StringRangeItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, StringRangeItem range, Boolean includeField) {
+        boolean serialize(StringBuilder destination, StringRangeItem range, Scope scope) {
             String leafAnnotations = leafAnnotations(range);
             String boundsAnnotation = boundsAnnotation(range);
             String annotations = leafAnnotations + (!leafAnnotations.isEmpty() && !boundsAnnotation.isEmpty() ? ", " : "") + boundsAnnotation;
@@ -937,7 +966,7 @@ public class VespaSerializer {
 
             // range
             destination.append(RANGE).append('(')
-                    .append(normalizeIndexName(range.getIndexName()))
+                    .append(scope.requiredIndexName(range.getIndexName()))
                     .append(", ");
 
             // from
@@ -989,7 +1018,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, RankItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, RankItem item, Scope scope) {
             destination.append(RANK).append('(');
             return true;
 
@@ -1007,7 +1036,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, LabelWrapperItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, LabelWrapperItem item, Scope scope) {
             destination.append(LABELED).append('(');
             return true;
         }
@@ -1020,7 +1049,7 @@ public class VespaSerializer {
         void onExit(StringBuilder destination, WordAlternativesItem item) { }
 
         @Override
-        boolean serialize(StringBuilder destination, WordAlternativesItem alternatives, Boolean includeField) {
+        boolean serialize(StringBuilder destination, WordAlternativesItem alternatives, Scope scope) {
             int initLen = 0;
             StringBuilder annotations = new StringBuilder(leafAnnotations(alternatives));
 
@@ -1037,7 +1066,7 @@ public class VespaSerializer {
             boolean isFromQuery = alternatives.isFromQuery();
             boolean needsAnnotations = !annotations.isEmpty() || origin != null || !isFromQuery;
 
-            serializeField(alternatives, includeField, destination);
+            serializeField(alternatives, scope, destination);
 
             if (needsAnnotations) {
                 destination.append("({");
@@ -1088,7 +1117,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, WandItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, WandItem item, Scope scope) {
             serializeWeightedSetContents(destination, WAND, item, specificAnnotations(item));
             return false;
         }
@@ -1139,7 +1168,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, WeakAndItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, WeakAndItem item, Scope scope) {
             if (needsAnnotationBlock(item)) {
                 destination.append("({");
                 boolean needsComma = false;
@@ -1168,7 +1197,7 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, WeightedSetItem item, Boolean includeField) {
+        boolean serialize(StringBuilder destination, WeightedSetItem item, Scope scope) {
             serializeWeightedSetContents(destination, WEIGHTED_SET, item);
             return false;
         }
@@ -1182,8 +1211,8 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, StringInItem item, Boolean includeField) {
-            destination.append(item.getIndexName()).append(" in (");
+        boolean serialize(StringBuilder destination, StringInItem item, Scope scope) {
+            destination.append(scope.requiredIndexName(item.getIndexName())).append(" in (");
             int initLen = destination.length();
             List<String> tokens = new ArrayList<>(item.getTokens());
             Collections.sort(tokens);
@@ -1204,8 +1233,8 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, NumericInItem item, Boolean includeField) {
-            destination.append(item.getIndexName()).append(" in (");
+        boolean serialize(StringBuilder destination, NumericInItem item, Scope scope) {
+            destination.append(scope.requiredIndexName(item.getIndexName())).append(" in (");
             int initLen = destination.length();
             List<Long> tokens = new ArrayList<>(item.getTokens());
             Collections.sort(tokens);
@@ -1227,8 +1256,8 @@ public class VespaSerializer {
         }
 
         @Override
-        boolean serialize(StringBuilder destination, WordItem item, Boolean includeField) {
-            serializeField(item, includeField, destination);
+        boolean serialize(StringBuilder destination, WordItem item, Scope scope) {
+            serializeField(item, scope, destination);
             VespaSerializer.annotatedTerm(destination, item, getAllAnnotations(item).toString());
             return false;
         }
@@ -1332,12 +1361,12 @@ public class VespaSerializer {
 
     private static class VespaVisitor extends QueryVisitor {
 
-        final Boolean includeField;
+        final Scope scope;
         final StringBuilder destination;
         final Deque<SerializerWrapper> state = new ArrayDeque<>();
 
-        VespaVisitor(Boolean includeField, StringBuilder destination) {
-            this.includeField = includeField;
+        VespaVisitor(Scope scope, StringBuilder destination) {
+            this.scope = scope;
             this.destination = destination;
         }
 
@@ -1361,7 +1390,7 @@ public class VespaSerializer {
                 destination.append(state.peekFirst().type.separator(state));
 
             state.addFirst(new SerializerWrapper(serializer, item));
-            return serializer.serialize(destination, item, includeField);
+            return serializer.serialize(destination, item, scope);
 
         }
     }
@@ -1507,11 +1536,11 @@ public class VespaSerializer {
     }
 
     private static void serialize(Item item, StringBuilder out) {
-        serialize(item, true, out);
+        serialize(item, Scope.ROOT, out);
     }
 
-    private static void serialize(Item item, Boolean includeField, StringBuilder out) {
-        VespaVisitor visitor = new VespaVisitor(includeField, out);
+    private static void serialize(Item item, Scope scope, StringBuilder out) {
+        VespaVisitor visitor = new VespaVisitor(scope, out);
         ToolBox.visit(visitor, item);
     }
 
@@ -1536,7 +1565,7 @@ public class VespaSerializer {
                                                      WeightedSetItem weightedSet, String optionalAnnotations) {
         boolean addedAnnotations = addAnnotations(destination, weightedSet, optionalAnnotations);
         destination.append(opName).append('(')
-                   .append(normalizeIndexName(weightedSet.getIndexName()))
+                   .append(defaultedIndexName(weightedSet.getIndexName()))
                    .append(", {");
         int initLen = destination.length();
         List<Entry<Object, Integer>> tokens = new ArrayList<>(weightedSet.getNumTokens());
@@ -1700,30 +1729,25 @@ public class VespaSerializer {
         for (int i = 0; i < item.getItemCount(); ++i) {
             if (i > 0)
                 destination.append(", ");
-            VespaSerializer.serialize(item.getItem(i), false, destination);
+            VespaSerializer.serialize(item.getItem(i), Scope.FUNCTION_ARGUMENT, destination);
         }
         destination.append(')');
         if (!annotations.isEmpty())
             destination.append(')');
     }
 
-    private static void serializeField(Item item, Boolean includeField, StringBuilder destination) {
+    private static void serializeField(Item item, Scope scope, StringBuilder destination) {
         if (!(item instanceof HasIndexItem indexItem))
             throw new IllegalArgumentException("Expected HasIndexItem, got " + item.getClass());
-        String indexName = normalizeIndexName(indexItem.getIndexName(), includeField);
+        String indexName = scope.optionalIndexName(indexItem.getIndexName());
         if ( ! indexName.isEmpty()) {
             destination.append(indexName).append(" contains ");
         }
     }
 
-    private static String normalizeIndexName(String indexName, Boolean includeField) {
-        if (includeField == null) return indexName; // We're in a context (sameElement) where both including and not including a field name is valid
-        if ( ! includeField) return ""; // We're in a context where the field name should not be included even if set
-        return indexName.isEmpty() ? "default" : indexName; // We're in a context where a field name must be included
-    }
-
-    private static String normalizeIndexName(String indexName) {
-        return normalizeIndexName(indexName, true);
+    /** Returns the given field name where one must be written, with an unset name written as the default index. */
+    private static String defaultedIndexName(String indexName) {
+        return indexName.isEmpty() ? "default" : indexName;
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -878,7 +878,8 @@ public class YqlParser implements Parser {
 
         @Override
         public String expand(String leaf) {
-            return prefix + leaf;
+            // An unset leaf name is the value of the element itself, which is a value of the field we are prefixing by
+            return leaf.isEmpty() ? field : prefix + leaf;
         }
 
         @Override
@@ -2494,12 +2495,10 @@ public class YqlParser implements Parser {
 
     /**
      * Returns the index of a field name as returned by {@link #getIndex}, where the empty name of the element
-     * value resolves to the field of the enclosing sameElement, as element values have the type of that field.
+     * value expands to the field of the enclosing sameElement, as element values have the type of that field.
      */
     private Index indexOf(String field) {
-        return indexFactsSession.getIndex(field.isEmpty() && indexNameExpander.elementValueField() != null
-                                          ? indexNameExpander.elementValueField()
-                                          : indexNameExpander.expand(field));
+        return indexFactsSession.getIndex(indexNameExpander.expand(field));
     }
 
     private Substring getSubstring(OperatorNode<ExpressionOperator> ast) {

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -125,6 +125,8 @@ public class YqlParser implements Parser {
 
     private static class IndexNameExpander {
         public String expand(String leaf) { return leaf; }
+        /** Returns the field whose element values the ELEMENT_VALUE placeholder refers to, or null if there is none here. */
+        public String elementValueField() { return null; }
     }
 
     private static final Integer DEFAULT_HITS = 10;
@@ -180,6 +182,8 @@ public class YqlParser implements Parser {
     public static final String DOCUMENT_FREQUENCY = "documentFrequency";
     public static final String DOT_PRODUCT = "dotProduct";
     public static final String ELEMENT_FILTER = "elementFilter";
+    /** Used in place of a field name inside sameElement to refer to the value of the element itself. */
+    public static final String ELEMENT_VALUE = "_";
     public static final String EQUIV = "equiv";
     public static final String FILTER = "filter";
     public static final String FREQUENCY = "frequency";
@@ -587,7 +591,7 @@ public class YqlParser implements Parser {
 
     private Item buildIn(OperatorNode<ExpressionOperator> ast) {
         String field = getIndex(ast.getArgument(0));
-        var index = indexFactsSession.getIndex(indexNameExpander.expand(field));
+        var index = indexOf(field);
         boolean stringField = index.isString();
         if (!index.isInteger() && !stringField)
             throw new IllegalArgumentException("The in operator is only supported for integer and string fields. The field " +
@@ -865,15 +869,20 @@ public class YqlParser implements Parser {
     }
 
     private static class PrefixExpander extends IndexNameExpander {
+        private final String field;
         private final String prefix;
-        public PrefixExpander(String prefix) {
-            this.prefix = prefix + ".";
+        public PrefixExpander(String field) {
+            this.field = field;
+            this.prefix = field + ".";
         }
 
         @Override
         public String expand(String leaf) {
             return prefix + leaf;
         }
+
+        @Override
+        public String elementValueField() { return field; }
     }
 
     private Item instantiateSameElementItem(String field, OperatorNode<ExpressionOperator> ast) {
@@ -1663,7 +1672,7 @@ public class YqlParser implements Parser {
         Preconditions.checkArgument(args.size() == 3,
                 "Expected 3 arguments, got %s.", args.size());
 
-        var index = indexFactsSession.getIndex(indexNameExpander.expand(getIndex(args.get(0))));
+        var index = indexOf(getIndex(args.get(0)));
         if (index.isString() && !index.isInteger() && !index.isNumerical()) {
             StringRangeItem range = instantiateStringRangeItem(args, spec);
             return leafStyleSettings(spec, range);
@@ -2469,9 +2478,28 @@ public class YqlParser implements Parser {
 
     private String getIndex(OperatorNode<ExpressionOperator> operatorNode) {
         String index = fetchFieldName(operatorNode);
+        if (isElementValue(index)) return ""; // the element value has no field name of its own
         String expanded = indexNameExpander.expand(index);
         Preconditions.checkArgument(indexFactsSession.isIndex(expanded), "Field '%s' does not exist.", expanded);
         return indexFactsSession.getCanonicName(index);
+    }
+
+    /**
+     * Returns whether the given field name is the ELEMENT_VALUE placeholder in a context where it is meaningful,
+     * that is inside a sameElement, where it refers to the value of the element itself rather than to a subfield.
+     */
+    private boolean isElementValue(String field) {
+        return ELEMENT_VALUE.equals(field) && indexNameExpander.elementValueField() != null;
+    }
+
+    /**
+     * Returns the index of a field name as returned by {@link #getIndex}, where the empty name of the element
+     * value resolves to the field of the enclosing sameElement, as element values have the type of that field.
+     */
+    private Index indexOf(String field) {
+        return indexFactsSession.getIndex(field.isEmpty() && indexNameExpander.elementValueField() != null
+                                          ? indexNameExpander.elementValueField()
+                                          : indexNameExpander.expand(field));
     }
 
     private Substring getSubstring(OperatorNode<ExpressionOperator> ast) {

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -579,14 +579,14 @@ public class YqlParser implements Parser {
         List<OperatorNode<ExpressionOperator>> args = ast.getArgument(1);
         Preconditions.checkArgument(args.size() == 2, "Expected 2 arguments, got %s.", args.size());
 
-        return fillWeightedSet(ast, args.get(1), new WeightedSetItem(getIndex(args.get(0))));
+        return fillWeightedSet(ast, args.get(1), new WeightedSetItem(getFieldIndex(args.get(0), WEIGHTED_SET)));
     }
 
     private Item buildDotProduct(OperatorNode<ExpressionOperator> ast) {
         List<OperatorNode<ExpressionOperator>> args = ast.getArgument(1);
         Preconditions.checkArgument(args.size() == 2, "Expected 2 arguments, got %s.", args.size());
 
-        return fillWeightedSet(ast, args.get(1), new DotProductItem(getIndex(args.get(0))));
+        return fillWeightedSet(ast, args.get(1), new DotProductItem(getFieldIndex(args.get(0), DOT_PRODUCT)));
     }
 
     private Item buildIn(OperatorNode<ExpressionOperator> ast) {
@@ -745,7 +745,7 @@ public class YqlParser implements Parser {
         Preconditions.checkArgument(args.size() == 3, "Expected 3 arguments, got %s.", args.size());
 
         PredicateQueryItem item = new PredicateQueryItem();
-        item.setIndexName(getIndex(args.get(0)));
+        item.setIndexName(getFieldIndex(args.get(0), PREDICATE));
 
         addFeatures(args.get(1),
                    (key, value, subqueryBitmap) -> item.addFeature(key, (String) value, subqueryBitmap), PredicateQueryItem.ALL_SUB_QUERIES);
@@ -806,7 +806,7 @@ public class YqlParser implements Parser {
         List<OperatorNode<ExpressionOperator>> args = ast.getArgument(1);
         Preconditions.checkArgument(args.size() == 2, "Expected 2 arguments, got %s.", args.size());
 
-        WandItem out = new WandItem(getIndex(args.get(0)));
+        WandItem out = new WandItem(getFieldIndex(args.get(0), WAND));
         out.setTargetHits(buildTargetHits(ast));
         out.setTotalTargetHits(getAnnotation(ast, TOTAL_TARGET_HITS, Integer.class, null, "total hits to produce across all nodes"));
         assignAnnotationAsDoubleIfNotNull(ast, SCORE_THRESHOLD, "score must be above this threshold for hit inclusion", out::setScoreThreshold);
@@ -894,12 +894,16 @@ public class YqlParser implements Parser {
 
         // All terms below sameElement are relative to this.
         IndexNameExpander prev = swapIndexCreator(new PrefixExpander(field));
-        for (OperatorNode<ExpressionOperator> term : ast.<List<OperatorNode<ExpressionOperator>>> getArgument(1)) {
-            // TODO: getIndex that is called once every term is rather expensive as it does sanity checking
-            // that is not necessary. This is an issue when having many elements
-            sameElement.addItem(convertExpression(term, field));
+        try {
+            for (OperatorNode<ExpressionOperator> term : ast.<List<OperatorNode<ExpressionOperator>>> getArgument(1)) {
+                // TODO: getIndex that is called once every term is rather expensive as it does sanity checking
+                // that is not necessary. This is an issue when having many elements
+                sameElement.addItem(convertExpression(term, field));
+            }
         }
-        swapIndexCreator(prev);
+        finally {
+            swapIndexCreator(prev); // Also on a failed term, as this parser may be used again
+        }
         return sameElement;
     }
 
@@ -2483,6 +2487,18 @@ public class YqlParser implements Parser {
         String expanded = indexNameExpander.expand(index);
         Preconditions.checkArgument(indexFactsSession.isIndex(expanded), "Field '%s' does not exist.", expanded);
         return indexFactsSession.getCanonicName(index);
+    }
+
+    /**
+     * Returns the index of a field named as the argument of a syntax which applies to a field as a whole, such as
+     * dotProduct or predicate, and which therefore has no form taking the value of an element instead of a field.
+     */
+    private String getFieldIndex(OperatorNode<ExpressionOperator> operatorNode, String syntax) {
+        String index = getIndex(operatorNode);
+        Preconditions.checkArgument( ! index.isEmpty(),
+                                    "%s takes a field name, but got '%s', which is the value of the element of the " +
+                                    "enclosing sameElement rather than a field.", syntax, ELEMENT_VALUE);
+        return index;
     }
 
     /**

--- a/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
@@ -361,6 +361,54 @@ public class VespaSerializerTestCase {
     }
 
     @Test
+    void testSameElementWithNumericRangeChild() {
+        // A non-equality IntItem child with an empty index must also serialize as a bare
+        // range/comparison, not with a "default" field prefix (same bug as equality, for the
+        // open-bound and two-sided-range branches of NumberSerializer).
+        SameElementItem lowerBound = new SameElementItem("ints");
+        lowerBound.setElementFilter(List.of(1));
+        lowerBound.addItem(new IntItem(new com.yahoo.prelude.query.Limit(2, true), com.yahoo.prelude.query.Limit.POSITIVE_INFINITY, ""));
+        assertEquals("ints contains ({elementFilter:[1]} sameElement(_ >= 2))",
+                     VespaSerializer.serialize(lowerBound));
+
+        SameElementItem upperBound = new SameElementItem("ints");
+        upperBound.setElementFilter(List.of(1));
+        upperBound.addItem(new IntItem(com.yahoo.prelude.query.Limit.NEGATIVE_INFINITY, new com.yahoo.prelude.query.Limit(5, true), ""));
+        assertEquals("ints contains ({elementFilter:[1]} sameElement(_ <= 5))",
+                     VespaSerializer.serialize(upperBound));
+
+        SameElementItem range = new SameElementItem("ints");
+        range.setElementFilter(List.of(1));
+        range.addItem(new IntItem(new com.yahoo.prelude.query.Limit(2, true), new com.yahoo.prelude.query.Limit(5, true), ""));
+        assertEquals("ints contains ({elementFilter:[1]} sameElement(range(_, 2, 5)))",
+                     VespaSerializer.serialize(range));
+
+        // The serialized forms are stable: they parse back to themselves
+        parseAndConfirm("ints contains ({elementFilter:[1]} sameElement(_ >= 2))");
+        parseAndConfirm("ints contains ({elementFilter:[1]} sameElement(_ <= 5))");
+        parseAndConfirm("ints contains ({elementFilter:[1]} sameElement(range(_, 2, 5)))");
+        parseAndConfirm("ints contains ({elementFilter:[1]} sameElement(({bounds: \"leftOpen\"}range(_, 2, 5))))");
+    }
+
+    @Test
+    void testSameElementValuePlaceholder() {
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+
+        // Every syntax which requires a field name uses the "_" placeholder for the value of the element itself
+        parseAndConfirm("field contains sameElement(_ >= 2)");
+        parseAndConfirm("field contains sameElement(range(_, 2, 5))");
+        parseAndConfirm("field contains sameElement(_ = true)");
+        parseAndConfirm("string contains sameElement(range(_, \"a\", \"b\"))");
+        parseAndConfirm("string contains sameElement(_ matches \"f.*\")");
+        parseAndConfirm("field contains sameElement(_ in (1, 2))");
+        parseAndConfirm("string contains sameElement(_ in (\"a\", \"b\"))");
+
+        // Syntaxes which are valid without a field name keep serializing without one
+        parseAndConfirm("field contains sameElement(2)", "field contains sameElement(_ = 2)");
+        parseAndConfirm("string contains sameElement(\"foo\")", "string contains sameElement(_ contains \"foo\")");
+    }
+
+    @Test
     void testAnnotatedAndSegment() {
         AndSegmentItem andSegment = new AndSegmentItem("abc", true, false);
         andSegment.addItem(new WordItem("a", "indexNamePlaceholder"));

--- a/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
@@ -7,6 +7,7 @@ import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.IndexModel;
 import com.yahoo.prelude.SearchDefinition;
 import com.yahoo.prelude.query.IntItem;
+import com.yahoo.prelude.query.Limit;
 import com.yahoo.prelude.query.RangeItem;
 import com.yahoo.prelude.query.SameElementItem;
 import com.yahoo.search.Query;
@@ -427,6 +428,27 @@ public class VespaSerializerTestCase {
 
         // A uri() on the element value itself has no subfield name to write
         parseAndConfirm("f contains sameElement(uri(\"http://foo.com\"))");
+    }
+
+    @Test
+    void testRangeAnnotations() {
+        // A leaf annotation without a bounds annotation must not leave a trailing comma in the annotation block
+        IntItem closed = new IntItem(new Limit(2, true), new Limit(5, true), "field");
+        closed.setLabel("foo");
+        assertEquals("({label: \"foo\"}range(field, 2, 5))", VespaSerializer.serialize(closed));
+
+        // That form parses back to an inclusive RangeItem, which has its own (also stable) canonical form
+        parseAndConfirm("{label: \"foo\"}range(field, 2, 5)", "({label: \"foo\"}range(field, 2, 5))");
+        parseAndConfirm("{label: \"foo\"}range(field, 2, 5)");
+
+        // A bounds annotation alone, and both annotations together, separated by a comma
+        IntItem leftOpen = new IntItem(new Limit(2, false), new Limit(5, true), "field");
+        assertEquals("({bounds: \"leftOpen\"}range(field, 2, 5))", VespaSerializer.serialize(leftOpen));
+
+        IntItem both = new IntItem(new Limit(2, false), new Limit(5, true), "field");
+        both.setLabel("foo");
+        assertEquals("({label: \"foo\", bounds: \"leftOpen\"}range(field, 2, 5))", VespaSerializer.serialize(both));
+        parseAndConfirm("({label: \"foo\", bounds: \"leftOpen\"}range(field, 2, 5))");
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
@@ -409,6 +409,27 @@ public class VespaSerializerTestCase {
     }
 
     @Test
+    void testSameElementWithOrChild() {
+        // A single AND or OR child supplies the parenthesis of the sameElement itself
+        parseAndConfirm("f contains sameElement(a contains \"x\" OR b contains \"y\")");
+        parseAndConfirm("f contains sameElement(a contains \"x\" AND b contains \"y\")");
+
+        // With more than one child, every child must be serialized, also when the first is an AND or OR
+        parseAndConfirm("f contains sameElement((a contains \"x\" OR b contains \"y\"), c contains \"z\")");
+        parseAndConfirm("f contains sameElement((a contains \"x\" AND b contains \"y\"), c contains \"z\")");
+    }
+
+    @Test
+    void testSameElementWithUriChild() {
+        // A uri() child inside sameElement keeps the name of the subfield it applies to
+        parseAndConfirm("f contains sameElement(url contains uri(\"http://foo.com\"))");
+        parseAndConfirm("f contains sameElement(url contains uri(\"http://foo.com\"), name contains \"x\")");
+
+        // A uri() on the element value itself has no subfield name to write
+        parseAndConfirm("f contains sameElement(uri(\"http://foo.com\"))");
+    }
+
+    @Test
     void testAnnotatedAndSegment() {
         AndSegmentItem andSegment = new AndSegmentItem("abc", true, false);
         andSegment.addItem(new WordItem("a", "indexNamePlaceholder"));

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -2151,4 +2151,23 @@ public class YqlParserTestCase {
                 "Top-level field x is not exact, so should produce WordItem");
     }
 
+    @Test
+    void testElementValueUsesEnclosingFieldSettings() {
+        SearchDefinition sd = new SearchDefinition("default");
+        Index exactArray = new Index("exactArray");
+        exactArray.setExact(true, null);
+        exactArray.setString(true);
+        sd.addIndex(exactArray);
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(new IndexFacts(new IndexModel(sd))));
+
+        // The element value has no subfield name of its own, so it must resolve to the enclosing sameElement field
+        // rather than to a non-existent "exactArray." index, both as a bare literal and through the placeholder
+        for (String query : List.of("select * from sources * where exactArray contains sameElement(\"hello\")",
+                                    "select * from sources * where exactArray contains sameElement(_ contains \"hello\")")) {
+            SameElementItem sameElement = (SameElementItem) parse(query).getRoot();
+            assertInstanceOf(ExactStringItem.class, sameElement.getItem(0),
+                             "exactArray is exact, so its element value should produce ExactStringItem: " + query);
+        }
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -519,6 +519,54 @@ public class YqlParserTestCase {
     }
 
     @Test
+    void testSameElementValuePlaceholder() {
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+
+        // "_" stands for the value of the element itself, so the term gets no field name of its own.
+        assertParse("select * from sources * where field contains ({elementFilter:[1]} sameElement(_ >= 2))",
+                    "field[1]:{[2;]}");
+        assertParse("select * from sources * where field contains sameElement(_ > 2)",
+                    "field:{>2}");
+        assertParse("select * from sources * where field contains sameElement(range(_, 2, 5))",
+                    "field:{[2;5]}");
+        assertParse("select * from sources * where field contains sameElement(_ = 2)",
+                    "field:{2}");
+        assertParse("select * from sources * where field contains sameElement(_ >= 2 and _ <= 5)",
+                    "field:{(AND [2;] [;5])}");
+        IntItem number = assertInstanceOf(IntItem.class,
+                ((SameElementItem) parse("select * from sources * where field contains sameElement(_ >= 2)").getRoot()).getItem(0));
+        assertEquals("", number.getIndexName());
+
+        // The element values have the type of the field of the sameElement, so a range on a string field
+        // is a string range even though the placeholder itself is not a field.
+        assertParse("select * from sources * where string contains sameElement(range(_, \"a\", \"b\"))",
+                    "string:{STRING_RANGE [\"a\";\"b\"]}");
+        StringRangeItem stringRange = assertInstanceOf(StringRangeItem.class,
+                ((SameElementItem) parse("select * from sources * where string contains sameElement(range(_, \"a\", \"b\"))").getRoot()).getItem(0));
+        assertEquals("", stringRange.getIndexName());
+
+        // It works with the other syntaxes taking a field name as well.
+        assertParse("select * from sources * where string contains sameElement(_ contains \"foo\")",
+                    "string:{foo}");
+        assertParse("select * from sources * where string contains sameElement(_ matches \"f.*\")",
+                    "string:{REGEXP f.*}");
+        assertParse("select * from sources * where field contains sameElement(_ in (1, 2))",
+                    "field:{NUMERIC_IN {1,2}}");
+        assertParse("select * from sources * where string contains sameElement(_ in (\"a\", \"b\"))",
+                    "string:{STRING_IN {\"a\",\"b\"}}");
+
+        // A boolean has no typed item form of its own, but is still a term on the element value.
+        assertParse("select * from sources * where field contains sameElement(_ = true)",
+                    "field:{true}");
+
+        // Outside sameElement the placeholder is an ordinary field name, so it must be a field.
+        assertParseFail("select * from sources * where _ >= 2",
+                        new IllegalArgumentException("Field '_' does not exist."));
+        assertParseFail("select * from sources * where field contains sameElement(string contains \"foo\")",
+                        new IllegalArgumentException("Field 'field.string' does not exist."));
+    }
+
+    @Test
     void testSameElementWithNestedAnd() {
         assertParse("select * from sources * where myStringArray contains sameElement('a' and 'b' and near('c', 'd'))",
                     "myStringArray:{(AND a b (NEAR(2) c d))}");

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -567,6 +567,33 @@ public class YqlParserTestCase {
     }
 
     @Test
+    void testElementValueIsRejectedWhereAFieldIsRequired() {
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+
+        // These apply to a field as a whole, so the value of an element is not something they can take
+        for (String syntax : List.of("dotProduct", "weightedSet", "wand")) {
+            assertParseFail("select * from sources * where string contains sameElement(" + syntax + "(_, {\"a\": 1}))",
+                            new IllegalArgumentException(syntax + " takes a field name, but got '_', which is the " +
+                                                         "value of the element of the enclosing sameElement rather " +
+                                                         "than a field."));
+        }
+        assertParseFail("select * from sources * where string contains sameElement(predicate(_, {\"a\":\"b\"}, {}))",
+                        new IllegalArgumentException("predicate takes a field name, but got '_', which is the value " +
+                                                     "of the element of the enclosing sameElement rather than a field."));
+    }
+
+    @Test
+    void testFailedSameElementTermDoesNotLeakTheFieldPrefix() {
+        parser = new YqlParser(new ParserEnvironment().setIndexFacts(createIndexFactsForInTest()));
+
+        // A term which fails to convert must leave the index name expander as it found it, as the parser is usable after
+        assertParseFail("select * from sources * where string contains sameElement(nosuchfield contains \"a\")",
+                        new IllegalArgumentException("Field 'string.nosuchfield' does not exist."));
+        assertParse("select * from sources * where string contains sameElement(_ contains \"foo\")",
+                    "string:{foo}");
+    }
+
+    @Test
     void testSameElementWithNestedAnd() {
         assertParse("select * from sources * where myStringArray contains sameElement('a' and 'b' and near('c', 'd'))",
                     "myStringArray:{(AND a b (NEAR(2) c d))}");


### PR DESCRIPTION
…pty index

NumberSerializer only honored the includeField/sameElement context in the equality branch, so an IntItem with an empty index using a range or open-ended bound still serialized with a spurious "default" field prefix. Thread the serialization scope through the remaining branches and serializeAsRange.

Also fixes a latent bug in serializeAsRange's closing-brace check, which compared destination.length() to annotations.length() and only worked by coincidence when the range was always the top-level item with an empty buffer; nesting inside sameElement made it emit a spurious "}".

A range or comparison has no YQL form without a field name, so an empty index name still had nothing parseable to serialize to. Add "_" as the name of the value of the element itself, valid inside sameElement, making these round trip to the same query tree:

    ints contains ({elementFilter:[1]} sameElement(_ >= 2))
    ints contains sameElement(range(_, 2, 5))

In YqlParser "_" resolves to an empty index name on the item, with its type taken from the field of the enclosing sameElement, so a range on a string field is still a string range. Outside sameElement it remains an ordinary field name. The other serializers which require a field name had the same "default" prefix problem and now use the placeholder as well: bool, regexp, range, string range and in. Terms which do have a field-less form still serialize without one: sameElement(2) and sameElement("foo") are unchanged.

Replace the tri-state Boolean deciding how an item writes its field name with a Scope enum of ROOT, FUNCTION_ARGUMENT and SAME_ELEMENT, so the sameElement case is a named constant rather than a null, and the two naming rules live on the enum as optionalIndexName and requiredIndexName. No output changes, except that a UriItem in a sameElement no longer throws NullPointerException on unboxing.
