### PR TITLE
disallow struct fields with names beginning with "_"

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/IndexFieldNames.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/IndexFieldNames.java
@@ -18,6 +18,13 @@ public class IndexFieldNames extends Processor {
 
     private static final String FIELD_NAME_REGEXP = "[a-zA-Z]\\w*";
 
+    /**
+     * Names beginning with this are reserved for names given a meaning by the query syntax, such as "_",
+     * the name of the value of an element itself in a sameElement query. Top level fields cannot begin with
+     * it by {@link #FIELD_NAME_REGEXP}, which requires a name to begin with a letter.
+     */
+    private static final String RESERVED_NAME_PREFIX = "_";
+
     public IndexFieldNames(Schema schema, DeployLogger deployLogger, RankProfileRegistry rankProfileRegistry, QueryProfiles queryProfiles) {
         super(schema, deployLogger, rankProfileRegistry, queryProfiles);
     }
@@ -30,7 +37,24 @@ public class IndexFieldNames extends Processor {
             if ( ! field.getName().matches(FIELD_NAME_REGEXP) && !field.isInternalField()) {
                 fail(schema, field, " Not a legal field name. Legal expression: " + FIELD_NAME_REGEXP);
             }
+            validateStructFieldNames(field);
         }
+    }
+
+    /** Validates the names of the struct fields of the given field, recursively. */
+    private void validateStructFieldNames(SDField field) {
+        for (SDField structField : field.getStructFields()) {
+            if (leafNameOf(structField).startsWith(RESERVED_NAME_PREFIX) && ! structField.isInternalField()) {
+                fail(schema, structField, " Not a legal field name: starting with '" + RESERVED_NAME_PREFIX + "' is reserved.");
+            }
+            validateStructFieldNames(structField);
+        }
+    }
+
+    /** Returns the name of the given struct field within its struct, as struct fields are named by their path. */
+    private static String leafNameOf(SDField structField) {
+        String name = structField.getName();
+        return name.substring(name.lastIndexOf('.') + 1);
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/schema/processing/IndexFieldNamesTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/IndexFieldNamesTestCase.java
@@ -1,0 +1,130 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.processing;
+
+import com.yahoo.schema.ApplicationBuilder;
+import com.yahoo.schema.parser.ParseException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author arnej
+ */
+public class IndexFieldNamesTestCase {
+
+    private static final String RESERVED_NAME_REASON =
+            " Not a legal field name: starting with '_' is reserved.";
+
+    @Test
+    void testFieldNamesMustStartWithALetter() {
+        assertFails("""
+                    schema s {
+                      document s {
+                        field _ type string {
+                          indexing: index
+                        }
+                      }
+                    }
+                    """,
+                    "For schema 's', field '_':  Not a legal field name. Legal expression: [a-zA-Z]\\w*");
+        assertFails("""
+                    schema s {
+                      document s {
+                        field _foo type string {
+                          indexing: index
+                        }
+                      }
+                    }
+                    """,
+                    "For schema 's', field '_foo':  Not a legal field name. Legal expression: [a-zA-Z]\\w*");
+    }
+
+    @Test
+    void testStructFieldNamesCannotBeginWithAnUnderscore() {
+        // "_" is the name of the value of the element itself inside a sameElement, so a subfield by that
+        // name could not be queried, and the names beginning with it are reserved for the same use.
+        // Top level fields cannot have such a name by the expression above.
+        assertFails("""
+                    schema s {
+                      document s {
+                        struct e {
+                          field _ type string {}
+                        }
+                        field arr type array<e> {
+                          indexing: summary
+                          struct-field _ { indexing: attribute }
+                        }
+                      }
+                    }
+                    """,
+                    "For schema 's', field 'arr._': " + RESERVED_NAME_REASON);
+        assertFails("""
+                    schema s {
+                      document s {
+                        struct e {
+                          field _name type string {}
+                        }
+                        field arr type array<e> {
+                          indexing: summary
+                          struct-field _name { indexing: attribute }
+                        }
+                      }
+                    }
+                    """,
+                    "For schema 's', field 'arr._name': " + RESERVED_NAME_REASON);
+
+        // Also in a struct nested below another one, such as the value of a map
+        assertFails("""
+                    schema s {
+                      document s {
+                        struct e {
+                          field _ type string {}
+                        }
+                        field m type map<string, e> {
+                          indexing: summary
+                          struct-field value._ { indexing: attribute }
+                        }
+                      }
+                    }
+                    """,
+                    "For schema 's', field 'm.value._': " + RESERVED_NAME_REASON);
+    }
+
+    @Test
+    void testLegalFieldNamesAreAccepted() throws ParseException, IOException {
+        // Struct fields with legal names, the implicit key and value fields of a map, and the internal
+        // fields of a position field, are all unaffected
+        ApplicationBuilder.createFromString("""
+                                            schema s {
+                                              document s {
+                                                struct e {
+                                                  field name type string {}
+                                                  field with_underscore type string {}
+                                                }
+                                                field arr type array<e> {
+                                                  indexing: summary
+                                                  struct-field name { indexing: attribute }
+                                                  struct-field with_underscore { indexing: attribute }
+                                                }
+                                                field m type map<string, e> {
+                                                  indexing: summary
+                                                  struct-field key { indexing: attribute }
+                                                }
+                                                field pos type position {
+                                                  indexing: attribute
+                                                }
+                                              }
+                                            }
+                                            """);
+    }
+
+    private void assertFails(String schema, String expectedMessage) {
+        var exception = assertThrows(IllegalArgumentException.class,
+                                     () -> ApplicationBuilder.createFromString(schema));
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+}


### PR DESCRIPTION
Beginning a field name with "_" is reserved.  Top level fields already cannot have such a name, as IndexFieldNames requires a name to begin with a letter, but that check only covers the fields of the document: a struct field was never checked. Walk the struct fields of every field, recursively, as a struct below another one is reachable too: a struct as the value of a map has its fields named "m.value.<name>".

The names Vespa generates itself are suffixed rather than prefixed ("<field>_zcurve", "<field>_literal"), and internal fields are exempt anyway, so nothing generated collides with the reserved prefix.
