### PR TITLE
Revert "config-provisioning: Ensure backwards compatibility of ClusterMembership [MERGEOK]"

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -78,9 +78,7 @@ public class ClusterMembership {
                                           int group,
                                           int index,
                                           boolean retired) {
-        return type.name() + "/" + id.value() + "/" + group + "/" + index +
-               ( retired ? "/retired" : "") +
-               ( type.isContent() ? "/stateful" : "");
+        return type.name() + "/" + id.value() + "/" + group + "/" + index + ( retired ? "/retired" : "");
     }
 
     /** Returns the type of the cluster this belongs to. */

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
@@ -89,7 +89,7 @@ public class ClusterMembershipTest {
                                          .profile("large-storage")
                                          .build();
         ClusterMembership membership = ClusterMembership.from(cluster, 37);
-        assertEquals("content/id1/0/37/stateful", membership.stringValue());
+        assertEquals("content/id1/0/37", membership.stringValue());
     }
 
     @Test
@@ -131,7 +131,7 @@ public class ClusterMembershipTest {
         assertEquals(0, instance.group());
         assertEquals(37, instance.index());
         assertFalse(instance.retired());
-        assertEquals("content/id1/0/37/stateful", instance.stringValue());
+        assertEquals("content/id1/0/37", instance.stringValue());
     }
 
     private void assertContentServiceWithGroup(ClusterMembership instance) {
@@ -140,7 +140,7 @@ public class ClusterMembershipTest {
         assertEquals(4, instance.group());
         assertEquals(37, instance.index());
         assertFalse(instance.retired());
-        assertEquals("content/id1/4/37/stateful", instance.stringValue());
+        assertEquals("content/id1/4/37", instance.stringValue());
     }
 
     /** Serializing a spec without a group assigned works, but not deserialization */
@@ -149,7 +149,7 @@ public class ClusterMembershipTest {
         assertEquals("id1", instance.id().value());
         assertEquals(37, instance.index());
         assertTrue(instance.retired());
-        assertEquals("content/id1/0/37/retired/stateful", instance.stringValue());
+        assertEquals("content/id1/0/37/retired", instance.stringValue());
         // Legacy form:
         assertEquals(instance, ClusterMembership.from("content/id1/37/retired"));
     }
@@ -160,7 +160,7 @@ public class ClusterMembershipTest {
         assertEquals(4, instance.group());
         assertEquals(37, instance.index());
         assertTrue(instance.retired());
-        assertEquals("content/id1/4/37/retired/stateful", instance.stringValue());
+        assertEquals("content/id1/4/37/retired", instance.stringValue());
     }
 
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#37791

Broke all builds.

Looking a bit more into it seems node repo is broken if this revert goes in as well, so probably need to fix tests instead