### PR TITLE
Reject use of element filter on query stack

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
@@ -110,12 +110,13 @@ public class SameElementItem extends NonReducibleCompositeItem implements HasInd
     @Override
     public boolean equals(Object other) {
         if ( ! super.equals(other)) return false;
-        return Objects.equals(this.fieldName, ((SameElementItem)other).fieldName);
+        return Objects.equals(this.fieldName, ((SameElementItem)other).fieldName)
+               && Objects.equals(this.elementFilter, ((SameElementItem)other).elementFilter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), fieldName);
+        return Objects.hash(super.hashCode(), fieldName, elementFilter);
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
@@ -26,6 +26,13 @@ public class SameElementItem extends NonReducibleCompositeItem implements HasInd
 
     @Override
     protected void encodeThis(ByteBuffer buffer, SerializationContext context) {
+        // The binary query stack format has no element filter field, and silently dropping the
+        // filter would over-match, so refuse rather than produce a query with different semantics.
+        if ( ! elementFilter.isEmpty()) {
+            throw new IllegalStateException("sameElement with an element filter cannot be serialized to the " +
+                                            "binary query stack. Turn off the send-old-query-stack option " +
+                                            "to use element filters.");
+        }
         super.encodeThis(buffer, context);
         putString(fieldName, buffer);
     }

--- a/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/SameElementItem.java
@@ -29,9 +29,7 @@ public class SameElementItem extends NonReducibleCompositeItem implements HasInd
         // The binary query stack format has no element filter field, and silently dropping the
         // filter would over-match, so refuse rather than produce a query with different semantics.
         if ( ! elementFilter.isEmpty()) {
-            throw new IllegalStateException("sameElement with an element filter cannot be serialized to the " +
-                                            "binary query stack. Turn off the send-old-query-stack option " +
-                                            "to use element filters.");
+            throw new IllegalStateException("cannot serialize sameElement with an element filter in old protocol");
         }
         super.encodeThis(buffer, context);
         putString(fieldName, buffer);

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/SameElementItemTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/SameElementItemTestCase.java
@@ -6,6 +6,7 @@ import com.yahoo.prelude.query.AndSegmentItem;
 import com.yahoo.prelude.query.PhraseItem;
 import com.yahoo.prelude.query.PhraseSegmentItem;
 import com.yahoo.prelude.query.SameElementItem;
+import com.yahoo.prelude.query.SerializationContext;
 import com.yahoo.prelude.query.WordItem;
 import org.junit.jupiter.api.Test;
 

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/SameElementItemTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/SameElementItemTestCase.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class SameElementItemTestCase {
@@ -26,6 +27,43 @@ public class SameElementItemTestCase {
         s.addItem(new WordItem("c", "f2"));
         s.addItem(new WordItem("d", "f3"));
         assertEquals("structa:{f1:b f2:c f3:d}", s.toString());
+    }
+
+    @Test
+    void testEqualsConsidersElementFilter() {
+        SameElementItem a = new SameElementItem("structa");
+        a.addItem(new WordItem("b", "f1"));
+        SameElementItem b = new SameElementItem("structa");
+        b.addItem(new WordItem("b", "f1"));
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+
+        b.setElementFilter(List.of(1));
+        assertNotEquals(a, b);
+
+        a.setElementFilter(List.of(1));
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+
+        b.setElementFilter(List.of(2));
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    void testBinaryEncodingRejectsElementFilter() {
+        SameElementItem plain = new SameElementItem("structa");
+        plain.addItem(new WordItem("b", "f1"));
+        plain.encode(java.nio.ByteBuffer.allocate(1024), SerializationContext.ignored());
+
+        SameElementItem filtered = new SameElementItem("structa");
+        filtered.addItem(new WordItem("b", "f1"));
+        filtered.setElementFilter(List.of(1));
+        try {
+            filtered.encode(java.nio.ByteBuffer.allocate(1024), SerializationContext.ignored());
+            fail("expected encode to reject an element filter");
+        } catch (IllegalStateException expected) {
+            // The binary query stack cannot represent the filter; dropping it would over-match.
+        }
     }
 
     @Test


### PR DESCRIPTION
And include the element filter in equals and hash.

_Co-written with Claude Code_