### PR TITLE
Stop using the SEND_OLD_QUERY_STACK flag

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
@@ -51,7 +51,6 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains> implements
     private final Collection<String> schemasWithGlobalPhase;
     private final ApplicationPackage app;
     private final boolean useLegacyWandQueryParsing;
-    private final boolean sendOldQueryStack;
 
     private QueryProfiles queryProfiles;
     private SemanticRules semanticRules;
@@ -63,7 +62,6 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains> implements
         this.app = deployState.getApplicationPackage();
         this.owningCluster = cluster;
         this.useLegacyWandQueryParsing = deployState.featureFlags().useLegacyWandQueryParsing();
-        this.sendOldQueryStack = deployState.featureFlags().sendOldQueryStack();
 
         owningCluster.addComponent(Component.fromClassAndBundle(CompiledQueryProfileRegistry.class, SEARCH_AND_DOCPROC_BUNDLE));
         owningCluster.addComponent(Component.fromClassAndBundle(com.yahoo.search.schema.SchemaInfo.class, SEARCH_AND_DOCPROC_BUNDLE));
@@ -179,7 +177,6 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains> implements
                                    .keepSegmentAnds(true)
                                    .keepIdeographicPunctuation(true));
         }
-        builder.sendOldQueryStack(sendOldQueryStack);
     }
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -249,7 +249,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public double clusterControllerNodeMemory() { return flag(PermanentFlags.CLUSTER_CONTROLLER_NODE_MEMORY).value(); }
         @Override public boolean useLegacyWandQueryParsing() { return flag(Flags.USE_LEGACY_WAND_QUERY_PARSING).value(); }
         @Override public boolean useSimpleAnnotations() { return flag(Flags.USE_SIMPLE_ANNOTATIONS).value(); }
-        @Override public boolean sendOldQueryStack() { return flag(Flags.SEND_OLD_QUERY_STACK).value(); }
+        @Override public boolean sendOldQueryStack() { return false; }
         @Override public boolean forwardAllLogLevels() { return flag(PermanentFlags.FORWARD_ALL_LOG_LEVELS).value(); }
         @Override public long zookeeperPreAllocSize() { return flag(PermanentFlags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB).value(); }
         @Override public int maxContentNodeMaintenanceOpConcurrency() { return flag(PermanentFlags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY).value(); }

--- a/container-search/src/main/java/com/yahoo/prelude/query/NearItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/NearItem.java
@@ -79,7 +79,7 @@ public class NearItem extends CompositeItem {
     protected void encodeThis(ByteBuffer buffer, SerializationContext context) {
         super.encodeThis(buffer, context);
         IntegerCompressor.putCompressedPositiveNumber(distance, buffer);
-        if (numNegativeItems != 0 && !ProtobufSerialization.isProtobufAlsoSerialized()) {
+        if (numNegativeItems != 0) {
             throw new IllegalArgumentException("cannot serialize negative items in old protocol");
         }
     }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
@@ -24,7 +24,6 @@ import com.yahoo.search.dispatch.LeanHit;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.grouping.vespa.GroupingExecutor;
 import com.yahoo.search.query.Model;
-import com.yahoo.search.query.QueryTree;
 import com.yahoo.search.query.Ranking;
 import com.yahoo.search.query.Sorting;
 import com.yahoo.search.query.Sorting.Order;
@@ -36,32 +35,12 @@ import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.slime.BinaryFormat;
 import com.yahoo.vespa.objects.BufferSerializer;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
 public class ProtobufSerialization {
-
-    /**
-     * Returns true if protobuf query tree serialization is being performed in addition to the old format.
-     * During the transition period, this allows old format serialization to skip exceptions for features
-     * that are only supported in the protobuf format, since the backend will use the protobuf format when
-     * both are present.
-     */
-    public static boolean isProtobufAlsoSerialized() {
-        return isProtobufAlsoSerialized.get();
-    }
-
-    /**
-     * Sets whether protobuf query tree serialization is being performed in addition to the old format.
-     * This is used during the transition period to suppress exceptions in old format encoding for features
-     * only supported in protobuf, since the backend will prefer the protobuf format when both are present.
-     */
-    public static void setProtobufAlsoSerialized(boolean value) {
-        isProtobufAlsoSerialized.set(value);
-    }
 
     /*
      * This is a thread local buffer that is used as scratchpad during serialization.
@@ -71,14 +50,6 @@ public class ProtobufSerialization {
      * There is a limited number of threads that will use this so the upper bound should be fine.
      */
     private static final ThreadLocal<GrowableByteBuffer> threadLocalBuffer = ThreadLocal.withInitial(() -> new GrowableByteBuffer(4096));
-
-    /*
-     * Tracks whether protobuf query tree serialization is being performed in addition to the old format.
-     * Used during the transition period to allow old format serialization to skip exceptions for
-     * features that are only supported in the protobuf format, since the backend will use the
-     * protobuf format when both are present.
-     */
-    private static final ThreadLocal<Boolean> isProtobufAlsoSerialized = ThreadLocal.withInitial(() -> false);
 
     static byte[] serializeSearchRequest(Query query, int hits, String nodeId, double contentShare, double requestTimeout, QrSearchersConfig qrSearchersConfig) {
         return convertFromQuery(query, hits, nodeId, contentShare, requestTimeout, qrSearchersConfig).toByteArray();
@@ -103,10 +74,6 @@ public class ProtobufSerialization {
         GrowableByteBuffer scratchPad = threadLocalBuffer.get();
         var queryTree = query.getModel().getQueryTree();
         var context = new SerializationContext(contentShare);
-        if (qrSearchersConfig.sendOldQueryStack()) {
-            isProtobufAlsoSerialized.set(true);
-            builder.setQueryTreeBlob(serializeQueryTree(queryTree, context, scratchPad));
-        }
         builder.setQueryTree(queryTree.toProtobufQueryTree(context));
         if (query.getGroupingSessionCache() || query.getRanking().getQueryCache()) {
             // TODO verify that the session key is included whenever rank properties would have been
@@ -258,10 +225,6 @@ public class ProtobufSerialization {
         var featureMap = ranking.getFeatures().asMap();
 
         var context = SerializationContext.ignored(); // Not necessary to track content share for docsum requests
-        if (qrSearchersConfig.sendOldQueryStack()) {
-            isProtobufAlsoSerialized.set(true);
-            builder.setQueryTreeBlob(serializeQueryTree(query.getModel().getQueryTree(), context, scratchPad));
-        }
         builder.setQueryTree(query.getModel().getQueryTree().toProtobufQueryTree(context));
 
         MapConverter.convertMapPrimitives(featureMap, builder::addFeatureOverrides);
@@ -378,21 +341,6 @@ public class ProtobufSerialization {
             builder.addHits(hitBuilder);
         });
         return builder.build();
-    }
-
-    private static ByteString serializeQueryTree(QueryTree queryTree, SerializationContext context,
-                                                 GrowableByteBuffer scratchPad) {
-        while (true) {
-            try {
-                scratchPad.clear();
-                ByteBuffer treeBuffer = scratchPad.getByteBuffer();
-                queryTree.encode(treeBuffer, context);
-                return ByteString.copyFrom(treeBuffer.flip());
-            } catch (java.nio.BufferOverflowException e) {
-                scratchPad.clear();
-                scratchPad.grow(scratchPad.capacity()*2);
-            }
-        }
     }
 
     private static void mergeRankProperties(Ranking ranking,

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingBackend.java
@@ -134,11 +134,6 @@ public class StreamingBackend extends VespaBackend {
                 : query.getTrace().getLevel();
     }
 
-    private boolean sendOldQueryStack() {
-        var config = clusterParams.getQrSearchersConfig();
-        return config != null && config.sendOldQueryStack();
-    }
-
     @Override
     public Result doSearch2(String schema, Query query) {
         if (query.getTimeLeft() <= 0)
@@ -166,7 +161,7 @@ public class StreamingBackend extends VespaBackend {
             partialSummaryHandler.wantToFill(query);
         }
         var visitorContext = new Visitor.Context(getSearchClusterName(), schema, effectiveTraceLevel,
-                                                 sendOldQueryStack(), partialSummaryHandler);
+                                                 partialSummaryHandler);
         Visitor visitor = visitorFactory.createVisitor(query, route, visitorContext);
         try {
             visitor.doSearch();

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingVisitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/StreamingVisitor.java
@@ -19,7 +19,6 @@ import com.yahoo.prelude.fastsearch.TimeoutException;
 import com.yahoo.prelude.query.SerializationContext;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
-import com.yahoo.search.dispatch.rpc.ProtobufSerialization;
 import com.yahoo.search.grouping.vespa.GroupingExecutor;
 import com.yahoo.search.query.Model;
 import com.yahoo.search.query.Ranking;
@@ -148,16 +147,9 @@ class StreamingVisitor extends VisitorDataHandler implements Visitor {
         }
 
         EncodedData ed = new EncodedData();
-        if (context.sendOldQueryStack()) {
-            ProtobufSerialization.setProtobufAlsoSerialized(true);
-            encodeQueryData(query, 0, ed);
-            params.setLibraryParameter("query", ed.getEncodedData());
-            params.setLibraryParameter("querystackcount", String.valueOf(ed.getReturned()));
-        } else {
-            // TODO: remove dummies - it's for backwards compatibility only
-            params.setLibraryParameter("query", new byte[]{(byte) 0});
-            params.setLibraryParameter("querystackcount", "1");
-        }
+        // TODO: remove dummies - it's for backwards compatibility only
+        params.setLibraryParameter("query", new byte[]{(byte) 0});
+        params.setLibraryParameter("querystackcount", "1");
         var serializationContext = SerializationContext.ignored(); // Not tracking content share in streaming
         var protobufTree = query.getModel().getQueryTree().toProtobufQueryTree(serializationContext);
         params.setLibraryParameter("querytree", protobufTree.toByteArray());

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/Visitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/Visitor.java
@@ -24,13 +24,12 @@ interface Visitor {
     record Context(String searchCluster,
                    String schema,
                    int traceLevelOverride,
-                   boolean sendOldQueryStack,
                    PartialSummaryHandler partialSummaryHandler) {
         Context(String searchCluster, String schema) {
             this(searchCluster, schema, 0);
         }
         Context(String searchCluster, String schema, int traceLevelOverride) {
-            this(searchCluster, schema, traceLevelOverride, false, null);
+            this(searchCluster, schema, traceLevelOverride, null);
         }
     }
 


### PR DESCRIPTION
The old, non-protobuf query stack serialization was only a fallback sent alongside the protobuf query tree in case a receiving node was running an older Vespa version that could not decode protobuf query trees. All supported nodes now always understand the protobuf format, so this dual-write can be dropped: queries are now always sent as protobuf only, avoiding the extra encoding work and payload.

Also removes the query-tree encoding helper, the "ProtobufAlsoSerialized" mechanism, and imports that were only used by the dropped fallback path. The flag itself and its config field are left in place for now, hardcoded to disabled.
