### PR TITLE
docs: fix user-facing typos in status page and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Use this if you only need to build the Java modules, otherwise follow the comple
 
 ### Run tests for shell scripts (on Mac)
 Shell scripts are tested with [BATS](https://bats-core.readthedocs.io/en/stable/).
-To run the tests locally, install the testing framework and its plugins.:
+To run the tests locally, install the testing framework and its plugins.
 ```bash
 brew install node
 sudo npm install -g bats bats-assert bats-support bats-mock

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/VdsClusterHtmlRenderer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/VdsClusterHtmlRenderer.java
@@ -549,7 +549,7 @@ public class VdsClusterHtmlRenderer {
                     .append("5) PC - Premature crashes - Number of times node has crashed since last time it had " +
                             "been stable in up or down state for more than "
                             + RealTimer.printDuration(stableStateTimePeriode) + ".<br>\n")
-                    .append("6) ELW - Events last week - The number of events that has occured on this node the " +
+                    .append("6) ELW - Events last week - The number of events that has occurred on this node the " +
                             "last week. (Or shorter period if a week haven't passed since restart or more than " +
                             "max events to keep in node event log have happened during last week.)<br>\n")
                     .append("</font>\n");

--- a/container-documentapi/README.md
+++ b/container-documentapi/README.md
@@ -4,5 +4,5 @@
 Dependency artifact for building container bundles.
 To build standalone document clients, use `documentapi` instead.
 
-The actual java code remains in `documentapi`, becuase it uses
+The actual java code remains in `documentapi`, because it uses
 common test files with the C++ code in the same module.

--- a/container-search-and-docproc/README.md
+++ b/container-search-and-docproc/README.md
@@ -1,7 +1,7 @@
 <!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 # Container search and docproc bundle
 
-Pacakges the search and document processing modules for JDisc
+Packages the search and document processing modules for JDisc
 into one bundle.
 
 This modules also contains the `ApplicationStatus` handler.


### PR DESCRIPTION
Four typo fixes:

1. `VdsClusterHtmlRenderer.java`: the cluster-controller HTML status page rendered "The number of events that has **occured**" → "occurred"
2. `container-documentapi/README.md`: "becuase" → "because"
3. `container-search-and-docproc/README.md`: "Pacakges" → "Packages"
4. `README.md`: stray `.:` → `.` in the BATS test setup section

Comment/string-only changes; no behavior change.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository.
