### PR TITLE
config-provisioning: Ensure backwards compatibility of ClusterMembership [MERGEOK]

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -78,7 +78,9 @@ public class ClusterMembership {
                                           int group,
                                           int index,
                                           boolean retired) {
-        return type.name() + "/" + id.value() + "/" + group + "/" + index + ( retired ? "/retired" : "");
+        return type.name() + "/" + id.value() + "/" + group + "/" + index +
+               ( retired ? "/retired" : "") +
+               ( type.isContent() ? "/stateful" : "");
     }
 
     /** Returns the type of the cluster this belongs to. */

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
@@ -89,7 +89,7 @@ public class ClusterMembershipTest {
                                          .profile("large-storage")
                                          .build();
         ClusterMembership membership = ClusterMembership.from(cluster, 37);
-        assertEquals("content/id1/0/37", membership.stringValue());
+        assertEquals("content/id1/0/37/stateful", membership.stringValue());
     }
 
     @Test
@@ -131,7 +131,7 @@ public class ClusterMembershipTest {
         assertEquals(0, instance.group());
         assertEquals(37, instance.index());
         assertFalse(instance.retired());
-        assertEquals("content/id1/0/37", instance.stringValue());
+        assertEquals("content/id1/0/37/stateful", instance.stringValue());
     }
 
     private void assertContentServiceWithGroup(ClusterMembership instance) {
@@ -140,7 +140,7 @@ public class ClusterMembershipTest {
         assertEquals(4, instance.group());
         assertEquals(37, instance.index());
         assertFalse(instance.retired());
-        assertEquals("content/id1/4/37", instance.stringValue());
+        assertEquals("content/id1/4/37/stateful", instance.stringValue());
     }
 
     /** Serializing a spec without a group assigned works, but not deserialization */
@@ -149,7 +149,7 @@ public class ClusterMembershipTest {
         assertEquals("id1", instance.id().value());
         assertEquals(37, instance.index());
         assertTrue(instance.retired());
-        assertEquals("content/id1/0/37/retired", instance.stringValue());
+        assertEquals("content/id1/0/37/retired/stateful", instance.stringValue());
         // Legacy form:
         assertEquals(instance, ClusterMembership.from("content/id1/37/retired"));
     }
@@ -160,7 +160,7 @@ public class ClusterMembershipTest {
         assertEquals(4, instance.group());
         assertEquals(37, instance.index());
         assertTrue(instance.retired());
-        assertEquals("content/id1/4/37/retired", instance.stringValue());
+        assertEquals("content/id1/4/37/retired/stateful", instance.stringValue());
     }
 
 }


### PR DESCRIPTION
Upgrade of ConfigServers on k8s failed due to:

```
java.lang.IllegalArgumentException: Cluster of type content must be stateful
	at com.yahoo.config.provision.ClusterSpec.<init>(ClusterSpec.java:45)
	at com.yahoo.config.provision.ClusterSpec$Builder.build(ClusterSpec.java:167)
	at com.yahoo.config.provision.ClusterMembership.<init>(ClusterMembership.java:73)
	at com.yahoo.config.provision.ClusterMembership.from(ClusterMembership.java:189)
	at com.yahoo.vespa.hosted.provision.persistence.NodeSerializer.clusterMembershipFromSlime(NodeSerializer.java:454)
	at com.yahoo.vespa.hosted.provision.persistence.NodeSerializer.allocationFromSlime(NodeSerializer.java:408)
	at com.yahoo.vespa.hosted.provision.persistence.NodeSerializer.nodeFromSlime(NodeSerializer.java:355)
	at com.yahoo.vespa.hosted.provision.persistence.NodeSerializer.fromJson(NodeSerializer.java:341)
	at java.base/java.util.Optional.map(Optional.java:260)
	at com.yahoo.vespa.hosted.provision.persistence.CuratorDb.lambda$readNode$8(CuratorDb.java:292)
	at java.base/java.util.Optional.map(Optional.java:260)
	at com.yahoo.vespa.hosted.provision.persistence.CuratorDb.readNode(CuratorDb.java:288)
	at com.yahoo.vespa.hosted.provision.persistence.CuratorDb.lambda$readNodes$6(CuratorDb.java:281)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at com.yahoo.vespa.hosted.provision.persistence.CuratorDb.readNodes(CuratorDb.java:282)
	at com.yahoo.vespa.hosted.provision.node.Nodes.list(Nodes.java:135)
	at com.yahoo.vespa.hosted.provision.maintenance.Expirer.getExpiredNodes(Expirer.java:55)
	at com.yahoo.vespa.hosted.provision.maintenance.Expirer.maintain(Expirer.java:43)
	at com.yahoo.concurrent.maintenance.Maintainer.doMaintain(Maintainer.java:89)
	at com.yahoo.concurrent.maintenance.Maintainer.run(Maintainer.java:144)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at 
```

This seems to be due to a backwards compatibility issue in `ClusterMembership`, hopefully this is the root cause.