### PR TITLE
fix: rename misspelled IndexingLangaugeCompletion to IndexingLanguageCompletion

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/SchemaCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/SchemaCompletion.java
@@ -11,7 +11,7 @@ import ai.vespa.schemals.lsp.schema.completion.provider.BodyKeywordCompletion;
 import ai.vespa.schemals.lsp.common.completion.CompletionProvider;
 import ai.vespa.schemals.lsp.schema.completion.provider.EmptyFileCompletion;
 import ai.vespa.schemals.lsp.schema.completion.provider.FieldsCompletion;
-import ai.vespa.schemals.lsp.schema.completion.provider.IndexingLangaugeCompletion;
+import ai.vespa.schemals.lsp.schema.completion.provider.IndexingLanguageCompletion;
 import ai.vespa.schemals.lsp.schema.completion.provider.InheritanceCompletion;
 import ai.vespa.schemals.lsp.schema.completion.provider.InheritsCompletion;
 import ai.vespa.schemals.lsp.schema.completion.provider.RankingExpressionCompletion;
@@ -34,7 +34,7 @@ public class SchemaCompletion {
         new InheritsCompletion(),
         new InheritanceCompletion(),
         new StructFieldCompletion(),
-        new IndexingLangaugeCompletion(),
+        new IndexingLanguageCompletion(),
         new RankingExpressionCompletion()
     };
 

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/IndexingLanguageCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/IndexingLanguageCompletion.java
@@ -14,9 +14,9 @@ import ai.vespa.schemals.tree.CSTUtils;
 import ai.vespa.schemals.tree.Node;
 
 /**
- * IndexingLangaugeProvider
+ * IndexingLanguageProvider
  */
-public class IndexingLangaugeCompletion implements CompletionProvider {
+public class IndexingLanguageCompletion implements CompletionProvider {
 
     private boolean matchCommon(EventCompletionContext context) {
         Position searchPos = context.startOfWord();


### PR DESCRIPTION
Mechanical rename of the misspelled completion-provider class:

- `IndexingLangaugeCompletion.java` → `IndexingLanguageCompletion.java` (file + class + javadoc comment)
- the two references in `SchemaCompletion.java` (import + usage)

"Langauge" → "Language"; the sibling provider in the same package (`RankingExpressionCompletion`) is spelled correctly.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository.
