### PR TITLE
Disable ONNX runtime telemetry to avoid crashing config-model unit tests

### DIFF
--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -310,6 +310,14 @@
           <redirectTestOutputToFile>${test.hide}</redirectTestOutputToFile>
           <environmentVariables>
             <VESPA_HOME>/opt/vespa</VESPA_HOME>
+            <!--
+              This prevents implicit ONNX Posix telemetry initialization from potentially SIGSEGV'ing
+              unit tests during ORT session construction. This telemetry init will run regexes on the
+              command line string, and at least one of these trigger exponential backtracking (on the
+              stack!) in GCC's regex implementation. With a sufficiently large unit test runner command
+              line, this may crash the process.
+             -->
+            <ORT_DISABLE_TELEMETRY>1</ORT_DISABLE_TELEMETRY>
           </environmentVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
@arnej27959 please review. Contender for the "silliest crash reason" award 🙃

ONNX runtime will by default generate platform-specific telemetry when creating an ORT environment. On POSIX platforms this involves chewing through several regular expressions matched against certain strings, such as the process command line. At least one of these regexes will trigger exponential, stack-based backtracking in GCCs regex implementation (this is one of the reasons we use RE2 for all user-facing regex processing in Vespa...).

If the input string is of sufficient size, this can result in recursing beyond the stack limits, segfaulting the entire JVM process.

Setting an `ORT_DISABLE_TELEMETRY=1` env var for all `config-model` unit tests disables the code path that triggers this crash.

This issue was made more joyous to debug by crashes only happening when tests were launched via an IDE, not when launched via the console (presumably the command line etc. differed just enough). And from ONNX runtime by default unpacking `.so` files from its own JAR, which do not have debug symbols available. And from there not being a JVM crash report generated, for some reason.
