### PR TITLE
Add string-range support to streaming search

### DIFF
--- a/searchlib/src/tests/query/streaming/query_builder_test.cpp
+++ b/searchlib/src/tests/query/streaming/query_builder_test.cpp
@@ -105,3 +105,38 @@ TEST(StreamingQueryBuilderTest, onear_with_negative_terms) {
     EXPECT_FALSE(terms[1]->isRanked()); // "x" is NOT ranked (negative term)
     EXPECT_FALSE(terms[2]->isRanked()); // "y" is NOT ranked (negative term)
 }
+
+TEST(StreamingQueryBuilderTest, string_range_term_is_constructed) {
+    QueryBuilder<SimpleQueryNodeTypes> builder;
+
+    auto spec = std::make_unique<search::StringRangeSpec>("aaa", true, false, "zzz", false, false, 100);
+    builder.add_string_range_term(search::query::StringRange(std::move(spec)), "", 42, Weight(24));
+    auto node = builder.build();
+
+    // Convert to protobuf
+    search::query::QueryToProtobuf converter;
+    auto                           protoQueryTree = converter.serialize(*node);
+
+    // Build streaming query from protobuf
+    auto serializedQueryTree =
+        SerializedQueryTree::fromProtobuf(std::make_unique<decltype(protoQueryTree)>(protoQueryTree));
+    QueryNodeResultFactory empty;
+    Query                  q(empty, *serializedQueryTree);
+
+    // Verify the term is a ranked string-range term
+    auto& string_range_term = dynamic_cast<search::streaming::QueryTerm&>(q.getRoot());
+    EXPECT_TRUE(string_range_term.is_string_range());
+    EXPECT_TRUE(string_range_term.isRanked());
+    EXPECT_EQ(42, string_range_term.uniqueId());
+    EXPECT_EQ(Weight(24), string_range_term.weight());
+
+    // Verify the string-range specs
+    auto term_spec = string_range_term.get_string_range_spec();
+    ASSERT_TRUE(term_spec);
+    EXPECT_EQ("aaa", term_spec->left);
+    EXPECT_TRUE(term_spec->left_closed);
+    EXPECT_FALSE(term_spec->left_unbounded);
+    EXPECT_EQ("zzz", term_spec->right);
+    EXPECT_FALSE(term_spec->right_closed);
+    EXPECT_FALSE(term_spec->right_unbounded);
+}

--- a/searchlib/src/vespa/searchlib/parsequery/parse.h
+++ b/searchlib/src/vespa/searchlib/parsequery/parse.h
@@ -132,6 +132,8 @@ public:
             return TermType::SUFFIXTERM;
         case ParseItem::ITEM_FUZZY:
             return TermType::FUZZYTERM;
+        case ParseItem::ITEM_STRING_RANGE_TERM:
+            return TermType::STRING_RANGE;
         case ParseItem::ITEM_GEO_LOCATION_TERM:
             return TermType::GEO_LOCATION;
         case ParseItem::ITEM_NEAREST_NEIGHBOR:

--- a/searchlib/src/vespa/searchlib/query/query_normalization.h
+++ b/searchlib/src/vespa/searchlib/query/query_normalization.h
@@ -18,7 +18,8 @@ enum class TermType : uint8_t {
     REGEXP = 5,
     GEO_LOCATION = 6,
     FUZZYTERM = 7,
-    NEAREST_NEIGHBOR = 8
+    NEAREST_NEIGHBOR = 8,
+    STRING_RANGE = 9
 };
 
 std::ostream& operator<<(std::ostream&, Normalizing);

--- a/searchlib/src/vespa/searchlib/query/query_term_simple.h
+++ b/searchlib/src/vespa/searchlib/query/query_term_simple.h
@@ -66,6 +66,7 @@ public:
     bool isGeoLoc() const noexcept { return (_type == Type::GEO_LOCATION); }
     bool isFuzzy() const noexcept { return (_type == Type::FUZZYTERM); }
     bool is_nearest_neighbor() const noexcept { return (_type == Type::NEAREST_NEIGHBOR); }
+    bool is_string_range() const noexcept { return (_type == Type::STRING_RANGE); }
     bool empty() const noexcept { return _term.empty(); }
     virtual void visitMembers(vespalib::ObjectVisitor& visitor) const;
     string getClassName() const;

--- a/searchlib/src/vespa/searchlib/query/streaming/query_builder.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/query_builder.cpp
@@ -160,7 +160,8 @@ std::unique_ptr<QueryNode> QueryBuilder::build(const QueryNode* parent, const Qu
     case ParseItem::ITEM_SUFFIXTERM:
     case ParseItem::ITEM_PURE_WEIGHTED_STRING:
     case ParseItem::ITEM_PURE_WEIGHTED_LONG:
-    case ParseItem::ITEM_FUZZY: {
+    case ParseItem::ITEM_FUZZY:
+    case ParseItem::ITEM_STRING_RANGE_TERM: {
         std::string index(queryRep.index_as_view());
         if (index.empty() &&
             ((type == ParseItem::ITEM_PURE_WEIGHTED_STRING) || (type == ParseItem::ITEM_PURE_WEIGHTED_LONG)) &&
@@ -195,6 +196,9 @@ std::unique_ptr<QueryNode> QueryBuilder::build(const QueryNode* parent, const Qu
                                                  normalize_mode, queryRep.fuzzy_max_edit_distance(),
                                                  queryRep.fuzzy_prefix_lock_length(),
                                                  queryRep.has_prefix_match_semantics());
+            } else if (sTerm == TermType::STRING_RANGE) {
+                qt = std::make_unique<QueryTerm>(factory.create(), ssIndex, TermType::STRING_RANGE,
+                                                 queryRep.get_string_range_spec());
             } else [[likely]] {
                 qt = std::make_unique<QueryTerm>(factory.create(), ssTerm, ssIndex, sTerm, normalize_mode);
             }
@@ -262,10 +266,6 @@ std::unique_ptr<QueryNode> QueryBuilder::build(const QueryNode* parent, const Qu
         break;
     case ParseItem::ITEM_SAME_ELEMENT:
         qn = build_same_element_term(factory, queryRep);
-        break;
-    case ParseItem::ITEM_STRING_RANGE_TERM:
-        // Lexical ranges are only implemented for attribute vectors, i.e. for indexed search.
-        vespalib::Issue::report("string range terms are not supported in streaming search");
         break;
     default:
         skip_unknown(queryRep);

--- a/searchlib/src/vespa/searchlib/query/streaming/query_builder.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/query_builder.h
@@ -35,6 +35,8 @@ class QueryBuilder {
                                                 bool allow_rewrite);
     std::unique_ptr<QueryNode> build_same_element_term(const QueryNodeResultFactory& factory,
                                                        QueryStackIterator&           queryRep);
+    std::unique_ptr<QueryNode> build_string_range_term(const QueryNodeResultFactory& factory,
+                                                       QueryStackIterator&           queryRep);
     std::unique_ptr<QueryNode> build_and_not(const QueryNodeResultFactory& factory, QueryStackIterator& queryRep);
     static void skip_unknown(QueryStackIterator& queryRep);
 

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
@@ -96,6 +96,20 @@ QueryTerm::QueryTerm(Type type, string index, std::unique_ptr<StringRangeSpec> s
       _fieldInfo() {
 }
 
+QueryTerm::QueryTerm(std::unique_ptr<QueryNodeResultBase> org, string index, Type type,
+                     std::unique_ptr<StringRangeSpec> range_spec)
+    : QueryTermUCS4(type, std::move(range_spec)),
+      _hitList(),
+      _index(std::move(index)),
+      _result(org.release()),
+      _encoding(0x01),
+      _isRanked(true),
+      _filter(false),
+      _weight(100),
+      _uniqueId(0),
+      _fieldInfo() {
+}
+
 QueryTerm::QueryTerm(std::unique_ptr<QueryNodeResultBase> org, string_view termS, string indexS, Type type,
                      Normalizing normalizing)
     : QueryTermUCS4(QueryNormalization::optional_fold(termS, type, normalizing), type),

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
@@ -75,6 +75,8 @@ public:
                     (type == Type::EXACTSTRINGTERM) ? Normalizing::LOWERCASE : Normalizing::LOWERCASE_AND_FOLD) {}
     QueryTerm(Type type, string index, std::unique_ptr<NumericRangeSpec> range);
     QueryTerm(Type type, string index, std::unique_ptr<StringRangeSpec> range);
+    QueryTerm(std::unique_ptr<QueryNodeResultBase> resultBase, string index, Type type,
+              std::unique_ptr<StringRangeSpec> range);
     QueryTerm(std::unique_ptr<QueryNodeResultBase> resultBase, string_view term, string index, Type type,
               Normalizing normalizing);
     QueryTerm(const QueryTerm&) = delete;

--- a/streamingvisitors/src/tests/searcher/searcher_test.cpp
+++ b/streamingvisitors/src/tests/searcher/searcher_test.cpp
@@ -113,6 +113,35 @@ std::tuple<uint8_t, uint32_t, bool, std::string_view> parse_fuzzy_params(std::st
     return {max_edits, prefix_length, prefix_match, term.substr(1)};
 }
 
+// "Parse" StringRangeSpec from string, only for testing
+// Format: left;closed;unbounded;right;closed;unbounded
+// Example: foo;true,false;bar;true;false
+// Assumption: Input is well-formed and neither left nor right contain a semicolon
+std::unique_ptr<search::StringRangeSpec> parse_string_range_params(std::string_view term) {
+    std::unique_ptr<search::StringRangeSpec> spec = std::make_unique<search::StringRangeSpec>();
+    std::string                              s(term);
+
+    spec->left = s.substr(0, s.find(';'));
+    s.erase(0, s.find(';') + 1);
+
+    spec->left_closed = (s.substr(0, s.find(';')) == "true");
+    s.erase(0, s.find(';') + 1);
+
+    spec->left_unbounded = (s.substr(0, s.find(';')) == "true");
+    s.erase(0, s.find(';') + 1);
+
+    spec->right = s.substr(0, s.find(';'));
+    s.erase(0, s.find(';') + 1);
+
+    spec->right_closed = (s.substr(0, s.find(';')) == "true");
+    s.erase(0, s.find(';') + 1);
+
+    spec->right_unbounded = (s.substr(0, s.find(';')) == "true");
+    s.erase(0, s.find(';') + 1);
+
+    return spec;
+}
+
 } // namespace
 
 class Query {
@@ -130,6 +159,9 @@ private:
                 qtv.push_back(std::make_unique<FuzzyTerm>(
                     eqnr.create(), std::string_view(actual_term.data(), actual_term.size()), effective_index,
                     TermType::FUZZYTERM, normalizing, max_edits, prefix_lock_length, prefix_match));
+            } else if (pt.second == TermType::STRING_RANGE) {
+                qtv.push_back(std::make_unique<QueryTerm>(eqnr.create(), effective_index, TermType::STRING_RANGE,
+                                                          parse_string_range_params(pt.first)));
             } else {
                 qtv.push_back(
                     std::make_unique<QueryTerm>(eqnr.create(), pt.first, effective_index, pt.second, normalizing));
@@ -168,6 +200,8 @@ public:
             return std::make_pair(term.substr(1), TermType::REGEXP);
         } else if (term[0] == '%') { // equally magic fuzzy enabler
             return std::make_pair(term.substr(1), TermType::FUZZYTERM);
+        } else if (term[0] == '~') { // equally magic string range
+            return std::make_pair(term.substr(1), TermType::STRING_RANGE);
         } else if (term[term.size() - 1] == '*') {
             return std::make_pair(term.substr(0, term.size() - 1), TermType::PREFIXTERM);
         } else {
@@ -857,6 +891,96 @@ TEST(SearcherTest, utf8_flexible_searcher_supports_fuzzy_prefix_matching_combine
     EXPECT_EQ(is_hit, search_string(fs, "%{p1,4}zoidber", "zoidburger"));
     EXPECT_EQ(no_hits, search_string(fs, "%{p1,4}zoidber", "zoidbananas"));
     EXPECT_EQ(is_hit, search_string(fs, "%{p2,4}zoidber", "zoidbananas"));
+}
+
+namespace {
+
+void verify_ranges(UTF8FlexibleStringFieldSearcher& fs) {
+    // Note: the ~ term prefix is a magic term-as-regex symbol used only for tests in this file
+    std::string closed_range("~09;true;false;0B;true;false");
+    EXPECT_EQ(no_hits, search_string(fs, closed_range, "08"));
+    EXPECT_EQ(is_hit, search_string(fs, closed_range, "09"));
+    EXPECT_EQ(is_hit, search_string(fs, closed_range, "0A"));
+    EXPECT_EQ(is_hit, search_string(fs, closed_range, "0B"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range, "0C"));
+
+    std::string left_open_range("~09;false;false;0B;true;false");
+    EXPECT_EQ(no_hits, search_string(fs, left_open_range, "08"));
+    EXPECT_EQ(no_hits, search_string(fs, left_open_range, "09"));
+    EXPECT_EQ(is_hit, search_string(fs, left_open_range, "0A"));
+    EXPECT_EQ(is_hit, search_string(fs, left_open_range, "0B"));
+    EXPECT_EQ(no_hits, search_string(fs, left_open_range, "0C"));
+
+    std::string right_open_range("~09;true;false;0B;false;false");
+    EXPECT_EQ(no_hits, search_string(fs, right_open_range, "08"));
+    EXPECT_EQ(is_hit, search_string(fs, right_open_range, "09"));
+    EXPECT_EQ(is_hit, search_string(fs, right_open_range, "0A"));
+    EXPECT_EQ(no_hits, search_string(fs, right_open_range, "0B"));
+    EXPECT_EQ(no_hits, search_string(fs, right_open_range, "0C"));
+
+    std::string open_range("~09;false;false;0B;false;false");
+    EXPECT_EQ(no_hits, search_string(fs, open_range, "08"));
+    EXPECT_EQ(no_hits, search_string(fs, open_range, "09"));
+    EXPECT_EQ(is_hit, search_string(fs, open_range, "0A"));
+    EXPECT_EQ(no_hits, search_string(fs, open_range, "0B"));
+    EXPECT_EQ(no_hits, search_string(fs, open_range, "0C"));
+
+    std::string left_unbounded_range("~;false;true;0B;true;false");
+    EXPECT_EQ(is_hit, search_string(fs, left_unbounded_range, "08"));
+    EXPECT_EQ(is_hit, search_string(fs, left_unbounded_range, "09"));
+    EXPECT_EQ(is_hit, search_string(fs, left_unbounded_range, "0A"));
+    EXPECT_EQ(is_hit, search_string(fs, left_unbounded_range, "0B"));
+    EXPECT_EQ(no_hits, search_string(fs, left_unbounded_range, "0C"));
+
+    std::string right_unbounded_range("~09;true;false;;false;true");
+    EXPECT_EQ(no_hits, search_string(fs, right_unbounded_range, "08"));
+    EXPECT_EQ(is_hit, search_string(fs, right_unbounded_range, "09"));
+    EXPECT_EQ(is_hit, search_string(fs, right_unbounded_range, "0A"));
+    EXPECT_EQ(is_hit, search_string(fs, right_unbounded_range, "0B"));
+    EXPECT_EQ(is_hit, search_string(fs, right_unbounded_range, "0C"));
+}
+
+} // namespace
+
+TEST(SearcherTest, utf8_flexible_searcher_handles_string_ranges_and_by_default_is_case_insensitive) {
+    UTF8FlexibleStringFieldSearcher fs(0);
+    verify_ranges(fs);
+
+    // Verify that matching is case insensitive
+    std::string closed_range("~0B;true;false;0D;true;false");
+    EXPECT_EQ(no_hits, search_string(fs, closed_range, "0a"));
+    EXPECT_EQ(is_hit, search_string(fs, closed_range, "0b"));
+    EXPECT_EQ(is_hit, search_string(fs, closed_range, "0c"));
+    EXPECT_EQ(is_hit, search_string(fs, closed_range, "0d"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range, "0e"));
+
+    std::string closed_range_lowercase("~0b;true;false;0d;true;false");
+    EXPECT_EQ(no_hits, search_string(fs, closed_range_lowercase, "0A"));
+    EXPECT_EQ(is_hit, search_string(fs, closed_range_lowercase, "0B"));
+    EXPECT_EQ(is_hit, search_string(fs, closed_range_lowercase, "0C"));
+    EXPECT_EQ(is_hit, search_string(fs, closed_range_lowercase, "0D"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range_lowercase, "0E"));
+}
+
+TEST(SearcherTest, utf8_flexible_searcher_handles_case_sensitive_string_range_matching) {
+    UTF8FlexibleStringFieldSearcher fs(0);
+    fs.normalize_mode(Normalizing::NONE);
+    verify_ranges(fs);
+
+    // Verify that matching is case sensitive
+    std::string closed_range("~0B;true;false;0D;true;false");
+    EXPECT_EQ(no_hits, search_string(fs, closed_range, "0a"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range, "0b"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range, "0c"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range, "0d"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range, "0e"));
+
+    std::string closed_range_lowercase("~0b;true;false;0d;true;false");
+    EXPECT_EQ(no_hits, search_string(fs, closed_range_lowercase, "0A"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range_lowercase, "0B"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range_lowercase, "0C"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range_lowercase, "0D"));
+    EXPECT_EQ(no_hits, search_string(fs, closed_range_lowercase, "0E"));
 }
 
 TEST(SearcherTest, bool_search) {

--- a/streamingvisitors/src/vespa/vsm/searcher/strchrfieldsearcher.cpp
+++ b/streamingvisitors/src/vespa/vsm/searcher/strchrfieldsearcher.cpp
@@ -50,7 +50,7 @@ size_t StrChrFieldSearcher::shortestTerm() const {
     size_t mintsz(_qtl.front()->termLen());
     for (auto it = _qtl.begin() + 1, mt = _qtl.end(); it != mt; it++) {
         const QueryTerm& qt = **it;
-        if (qt.isRegex() || qt.isFuzzy()) {
+        if (qt.isRegex() || qt.isFuzzy() || qt.is_string_range()) {
             return 0; // Must avoid "too short query term" optimization when using regex or fuzzy
         }
         mintsz = std::min(mintsz, qt.termLen());

--- a/streamingvisitors/src/vespa/vsm/searcher/utf8flexiblestringfieldsearcher.cpp
+++ b/streamingvisitors/src/vespa/vsm/searcher/utf8flexiblestringfieldsearcher.cpp
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "utf8flexiblestringfieldsearcher.h"
 
+#include "vespa/searchlib/attribute/string_range_search_helper.h"
+
 #include <vespa/searchlib/query/streaming/fuzzy_term.h>
 #include <vespa/searchlib/query/streaming/regexp_term.h>
 
@@ -48,6 +50,18 @@ size_t UTF8FlexibleStringFieldSearcher::match_fuzzy(const FieldRef& f, search::s
     return 1;
 }
 
+size_t UTF8FlexibleStringFieldSearcher::match_string_range(const FieldRef& f, search::streaming::QueryTerm& qt) {
+    search::attribute::StringRangeSearchHelper helper(qt.get_string_range_spec(),
+                                                      normalize_mode() == Normalizing::NONE);
+    // StringRangeSearchHelper takes a null-terminated string
+    // TODO Avoid having to copy the string
+    std::string copy({f.data(), f.size()});
+    if (helper.is_valid() && helper.is_match(copy.c_str())) {
+        addHit(qt, 0);
+    }
+    return 1;
+}
+
 size_t UTF8FlexibleStringFieldSearcher::matchTerm(const FieldRef& f, QueryTerm& qt) {
     if (qt.isPrefix()) {
         LOG(debug, "Use prefix match for prefix term '%s:%s'", qt.index().c_str(), qt.getTerm());
@@ -67,6 +81,9 @@ size_t UTF8FlexibleStringFieldSearcher::matchTerm(const FieldRef& f, QueryTerm& 
     } else if (qt.isFuzzy()) {
         LOG(debug, "Use fuzzy match for term '%s:%s'", qt.index().c_str(), qt.getTerm());
         return match_fuzzy(f, qt);
+    } else if (qt.is_string_range()) {
+        LOG(debug, "Use string-range match for term '%s:%s'", qt.index().c_str(), qt.getTerm());
+        return match_string_range(f, qt);
     } else {
         if (substring()) {
             LOG(debug, "Use substring match for term '%s:%s'", qt.index().c_str(), qt.getTerm());

--- a/streamingvisitors/src/vespa/vsm/searcher/utf8flexiblestringfieldsearcher.h
+++ b/streamingvisitors/src/vespa/vsm/searcher/utf8flexiblestringfieldsearcher.h
@@ -25,6 +25,7 @@ private:
 
     size_t match_regexp(const FieldRef& f, search::streaming::QueryTerm& qt);
     size_t match_fuzzy(const FieldRef& f, search::streaming::QueryTerm& qt);
+    size_t match_string_range(const FieldRef& f, search::streaming::QueryTerm& qt);
 
 public:
     std::unique_ptr<FieldSearcher> duplicate() const override;

--- a/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
@@ -134,7 +134,7 @@ void FieldSearchSpec::reconfig(const QueryTerm& term) {
     case VsmfieldsConfig::Fieldspec::Searchmethod::SSE2UTF8:
         if ((term.isSubstring() && _arg1 != "substring") || (term.isSuffix() && _arg1 != "suffix") ||
             (term.isExactstring() && _arg1 != "exact") || (term.isPrefix() && _arg1 == "suffix") ||
-            (term.isRegex() || term.isFuzzy()))
+            (term.isRegex() || term.isFuzzy() || term.is_string_range()))
         {
             _searcher = std::make_unique<UTF8FlexibleStringFieldSearcher>(id());
             propagate_settings_to_searcher();


### PR DESCRIPTION
Makes string ranges work in streaming search.

For a string range, a `QueryTerm` is constructed via a new constructor, which is a bit ugly. Maybe this should be refactored into its own sub-class if that is possible.

The `UTF8FlexibleStringFieldSearcher` is extended by string-range functionality by re-using the `StringRangeSearchHelper`. This works, but the downside to this is that the `StringRangeSearchHelper` expects a null-terminated string, which means that the string view that is searched has to be copied into a string. I left a TODO there.