### PR TITLE
Always set cluster spec on ApplicationContainerCluster

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -1050,6 +1050,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
     private void addStandaloneNode(ApplicationContainerCluster cluster, DeployState deployState) {
         ApplicationContainer container = new ApplicationContainer(cluster, "standalone", cluster.getContainers().size(), deployState);
+        cluster.setSpec(defaultSpec(cluster, deployState));
         cluster.addContainers(List.of(container));
     }
 
@@ -1238,6 +1239,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     }
 
     private List<ApplicationContainer> singleHostContainerCluster(ApplicationContainerCluster cluster, HostResource host, ConfigModelContext context) {
+        cluster.setSpec(defaultSpec(cluster, context.getDeployState()));
         ApplicationContainer node = new ApplicationContainer(cluster, "container.0", 0, context.getDeployState());
         node.setHostResource(host);
         node.initService(context.getDeployState());
@@ -1315,8 +1317,13 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             nodes.add(new ContainerServiceBuilder("container." + nodeIndex, nodeIndex).build(deployState, cluster, nodeElem));
             nodeIndex++;
         }
-        cluster.setSpec(ClusterSpec.request(ClusterSpec.Type.container, cluster.id()).vespaVersion(deployState.getVespaVersion()).build());
+        cluster.setSpec(defaultSpec(cluster, deployState));
         return nodes;
+    }
+
+    /** The cluster spec to use for clusters which are not allocated from a node repository. */
+    private static ClusterSpec defaultSpec(ApplicationContainerCluster cluster, DeployState deployState) {
+        return ClusterSpec.request(ClusterSpec.Type.container, cluster.id()).vespaVersion(deployState.getVespaVersion()).build();
     }
 
     private static boolean useCpuSocketAffinity(Element nodesElement) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForSidecarValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForSidecarValidatorTest.java
@@ -44,6 +44,15 @@ public class RestartOnDeployForSidecarValidatorTest {
         </services>
         """;
 
+    private static final String SELF_HOSTED_SERVICES_XML = """
+        <?xml version='1.0' encoding='utf-8' ?>
+        <services version='1.0'>
+          <container id='feed' version='1.0'>
+            <document-api/>
+          </container>
+        </services>
+        """;
+
     private static final SidecarSpec SIDECAR_1 = SidecarSpec.builder()
             .id(0)
             .name("triton")
@@ -129,6 +138,13 @@ public class RestartOnDeployForSidecarValidatorTest {
         assertRestartActionProperties(
                 result.get(0),
                 "Need to restart services in cluster 'feed' due to removed sidecars: 'triton'");
+    }
+
+    @Test
+    void validate_self_hosted_cluster_without_nodes_tag() {
+        var current = new VespaModelCreatorWithMockPkg(null, SELF_HOSTED_SERVICES_XML).create();
+        var next = new VespaModelCreatorWithMockPkg(null, SELF_HOSTED_SERVICES_XML).create();
+        assertEquals(List.of(), validate(current, next));
     }
 
     private List<ConfigChangeAction> validate(VespaModel current, VespaModel next) {


### PR DESCRIPTION
The spec was never set for self-hosted clusters without a nodes tag, nor for standalone clusters, so getSpec() returned null. This caused an NPE in RestartOnDeployForSidecarValidator after the null-tolerant workaround was removed.
