### PR TITLE
docs: fix addAfter javadoc copy-paste and paramater typos

### DIFF
--- a/docproc/src/main/java/com/yahoo/docproc/CallStack.java
+++ b/docproc/src/main/java/com/yahoo/docproc/CallStack.java
@@ -207,7 +207,7 @@ public class CallStack {
      * the stack. This cannot be called during an iteration.
      *
      * @param after
-     *            the call to add this before. If this call is not present, (the
+     *            the call to add this after. If this call is not present, (the
      *            same object instance), the new processor is added as the last
      *            element
      * @param call
@@ -241,7 +241,7 @@ public class CallStack {
      * Adds multiple elements just after another given element on the stack.
      * This cannot be called during an iteration.
      *
-     * @param after the call to add this before. If this call is not present, (the
+     * @param after the call to add this after. If this call is not present, (the
      *              same object instance), the new processor is added as the last element
      * @param callStack the calls to add
      * @return this for convenience

--- a/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/RPCTargetPool.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/RPCTargetPool.java
@@ -35,7 +35,7 @@ public class RPCTargetPool {
 
     /**
      * Constructs a new instance of this class, using the given {@link Timer} for detecting and closing connections that
-     * have expired according to the second paramter.
+     * have expired according to the second parameter.
      *
      * @param timer      The timer to use for connection expiration.
      * @param expireSecs The number of seconds until an idle connection is closed.

--- a/vespajlib/src/main/java/com/yahoo/text/Lowercase.java
+++ b/vespajlib/src/main/java/com/yahoo/text/Lowercase.java
@@ -6,7 +6,7 @@ import java.util.Locale;
 /**
  * The lower casing method to use in Vespa when doing string processing of data
  * which is not to be handled as natural language data, e.g. field names or
- * configuration paramaters.
+ * configuration parameters.
  *
  * @author Steinar Knutsen
  */


### PR DESCRIPTION
Doc-comment-only fixes:

1. `CallStack.addAfter` has three overloads whose `@param after` documentation reads "the call to add this **before**" — copied from the `addBefore` javadoc. The methods insert *after* the reference call (`elements.add(insertPosition + 1, call)`). Fixed all three.
2. `paramaters` → `parameters` in `Lowercase.java` and `RPCTargetPool.java` javadoc.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository.
