### PR TITLE
Remove plumbing left over from the old query stack

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -249,7 +249,6 @@ public class ModelContextImpl implements ModelContext {
         @Override public double clusterControllerNodeMemory() { return flag(PermanentFlags.CLUSTER_CONTROLLER_NODE_MEMORY).value(); }
         @Override public boolean useLegacyWandQueryParsing() { return flag(Flags.USE_LEGACY_WAND_QUERY_PARSING).value(); }
         @Override public boolean useSimpleAnnotations() { return flag(Flags.USE_SIMPLE_ANNOTATIONS).value(); }
-        @Override public boolean sendOldQueryStack() { return false; }
         @Override public boolean forwardAllLogLevels() { return flag(PermanentFlags.FORWARD_ALL_LOG_LEVELS).value(); }
         @Override public long zookeeperPreAllocSize() { return flag(PermanentFlags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB).value(); }
         @Override public int maxContentNodeMaintenanceOpConcurrency() { return flag(PermanentFlags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY).value(); }

--- a/container-disc/src/main/resources/configdefinitions/container.qr-searchers.def
+++ b/container-disc/src/main/resources/configdefinitions/container.qr-searchers.def
@@ -81,9 +81,3 @@ parserSettings.keepSegmentAnds bool default=false
 
 ## keep ideographic comma and full stop (default: replace with space)
 parserSettings.keepIdeographicPunctuation bool default=false
-
-## send query tree as protobuf (ignored, always true)
-sendProtobufQuerytree bool default=true
-
-## send query stack in legacy format in addition to protobuf format
-sendOldQueryStack bool default=false

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -18,7 +18,6 @@ import com.yahoo.search.dispatch.rpc.RpcConnectionPool;
 import com.yahoo.search.dispatch.rpc.RpcInvokerFactory;
 import com.yahoo.search.dispatch.rpc.RpcPingFactory;
 import com.yahoo.search.dispatch.rpc.RpcResourcePool;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.search.dispatch.searchcluster.AvailabilityPolicy;
 import com.yahoo.search.dispatch.searchcluster.Group;
 import com.yahoo.search.dispatch.searchcluster.Node;
@@ -69,7 +68,6 @@ public class Dispatcher extends AbstractComponent {
     private final RpcConnectionPool rpcResourcePool;
     private final SearchCluster searchCluster;
     private final ClusterMonitor<Node> clusterMonitor;
-    private final QrSearchersConfig qrSearchersConfig;
     private final String localAvailabilityZone;
     private volatile VolatileItems volatileItems;
 
@@ -119,19 +117,17 @@ public class Dispatcher extends AbstractComponent {
     public static QueryProfileType getArgumentType() { return argumentType; }
 
     interface InvokerFactoryFactory {
-        InvokerFactory create(RpcConnectionPool rpcConnectionPool, SearchGroups searchGroups, DispatchConfig dispatchConfig, QrSearchersConfig qrSearchersConfig);
+        InvokerFactory create(RpcConnectionPool rpcConnectionPool, SearchGroups searchGroups, DispatchConfig dispatchConfig);
     }
 
     @Inject
     public Dispatcher(ComponentId clusterId,
                       DispatchConfig dispatchConfig,
-                      QrSearchersConfig qrSearchersConfig,
                       DispatchNodesConfig nodesConfig,
                       SystemInfo systemInfo,
                       VipStatus vipStatus) {
         this(clusterId,
              dispatchConfig,
-             qrSearchersConfig,
              new RpcResourcePool(dispatchConfig, nodesConfig),
              nodesConfig,
              systemInfo,
@@ -142,14 +138,12 @@ public class Dispatcher extends AbstractComponent {
 
     Dispatcher(ComponentId clusterId,
                DispatchConfig dispatchConfig,
-               QrSearchersConfig qrSearchersConfig,
                RpcConnectionPool rpcConnectionPool,
                DispatchNodesConfig nodesConfig,
                SystemInfo systemInfo,
                VipStatus vipStatus,
                InvokerFactoryFactory invokerFactories) {
         this(dispatchConfig,
-             qrSearchersConfig,
              rpcConnectionPool,
              new SearchCluster(clusterId.stringValue(),
                                AvailabilityPolicy.from(dispatchConfig),
@@ -161,13 +155,11 @@ public class Dispatcher extends AbstractComponent {
     }
 
     Dispatcher(DispatchConfig dispatchConfig,
-               QrSearchersConfig qrSearchersConfig,
                RpcConnectionPool rpcConnectionPool,
                SearchCluster searchCluster,
                SystemInfo systemInfo,
                InvokerFactoryFactory invokerFactories) {
         this(dispatchConfig,
-             qrSearchersConfig,
              rpcConnectionPool,
              searchCluster,
              new ClusterMonitor<>(searchCluster, false),
@@ -177,14 +169,12 @@ public class Dispatcher extends AbstractComponent {
     }
 
     Dispatcher(DispatchConfig dispatchConfig,
-               QrSearchersConfig qrSearchersConfig,
                RpcConnectionPool rpcConnectionPool,
                SearchCluster searchCluster,
                ClusterMonitor<Node> clusterMonitor,
                SystemInfo systemInfo,
                InvokerFactoryFactory invokerFactories) {
         this.dispatchConfig = dispatchConfig;
-        this.qrSearchersConfig = qrSearchersConfig;
         this.rpcResourcePool = rpcConnectionPool;
         this.searchCluster = searchCluster;
         this.clusterMonitor = clusterMonitor;
@@ -198,16 +188,14 @@ public class Dispatcher extends AbstractComponent {
     Dispatcher(ClusterMonitor<Node> clusterMonitor,
                SearchCluster searchCluster,
                DispatchConfig dispatchConfig,
-               QrSearchersConfig qrSearchersConfig,
                SystemInfo systemInfo,
                InvokerFactory invokerFactory) {
         this(dispatchConfig,
-             qrSearchersConfig,
              null,
              searchCluster,
              clusterMonitor,
              systemInfo,
-             (__, ___, ____, _____) -> invokerFactory);
+             (__, ___, ____) -> invokerFactory);
     }
 
     /** Returns the snapshot of volatile items that need to be kept together, incrementing its reference counter. */
@@ -270,7 +258,7 @@ public class Dispatcher extends AbstractComponent {
                                  // so nodes removed by a later reconfiguration stay resolvable until this generation drains.
                                  // The pool is null in some tests, which use invoker factories that don't need it.
                                  invokerFactories.create(rpcResourcePool == null ? null : rpcResourcePool.snapshot(),
-                                                         searchCluster.groupList(), dispatchConfig, qrSearchersConfig));
+                                                         searchCluster.groupList(), dispatchConfig));
     }
 
     private void initialWarmup(double warmupTime) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/ReconfigurableDispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/ReconfigurableDispatcher.java
@@ -6,7 +6,6 @@ import com.yahoo.component.ComponentId;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.container.QrConfig;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.container.handler.VipStatus;
 import com.yahoo.vespa.config.search.DispatchConfig;
 import com.yahoo.vespa.config.search.DispatchNodesConfig;
@@ -25,10 +24,9 @@ public class ReconfigurableDispatcher extends Dispatcher {
     @Inject
     public ReconfigurableDispatcher(ComponentId clusterId,
                                     DispatchConfig dispatchConfig,
-                                    QrSearchersConfig qrSearchersConfig,
                                     SystemInfo systemInfo,
                                     VipStatus vipStatus) {
-        super(clusterId, dispatchConfig, qrSearchersConfig, new DispatchNodesConfig.Builder().build(), systemInfo, vipStatus);
+        super(clusterId, dispatchConfig, new DispatchNodesConfig.Builder().build(), systemInfo, vipStatus);
         this.subscriber = new ConfigSubscriber();
         CountDownLatch configured = new CountDownLatch(1);
         this.subscriber.subscribe(nodesConfig -> { updateWithNewConfig(nodesConfig); configured.countDown(); },

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/ProtobufSerialization.java
@@ -17,7 +17,6 @@ import com.yahoo.prelude.fastsearch.GroupingListHit;
 import com.yahoo.prelude.fastsearch.VespaBackend;
 import com.yahoo.prelude.query.SerializationContext;
 import com.yahoo.search.Query;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.search.Result;
 import com.yahoo.search.dispatch.InvokerResult;
 import com.yahoo.search.dispatch.LeanHit;
@@ -51,8 +50,8 @@ public class ProtobufSerialization {
      */
     private static final ThreadLocal<GrowableByteBuffer> threadLocalBuffer = ThreadLocal.withInitial(() -> new GrowableByteBuffer(4096));
 
-    static byte[] serializeSearchRequest(Query query, int hits, String nodeId, double contentShare, double requestTimeout, QrSearchersConfig qrSearchersConfig) {
-        return convertFromQuery(query, hits, nodeId, contentShare, requestTimeout, qrSearchersConfig).toByteArray();
+    static byte[] serializeSearchRequest(Query query, int hits, String nodeId, double contentShare, double requestTimeout) {
+        return convertFromQuery(query, hits, nodeId, contentShare, requestTimeout).toByteArray();
     }
 
     private static void convertSearchReplyErrors(Result target, List<SearchProtocol.Error> errors, boolean softTimeout, boolean annTimeout) {
@@ -64,7 +63,7 @@ public class ProtobufSerialization {
     }
 
     static SearchProtocol.SearchRequest convertFromQuery(Query query, int hits, String nodeId, double contentShare,
-                                                         double requestTimeout, QrSearchersConfig qrSearchersConfig) {
+                                                         double requestTimeout) {
         var builder = SearchProtocol.SearchRequest.newBuilder().setHits(hits).setOffset(query.getOffset())
                 .setTimeout((int) (requestTimeout * 1000));
         var documentDb = query.getModel().getDocumentDb();
@@ -170,8 +169,7 @@ public class ProtobufSerialization {
                                                                            String summaryClass,
                                                                            Set<String> fields,
                                                                            boolean includeQueryData,
-                                                                           double requestTimeout,
-                                                                           QrSearchersConfig qrSearchersConfig) {
+                                                                           double requestTimeout) {
         var builder = SearchProtocol.DocsumRequest.newBuilder()
                 .setTimeout((int) (requestTimeout * 1000))
                 .setDumpFeatures(query.properties().getBoolean(Ranking.RANKFEATURES, false));
@@ -200,7 +198,7 @@ public class ProtobufSerialization {
         }
         GrowableByteBuffer scratchPad = threadLocalBuffer.get();
         if (includeQueryData) {
-            mergeQueryDataToDocsumRequest(query, scratchPad, builder, qrSearchersConfig);
+            mergeQueryDataToDocsumRequest(query, scratchPad, builder);
         }
         if (query.getTrace().getLevel() >= 3) {
             query.trace((includeQueryData ? "ProtoBuf: Resending " : "Not resending ") + "query during document summary fetching", 3);
@@ -219,8 +217,7 @@ public class ProtobufSerialization {
 
     private static void mergeQueryDataToDocsumRequest(Query query,
                                                       GrowableByteBuffer scratchPad,
-                                                      SearchProtocol.DocsumRequest.Builder builder,
-                                                      QrSearchersConfig qrSearchersConfig) {
+                                                      SearchProtocol.DocsumRequest.Builder builder) {
         var ranking = query.getRanking();
         var featureMap = ranking.getFeatures().asMap();
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcInvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcInvokerFactory.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch.rpc;
 
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.prelude.fastsearch.VespaBackend;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -22,7 +21,6 @@ public class RpcInvokerFactory extends InvokerFactory {
     private final RpcConnectionPool rpcResourcePool;
     private final CompressPayload compressor;
     private final RpcProtobufFillInvoker.DecodePolicy decodeType;
-    private final QrSearchersConfig qrSearchersConfig;
 
     private static RpcProtobufFillInvoker.DecodePolicy convert(DispatchConfig.SummaryDecodePolicy.Enum decoding) {
         return switch (decoding) {
@@ -31,17 +29,16 @@ public class RpcInvokerFactory extends InvokerFactory {
         };
     }
 
-    public RpcInvokerFactory(RpcConnectionPool rpcResourcePool, SearchGroups cluster, DispatchConfig dispatchConfig, QrSearchersConfig qrSearchersConfig) {
+    public RpcInvokerFactory(RpcConnectionPool rpcResourcePool, SearchGroups cluster, DispatchConfig dispatchConfig) {
         super(cluster, dispatchConfig);
         this.rpcResourcePool = rpcResourcePool;
         this.compressor = new CompressService();
         this.decodeType = convert(dispatchConfig.summaryDecodePolicy());
-        this.qrSearchersConfig = qrSearchersConfig;
     }
 
     @Override
     protected Optional<SearchInvoker> createNodeSearchInvoker(VespaBackend searcher, Query query, int maxHits, Node node) {
-        return Optional.of(new RpcSearchInvoker(searcher, compressor, node, rpcResourcePool, maxHits, qrSearchersConfig));
+        return Optional.of(new RpcSearchInvoker(searcher, compressor, node, rpcResourcePool, maxHits));
     }
 
     @Override
@@ -49,7 +46,7 @@ public class RpcInvokerFactory extends InvokerFactory {
         Query query = result.getQuery();
         boolean summaryNeedsQuery = searcher.summaryNeedsQuery(query);
         return new RpcProtobufFillInvoker(rpcResourcePool, compressor, searcher.getDocumentDatabase(query),
-                                          searcher.getServerId(), decodeType, summaryNeedsQuery, qrSearchersConfig);
+                                          searcher.getServerId(), decodeType, summaryNeedsQuery);
     }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcProtobufFillInvoker.java
@@ -7,7 +7,6 @@ import ai.vespa.telemetry.api.trace.OtelTracing;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.yahoo.collections.ListMap;
 import com.yahoo.compress.Compressor;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.container.protect.Error;
 import com.yahoo.data.access.Inspector;
 import com.yahoo.data.access.slime.SlimeAdapter;
@@ -63,7 +62,6 @@ public class RpcProtobufFillInvoker extends FillInvoker {
     private final String serverId;
     private final CompressPayload compressor;
     private final DecodePolicy decodePolicy;
-    private final QrSearchersConfig qrSearchersConfig;
 
     private record ResponseAndHits(Client.ResponseOrError<ProtobufResponse> response, List<FastHit> hits) {}
 
@@ -82,15 +80,13 @@ public class RpcProtobufFillInvoker extends FillInvoker {
     private static final AtomicInteger retryTimeoutCounter = new AtomicInteger();
 
     RpcProtobufFillInvoker(RpcConnectionPool resourcePool, CompressPayload compressor, DocumentDatabase documentDb,
-                           String serverId, DecodePolicy decodePolicy, boolean summaryNeedsQuery,
-                           QrSearchersConfig qrSearchersConfig) {
+                           String serverId, DecodePolicy decodePolicy, boolean summaryNeedsQuery) {
         this.documentDb = documentDb;
         this.resourcePool = resourcePool;
         this.serverId = serverId;
         this.summaryNeedsQuery = summaryNeedsQuery;
         this.compressor = compressor;
         this.decodePolicy = decodePolicy;
-        this.qrSearchersConfig = qrSearchersConfig;
         this.partialSummaryHandler = new PartialSummaryHandler(documentDb);
     }
 
@@ -131,7 +127,7 @@ public class RpcProtobufFillInvoker extends FillInvoker {
         String askForSummary = partialSummaryHandler.askForSummary();
         Set<String> onlyFields = partialSummaryHandler.askForFields();
         var builder = ProtobufSerialization.createDocsumRequestBuilder(
-                result.getQuery(), serverId, askForSummary, onlyFields, summaryNeedsQuery, timeout.request(), qrSearchersConfig);
+                result.getQuery(), serverId, askForSummary, onlyFields, summaryNeedsQuery, timeout.request());
         hitsByNode.forEach((nodeId, hits) -> {
             var payload = ProtobufSerialization.serializeDocsumRequest(builder, hits);
             sendDocsumsRequest(nodeId, hits, payload, result, timeout.client());

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcSearchInvoker.java
@@ -4,7 +4,6 @@ package com.yahoo.search.dispatch.rpc;
 import ai.vespa.telemetry.api.trace.TraceAttributes;
 import ai.vespa.telemetry.api.trace.OtelTracing;
 import com.yahoo.compress.Compressor;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.prelude.fastsearch.VespaBackend;
 import com.yahoo.search.Query;
 import com.yahoo.search.dispatch.InvokerResult;
@@ -39,7 +38,6 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
     private final BlockingQueue<Client.ResponseOrError<ProtobufResponse>> responses;
     private final int maxHits;
     private final CompressPayload compressor;
-    private final QrSearchersConfig qrSearchersConfig;
 
     private Query query;
 
@@ -47,7 +45,7 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
      *  Created on the worker thread, ended on whichever thread learns the outcome — Span is thread-safe. */
     private Span span = Span.getInvalid();
 
-    RpcSearchInvoker(VespaBackend searcher, CompressPayload compressor, Node node, RpcConnectionPool resourcePool, int maxHits, QrSearchersConfig qrSearchersConfig) {
+    RpcSearchInvoker(VespaBackend searcher, CompressPayload compressor, Node node, RpcConnectionPool resourcePool, int maxHits) {
         super(Optional.of(node));
         this.searcher = searcher;
         this.node = node;
@@ -55,7 +53,6 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
         this.responses = new LinkedBlockingQueue<>(1);
         this.maxHits = maxHits;
         this.compressor = compressor;
-        this.qrSearchersConfig = qrSearchersConfig;
     }
 
     @Override
@@ -174,7 +171,7 @@ public class RpcSearchInvoker extends SearchInvoker implements Client.ResponseRe
                                    ProtobufSerialization.serializeSearchRequest(query,
                                                                                 Math.min(query.getHits(), maxHits),
                                                                                 searcher.getServerId(), contentShare,
-                                                                                requestTimeout, qrSearchersConfig));
+                                                                                requestTimeout));
     }
 
     private boolean newSerializationWillBeSimilar(double newContentShare, SerializedQuery serializedQuery) {

--- a/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
@@ -491,7 +491,6 @@ public class ClusterSearcherTestCase {
                                         new ai.vespa.cloud.Node(0, "default"));
         Dispatcher dispatcher = new Dispatcher(ComponentId.createAnonymousComponentId("test-id"),
                                                dispatchConfig,
-                                               new QrSearchersConfig.Builder().build(),
                                                nodesConfig,
                                                systemInfo,
                                                vipStatus);

--- a/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
@@ -7,7 +7,6 @@ import ai.vespa.cloud.Environment;
 import ai.vespa.cloud.SystemInfo;
 import ai.vespa.cloud.Zone;
 import com.yahoo.compress.CompressionType;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.prelude.Pong;
 import com.yahoo.prelude.fastsearch.VespaBackend;
 import com.yahoo.search.Query;
@@ -76,7 +75,6 @@ public class DispatcherTest {
         Dispatcher disp = new Dispatcher(new ClusterMonitor<>(cl, false),
                                          cl,
                                          dispatchConfig,
-                                         new QrSearchersConfig.Builder().build(),
                                          systemInfo("default"),
                                          invokerFactory);
         SearchInvoker invoker = disp.getSearchInvoker(q, null);
@@ -97,7 +95,6 @@ public class DispatcherTest {
         Dispatcher disp = new Dispatcher(new ClusterMonitor<>(cl, false),
                                          cl,
                                          dispatchConfig,
-                                         new QrSearchersConfig.Builder().build(),
                                          systemInfo("default"),
                                          invokerFactory);
         SearchInvoker invoker = disp.getSearchInvoker(new Query(), null);
@@ -120,7 +117,6 @@ public class DispatcherTest {
         Dispatcher disp = new Dispatcher(new ClusterMonitor<>(cl, false),
                                          cl,
                                          dispatchConfig,
-                                         new QrSearchersConfig.Builder().build(),
                                          systemInfo("default"),
                                          invokerFactory);
         SearchInvoker invoker = disp.getSearchInvoker(new Query(), null);
@@ -138,7 +134,6 @@ public class DispatcherTest {
             Dispatcher disp = new Dispatcher(new ClusterMonitor<>(cl, false),
                                              cl,
                                              dispatchConfig,
-                                             new QrSearchersConfig.Builder().build(),
                                              systemInfo("default"),
                                              invokerFactory);
             disp.getSearchInvoker(new Query(), null);
@@ -156,7 +151,6 @@ public class DispatcherTest {
         Dispatcher dispatcher = new Dispatcher(new ClusterMonitor<>(cluster, false),
                                                cluster,
                                                dispatchConfig,
-                                               new QrSearchersConfig.Builder().build(),
                                                systemInfo("default"),
                                                new MockInvokerFactory(cluster.groupList(), dispatchConfig, (n, a) -> true));
         cluster.pingIterationCompleted();
@@ -171,7 +165,6 @@ public class DispatcherTest {
         Dispatcher dispatcher = new Dispatcher(new ClusterMonitor<>(cluster, false),
                                                cluster,
                                                dispatchConfig,
-                                               new QrSearchersConfig.Builder().build(),
                                                systemInfo("default"),
                                                new MockInvokerFactory(cluster.groupList(), dispatchConfig, (n, a) -> true));
         cluster.pingIterationCompleted();
@@ -187,7 +180,6 @@ public class DispatcherTest {
         Dispatcher dispatcher = new Dispatcher(new ClusterMonitor<>(cluster, false),
                                                cluster,
                                                dispatchConfig,
-                                               new QrSearchersConfig.Builder().build(),
                                                systemInfo("default"),
                                                new MockInvokerFactory(cluster.groupList(), dispatchConfig, (n, a) -> true));
         cluster.pingIterationCompleted();
@@ -203,7 +195,6 @@ public class DispatcherTest {
         Dispatcher dispatcher = new Dispatcher(new ClusterMonitor<>(cluster, false),
                                                cluster,
                                                dispatchConfig,
-                                               new QrSearchersConfig.Builder().build(),
                                                systemInfo("default"),
                                                new MockInvokerFactory(cluster.groupList(), dispatchConfig, (n, a) -> true));
         cluster.pingIterationCompleted();
@@ -274,7 +265,7 @@ public class DispatcherTest {
         };
 
         // This factory just forwards search to the dummy RPC layer above, nothing more.
-        InvokerFactoryFactory invokerFactories = (rpcConnectionPool, searchGroups, dispatchConfig, qrSearchersConfig) -> new InvokerFactory(searchGroups, dispatchConfig) {
+        InvokerFactoryFactory invokerFactories = (rpcConnectionPool, searchGroups, dispatchConfig) -> new InvokerFactory(searchGroups, dispatchConfig) {
             @Override protected Optional<SearchInvoker> createNodeSearchInvoker(VespaBackend searcher, Query query, int maxHits, Node node) {
                 return Optional.of(new SearchInvoker(Optional.of(node)) {
                     @Override protected Object sendSearchRequest(Query query, double contentShare, Object context) {
@@ -297,7 +288,6 @@ public class DispatcherTest {
         };
 
         Dispatcher dispatcher = new Dispatcher(dispatchConfig,
-                                               new QrSearchersConfig.Builder().build(),
                                                rpcPool,
                                                cluster,
                                                systemInfo("default"),

--- a/container-search/src/test/java/com/yahoo/search/dispatch/MockDispatcher.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/MockDispatcher.java
@@ -7,7 +7,6 @@ import ai.vespa.cloud.Cluster;
 import ai.vespa.cloud.Environment;
 import ai.vespa.cloud.SystemInfo;
 import ai.vespa.cloud.Zone;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.container.handler.VipStatus;
 import com.yahoo.search.cluster.ClusterMonitor;
 import com.yahoo.search.dispatch.rpc.RpcInvokerFactory;
@@ -61,7 +60,7 @@ public class MockDispatcher extends Dispatcher {
              searchCluster,
              dispatchConfig,
              systemInfo,
-             new RpcInvokerFactory(rpcResourcePool, searchCluster.groupList(), dispatchConfig, new QrSearchersConfig.Builder().build()));
+             new RpcInvokerFactory(rpcResourcePool, searchCluster.groupList(), dispatchConfig));
     }
 
     private MockDispatcher(ClusterMonitor clusterMonitor,
@@ -72,7 +71,6 @@ public class MockDispatcher extends Dispatcher {
         super(clusterMonitor,
               searchCluster,
               dispatchConfig,
-              new QrSearchersConfig.Builder().build(),
               systemInfo,
               invokerFactory);
         this.clusterMonitor = clusterMonitor;

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/NodeFillTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/NodeFillTracingTest.java
@@ -3,7 +3,6 @@ package com.yahoo.search.dispatch.rpc;
 
 import ai.vespa.telemetry.api.trace.TraceAttributes;
 import com.yahoo.compress.CompressionType;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.prelude.fastsearch.DocumentDatabase;
 import com.yahoo.prelude.fastsearch.FastHit;
 import com.yahoo.search.Query;
@@ -257,8 +256,7 @@ class NodeFillTracingTest {
                                           new DocumentDatabase(schemaWithDefaultSummary()),
                                           "container.0",
                                           RpcProtobufFillInvoker.DecodePolicy.EAGER,
-                                          false,
-                                          new QrSearchersConfig.Builder().build());
+                                          false);
     }
 
     /** A schema declaring a "default" document summary, which is the class the tests ask to fill. */

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/NodeSearchTracingTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/NodeSearchTracingTest.java
@@ -4,7 +4,6 @@ package com.yahoo.search.dispatch.rpc;
 import ai.vespa.telemetry.api.trace.TraceAttributes;
 import com.google.common.collect.ImmutableMap;
 import com.yahoo.compress.CompressionType;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.prelude.fastsearch.ClusterParams;
 import com.yahoo.prelude.fastsearch.VespaBackend;
 import com.yahoo.search.Query;
@@ -154,8 +153,7 @@ class NodeSearchTracingTest {
         SpanRecorder recorder = SpanRecorder.underParentSpan("dispatch.search");
         // An empty pool: getConnection returns null, so sendSearchRequest takes the unknown-node early return.
         RpcSearchInvoker invoker = new RpcSearchInvoker(mockSearcher(), compressor, node(),
-                                                        new RpcResourcePool(ImmutableMap.of()), 1000,
-                                                        new QrSearchersConfig.Builder().build());
+                                                        new RpcResourcePool(ImmutableMap.of()), 1000);
 
         recorder.record(() -> {
             invoker.sendSearchRequest(new Query("?query=test"), 1.0, null);
@@ -181,8 +179,7 @@ class NodeSearchTracingTest {
             @Override public void close() { }
         };
         return new RpcSearchInvoker(mockSearcher(), compressor, node(),
-                                    new RpcResourcePool(ImmutableMap.of(node().key(), connection)), 1000,
-                                    new QrSearchersConfig.Builder().build());
+                                    new RpcResourcePool(ImmutableMap.of(node().key(), connection)), 1000);
     }
 
     private VespaBackend mockSearcher() {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
@@ -4,7 +4,6 @@ package com.yahoo.search.dispatch.rpc;
 
 import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
 import com.google.protobuf.ByteString;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.document.GlobalId;
 import com.yahoo.document.idstring.IdString;
 import com.yahoo.prelude.fastsearch.FastHit;
@@ -39,7 +38,7 @@ public class ProtobufSerializationTest {
                 .setRequest("?query=test&ranking.features.query(tensor_1)=[1.200]")
                 .build();
 
-        SearchProtocol.SearchRequest request1 = ProtobufSerialization.convertFromQuery(query, 9, "serverId", 1.0, 0.5, new QrSearchersConfig.Builder().build());
+        SearchProtocol.SearchRequest request1 = ProtobufSerialization.convertFromQuery(query, 9, "serverId", 1.0, 0.5);
         assertEquals(9, request1.getHits());
         assertEquals(0, request1.getRankPropertiesCount());
         assertEquals(0, request1.getTensorRankPropertiesCount());
@@ -52,7 +51,7 @@ public class ProtobufSerializationTest {
         assertFalse(request1.hasProfiling());
 
         query.prepare(); // calling prepare() moves "overrides" to "features" - content stays the same
-        SearchProtocol.SearchRequest request2 = ProtobufSerialization.convertFromQuery(query, 9, "serverId", 1.0, 0.5, new QrSearchersConfig.Builder().build());
+        SearchProtocol.SearchRequest request2 = ProtobufSerialization.convertFromQuery(query, 9, "serverId", 1.0, 0.5);
         assertEquals(9, request2.getHits());
         assertEquals(0, request2.getRankPropertiesCount());
         assertEquals(2, request2.getTensorRankPropertiesCount());
@@ -67,8 +66,7 @@ public class ProtobufSerializationTest {
     @Test
     void testDocsumSerialization() {
         Query q = new Query("search/?query=test&hits=10&offset=3");
-        var builder = ProtobufSerialization.createDocsumRequestBuilder(q, "server", "summary", Set.of("f1", "f2"),true, 0.5,
-                                                                       new QrSearchersConfig.Builder().sendProtobufQuerytree(true).build());
+        var builder = ProtobufSerialization.createDocsumRequestBuilder(q, "server", "summary", Set.of("f1", "f2"), true, 0.5);
         builder.setTimeout(0);
         var hit = new FastHit(new GlobalId(IdString.createIdString("id:ns:type::id")).getRawId(), 0, OptionalInt.of(0), 0, 0);
         var bytes = ProtobufSerialization.serializeDocsumRequest(builder, List.of(hit));
@@ -154,7 +152,7 @@ public class ProtobufSerializationTest {
                 "trace.profiling.matching.depth=3&" +
                 "trace.profiling.firstPhaseRanking.depth=5&" +
                 "trace.profiling.secondPhaseRanking.depth=-7");
-        var req = ProtobufSerialization.convertFromQuery(q, 1, "serverId", 1.0, 0.5, new QrSearchersConfig.Builder().build());
+        var req = ProtobufSerialization.convertFromQuery(q, 1, "serverId", 1.0, 0.5);
         assertEquals(3, req.getProfiling().getMatch().getDepth());
         assertEquals(5, req.getProfiling().getFirstPhase().getDepth());
         assertEquals(-7, req.getProfiling().getSecondPhase().getDepth());
@@ -164,7 +162,7 @@ public class ProtobufSerializationTest {
     void only_set_profiling_parameters_are_serialized_in_search_request() {
         var q = new Query("?query=test&trace.level=1&" +
                 "trace.profiling.matching.depth=3");
-        var req = ProtobufSerialization.convertFromQuery(q, 1, "serverId", 1.0, 0.5, new QrSearchersConfig.Builder().build());
+        var req = ProtobufSerialization.convertFromQuery(q, 1, "serverId", 1.0, 0.5);
         assertEquals(3, req.getProfiling().getMatch().getDepth());
         assertFalse(req.getProfiling().hasFirstPhase());
         assertFalse(req.getProfiling().hasSecondPhase());
@@ -173,13 +171,13 @@ public class ProtobufSerializationTest {
     @Test
     void feature_sort_is_serialized_as_opaque_field() {
         Query q = new Query("?query=test&sorting=-feature(foo)");
-        var req = ProtobufSerialization.convertFromQuery(q, 1, "serverId", 1.0, 0.5, new QrSearchersConfig.Builder().build());
+        var req = ProtobufSerialization.convertFromQuery(q, 1, "serverId", 1.0, 0.5);
         assertEquals(1, req.getSortingCount());
         assertEquals("feature(foo)", req.getSorting(0).getField());
         assertFalse(req.getSorting(0).getAscending());
 
         Query ascending = new Query("?query=test&sorting=feature(foo)");
-        var req2 = ProtobufSerialization.convertFromQuery(ascending, 1, "serverId", 1.0, 0.5, new QrSearchersConfig.Builder().build());
+        var req2 = ProtobufSerialization.convertFromQuery(ascending, 1, "serverId", 1.0, 0.5);
         assertEquals("feature(foo)", req2.getSorting(0).getField());
         assertTrue(req2.getSorting(0).getAscending());
     }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/RpcSearchInvokerTest.java
@@ -6,7 +6,6 @@ import ai.vespa.searchlib.searchprotocol.protobuf.SearchProtocol;
 import com.google.common.collect.ImmutableMap;
 import com.yahoo.compress.CompressionType;
 import com.yahoo.concurrent.Timer;
-import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.prelude.cluster.ClusterSearcher;
 import com.yahoo.prelude.fastsearch.ClusterParams;
 import com.yahoo.prelude.fastsearch.VespaBackend;
@@ -414,7 +413,7 @@ public class RpcSearchInvokerTest {
 
     RpcSearchInvoker createRpcInvoker(Node node, int maxHits, Holders holders) {
         var mockPool = new RpcResourcePool(ImmutableMap.of(node.key(), parameterCollectorClient(holders).createConnection(node.hostname(), 123)));
-        return new RpcSearchInvoker(mockSearcher(), compressor, node, mockPool, maxHits, new QrSearchersConfig.Builder().build());
+        return new RpcSearchInvoker(mockSearcher(), compressor, node, mockPool, maxHits);
     }
 
     void verifyConnections(RpcResourcePool rpcResourcePool, int numGroups, int nodesPerGroup, int expectNeedCloseCount) {


### PR DESCRIPTION
Follow-up to "Stop using the SEND_OLD_QUERY_STACK flag", which stopped sending the legacy (non-protobuf) query stack alongside the protobuf query tree but deliberately left the config and its plumbing in place, hardcoded to disabled.

Nothing reads those settings anymore, so drop the qr-searchers config fields sendOldQueryStack and sendProtobufQuerytree, and with them the QrSearchersConfig instance that existed only to carry them: it was injected into Dispatcher/ReconfigurableDispatcher and threaded through InvokerFactoryFactory, RpcInvokerFactory, RpcSearchInvoker, RpcProtobufFillInvoker and ProtobufSerialization without being used for anything else. Dispatching no longer depends on qr-searchers config at all, which makes the constructors and the serialization API simpler and removes a config dependency that could confuse future readers.

Also drops the ModelContextImpl override that hardcoded the flag value; the ModelContext default (false) is equivalent and has no callers left.

No behavior change: query trees are, as before, always sent as protobuf only. The feature flag definition (Flags.SEND_OLD_QUERY_STACK) and the ModelContext.sendOldQueryStack() accessor are now unused and can be retired separately.
