### PR TITLE
Add a tokens setting to the linguistics block of a field

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/Schema.java
+++ b/config-model/src/main/java/com/yahoo/schema/Schema.java
@@ -506,7 +506,7 @@ public class Schema implements ImmutableSchema {
     }
 
     /** Returns the schema level index of this name, in this or any inherited schema, if any */
-    Optional<Index> getSchemaIndex(String name) {
+    public Optional<Index> getSchemaIndex(String name) {
         if (indices.containsKey(name)) return Optional.of(indices.get(name));
         if (inherited.isPresent()) return requireInherited().getSchemaIndex(name);
         return Optional.empty();

--- a/config-model/src/main/java/com/yahoo/schema/derived/IndexInfo.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/IndexInfo.java
@@ -26,7 +26,6 @@ import com.yahoo.search.config.IndexInfoConfig;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -167,7 +166,7 @@ public class IndexInfo extends Derived {
                 addIndexCommand(field.getName(), CMD_FAST_SEARCH);
         } else if (field.doesIndexing()) {
             if (stemSomehow(field, schema)) {
-                addIndexCommand(field, stemCmd(field, schema), new StemmingOverrider(this, schema));
+                addIndexCommand(field, CMD_STEM + ":" + field.getEffectiveSearchStemming(schema).toStemMode());
             }
             if (normalizeAccents(field)) {
                 addIndexCommand(field, CMD_NORMALIZE);
@@ -223,12 +222,8 @@ public class IndexInfo extends Derived {
                 && field.getMatching().getCase().equals(Case.UNCASED));
     }
 
-    static String stemCmd(ImmutableSDField field, Schema schema) {
-        return CMD_STEM + ":" + field.getStemming(schema).toStemMode();
-    }
-
     private boolean stemSomehow(ImmutableSDField field, Schema schema) {
-        if (field.getStemming(schema).equals(Stemming.NONE)) return false;
+        if (field.getEffectiveSearchStemming(schema).equals(Stemming.NONE)) return false;
         return isTypeOrNested(field, DataType.STRING);
     }
 
@@ -237,7 +232,7 @@ public class IndexInfo extends Derived {
     }
 
     private boolean isTypeOrNested(ImmutableSDField field, DataType type) {
-        return type.equals(field.getDataType()) || type.equals(field.getDataType().getNestedType());
+        return field.isOfTypeOrNested(type);
     }
 
     private boolean isUriField(ImmutableSDField field) {
@@ -269,29 +264,17 @@ public class IndexInfo extends Derived {
         }
     }
 
-    /**
-     * Sets a command for all indices of a field
-     */
+    /** Sets a command for the given index */
     private void addIndexCommand(Index index, String command) {
         addIndexCommand(index.getName(), command);
     }
 
-    /**
-     * Sets a command for all indices of a field
-     */
+    /** Sets a command for all indices of a field */
     private void addIndexCommand(ImmutableSDField field, String command) {
-        addIndexCommand(field, command, null);
+        addIndexCommand(field.getName(), command);
     }
 
-    /**
-     * Sets a command for all indices of a field
-     */
-    private void addIndexCommand(ImmutableSDField field, String command, IndexOverrider overrider) {
-        if (overrider == null || !overrider.override(field.getName(), command, field)) {
-            addIndexCommand(field.getName(), command);
-        }
-    }
-
+    /** Sets a command for the index of the given name */
     private void addIndexCommand(String indexName, String command) {
         commands.add(new IndexCommand(indexName, command));
     }
@@ -377,7 +360,7 @@ public class IndexInfo extends Derived {
             }
             if (stemming(field)) {
                 anyStemming = true;
-                stemmingCommand = CMD_STEM + ":" + getEffectiveStemming(field).toStemMode();
+                stemmingCommand = CMD_STEM + ":" + field.getEffectiveSearchStemming(schema).toStemMode();
             }
             if (normalizeAccents(field)) {
                 anyNormalizing = true;
@@ -458,25 +441,15 @@ public class IndexInfo extends Derived {
         return false;
     }
 
-    private Stemming getEffectiveStemming(ImmutableSDField field) {
-        Stemming active = field.getStemming(schema);
-        if (field.getIndex(field.getName()) != null) {
-            if (field.getIndex(field.getName()).getStemming()!=null) {
-                active = field.getIndex(field.getName()).getStemming();
-            }
-        }
-        return Objects.requireNonNullElse(active, Stemming.BEST);
-    }
-
+    /** Returns whether this field is stemmed when searched, as the query side sees it. */
     private boolean stemming(ImmutableSDField field) {
-        if (field.getStemming() != null) {
-            return !field.getStemming().equals(Stemming.NONE);
-        }
-        if (schema.getStemming() == Stemming.NONE) return false;
-        if (field.isImportedField()) return false;
-        if (field.getIndex(field.getName())==null) return true;
-        if (field.getIndex(field.getName()).getStemming()==null) return true;
-        return !(field.getIndex(field.getName()).getStemming().equals(Stemming.NONE));
+        // A field which cannot be stemmed must not decide the stem command of a fieldset it is in:
+        // FieldSetSettings skips those fields when checking that the fields of a fieldset agree, so
+        // letting one of them win here would emit a command that check never validated. This must
+        // also be tested before anything else: ImmutableImportedSDField does not support resolving
+        // stemming at all.
+        if ( ! field.isStemmable()) return false;
+        return ! field.getEffectiveSearchStemming(schema).equals(Stemming.NONE);
     }
 
     private boolean isExactMatch(Matching m) {
@@ -513,57 +486,6 @@ public class IndexInfo extends Derived {
 
         public String toString() {
             return "index command " + command + " on index " + index;
-        }
-
-    }
-
-    /**
-     * A command which may override the command setting of a field for a particular index
-     */
-    private static abstract class IndexOverrider {
-
-        protected final IndexInfo owner;
-
-        public IndexOverrider(IndexInfo owner) {
-            this.owner = owner;
-        }
-
-        /**
-         * Override the setting of this index for this field, returns true if overriden, false if this index should be
-         * set according to the field
-         */
-        public abstract boolean override(String indexName, String command, ImmutableSDField field);
-
-    }
-
-    private static class StemmingOverrider extends IndexOverrider {
-
-        private final Schema schema;
-
-        public StemmingOverrider(IndexInfo owner, Schema schema) {
-            super(owner);
-            this.schema = schema;
-        }
-
-        public boolean override(String indexName, String command, ImmutableSDField field) {
-            if (schema == null) {
-                return false;
-            }
-
-            Index index = schema.getIndex(indexName);
-            if (index == null) {
-                return false;
-            }
-
-            Stemming indexStemming = index.getStemming();
-            if (indexStemming == null) {
-                return false;
-            }
-
-            if ( ! Stemming.NONE.equals(indexStemming)) {
-                owner.addIndexCommand(indexName, CMD_STEM + ":" + indexStemming.toStemMode());
-            }
-            return true;
         }
 
     }

--- a/config-model/src/main/java/com/yahoo/schema/document/ImmutableImportedSDField.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/ImmutableImportedSDField.java
@@ -160,6 +160,12 @@ public class ImmutableImportedSDField implements ImmutableSDField {
     public String getSearchLinguisticsProfile() { return importedField.targetField().getSearchLinguisticsProfile(); }
 
     @Override
+    public TokensMode getIndexLinguisticsTokens() { return importedField.targetField().getIndexLinguisticsTokens(); }
+
+    @Override
+    public TokensMode getSearchLinguisticsTokens() { return importedField.targetField().getSearchLinguisticsTokens(); }
+
+    @Override
     public ImmutableSDField getStructField(String name) {
         throw createUnsupportedException("struct");
     }
@@ -176,6 +182,25 @@ public class ImmutableImportedSDField implements ImmutableSDField {
 
     @Override
     public Stemming getStemming(Schema schema) {
+        throw createUnsupportedException("stemming");
+    }
+
+    // The tokens getters above delegate to the target field, as callers read them before deciding
+    // whether a field is imported. Resolving what they mean for stemming is not supported, as for
+    // getStemming(Schema): imported fields are attributes, which are never stemmed.
+
+    @Override
+    public Stemming getIndexStemming(Schema schema) {
+        throw createUnsupportedException("stemming");
+    }
+
+    @Override
+    public Stemming getSearchStemming(Schema schema) {
+        throw createUnsupportedException("stemming");
+    }
+
+    @Override
+    public Stemming getEffectiveSearchStemming(Schema schema) {
         throw createUnsupportedException("stemming");
     }
 

--- a/config-model/src/main/java/com/yahoo/schema/document/ImmutableSDField.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/ImmutableSDField.java
@@ -84,6 +84,10 @@ public interface ImmutableSDField {
 
     String getSearchLinguisticsProfile();
 
+    TokensMode getIndexLinguisticsTokens();
+
+    TokensMode getSearchLinguisticsTokens();
+
     ImmutableSDField getStructField(String name);
 
     Collection<? extends ImmutableSDField> getStructFields();
@@ -91,6 +95,84 @@ public interface ImmutableSDField {
     Stemming getStemming();
 
     Stemming getStemming(Schema schema);
+
+    /**
+     * Returns the stemming to use when turning the content of this field into tokens:
+     * The index side of the linguistics tokens setting of this field if set, otherwise the
+     * stemming setting of this field, or of the schema if this field has none. Never null.
+     * Not supported for imported fields, which are attributes and are never stemmed.
+     */
+    default Stemming getIndexStemming(Schema schema) {
+        TokensMode tokens = getIndexLinguisticsTokens();
+        return tokens != null ? tokens.toStemming() : getStemming(schema);
+    }
+
+    /**
+     * Returns the stemming to use when turning query terms for this field into tokens:
+     * The search side of the linguistics tokens setting of this field if set, otherwise the
+     * stemming setting of this field, or of the schema if this field has none. Never null.
+     * Not supported for imported fields, which are attributes and are never stemmed.
+     */
+    default Stemming getSearchStemming(Schema schema) {
+        TokensMode tokens = getSearchLinguisticsTokens();
+        return tokens != null ? tokens.toStemming() : getStemming(schema);
+    }
+
+    /**
+     * Returns the stemming which is in effect when searching this field, taking every setting which
+     * can influence it into account. This is what the index-info derived config tells the query side
+     * to do, so every check of the query side stemming of a field must resolve it through this:
+     * <ol>
+     *   <li>The search side of the linguistics tokens setting of this field, if set.</li>
+     *   <li>Otherwise, the stemming setting of this field, or of the schema if this field has none,
+     *       when that is {@link Stemming#NONE}: An index level setting can change how a field is
+     *       stemmed, but cannot turn stemming on for a field which has it off. Word and exact
+     *       matching rely on this, as they turn stemming off by setting it to NONE on the field.</li>
+     *   <li>Otherwise, the stemming setting of the index of this field, if any: given in an index
+     *       block in this field, or in a schema level index block of the same name.</li>
+     *   <li>Otherwise, the stemming setting of this field, or of the schema.</li>
+     * </ol>
+     * Never null. Not supported for imported fields, which are attributes and are never stemmed.
+     */
+    default Stemming getEffectiveSearchStemming(Schema schema) {
+        TokensMode tokens = getSearchLinguisticsTokens();
+        if (tokens != null) return tokens.toStemming();
+        Stemming stemming = getStemming(schema);
+        if (stemming == Stemming.NONE) return stemming;
+        Stemming indexStemming = getStemmingOfIndex(schema);
+        return indexStemming != null ? indexStemming : stemming;
+    }
+
+    /**
+     * Returns the stemming setting of the index of this field, given in an index block in this field,
+     * or otherwise in a schema level index block of the same name, or null if neither sets one.
+     * This is not consulted through {@link Schema#getIndex}, as that loses the stemming setting
+     * when consolidating a field level and a schema level block of the same name.
+     */
+    default Stemming getStemmingOfIndex(Schema schema) {
+        Index fieldIndex = getIndex(getName());
+        if (fieldIndex != null && fieldIndex.getStemming() != null) return fieldIndex.getStemming();
+        return schema.getSchemaIndex(getName()).map(Index::getStemming).orElse(null);
+    }
+
+    /**
+     * Returns whether stemming, and thereby the linguistics tokens setting, applies to this field at all:
+     * It must be a string field with text matching, and not an imported one. Every place which decides
+     * what the query side should do with the terms of a field must skip the fields where this is false,
+     * and must do so before resolving stemming: an imported field does not support that at all, and a
+     * field which cannot be stemmed must not be allowed to decide the stemming of a fieldset it is in.
+     */
+    default boolean isStemmable() {
+        if (isImportedField()) return false; // imported fields are attributes, which are not stemmed
+        // Word, exact and gram matching produce a single token, so such a field is never stemmed
+        if (getMatching().getType() != MatchType.TEXT) return false;
+        return isOfTypeOrNested(DataType.STRING);
+    }
+
+    /** Returns whether this field is of the given type, or is a collection of it. */
+    default boolean isOfTypeOrNested(DataType type) {
+        return type.equals(getDataType()) || type.equals(getDataType().getNestedType());
+    }
 
     Ranking getRanking();
 

--- a/config-model/src/main/java/com/yahoo/schema/document/SDField.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/SDField.java
@@ -101,6 +101,8 @@ public class SDField extends Field implements ImmutableSDField {
 
     private String indexLinguisticsProfile;
     private String searchLinguisticsProfile;
+    private TokensMode indexLinguisticsTokens;
+    private TokensMode searchLinguisticsTokens;
 
     /** Extra query commands of this field */
     private final List<String> queryCommands = new java.util.ArrayList<>(0);
@@ -784,6 +786,16 @@ public class SDField extends Field implements ImmutableSDField {
 
     @Override
     public String getSearchLinguisticsProfile() { return searchLinguisticsProfile; }
+
+    public void setIndexLinguisticsTokens(TokensMode tokens) { this.indexLinguisticsTokens = tokens; }
+
+    @Override
+    public TokensMode getIndexLinguisticsTokens() { return indexLinguisticsTokens; }
+
+    public void setSearchLinguisticsTokens(TokensMode tokens) { this.searchLinguisticsTokens = tokens; }
+
+    @Override
+    public TokensMode getSearchLinguisticsTokens() { return searchLinguisticsTokens; }
 
     public void addQueryCommand(String name) {
        queryCommands.add(name);

--- a/config-model/src/main/java/com/yahoo/schema/document/Stemming.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/Stemming.java
@@ -38,7 +38,7 @@ public enum Stemming {
      * @throws IllegalArgumentException if there is no stemming type with the given name
      */
     public static Stemming get(String stemmingName) {
-        return switch (stemmingName.toLowerCase(Locale.ENGLISH)) {
+        return switch (stemmingName.toLowerCase(Locale.ROOT)) {
             case "none" -> Stemming.NONE;
             case "shortest" -> Stemming.SHORTEST;
             case "best" -> Stemming.BEST;

--- a/config-model/src/main/java/com/yahoo/schema/document/TokensMode.java
+++ b/config-model/src/main/java/com/yahoo/schema/document/TokensMode.java
@@ -1,0 +1,70 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.document;
+
+import java.util.Locale;
+
+/**
+ * The tokens setting of the linguistics block of a field. This describes which tokens the
+ * linguistics implementation should produce for the content of this field: The original token
+ * only, one or more alternatives to it (stems, decompoundings, synonyms, ...), or both.
+ * <p>
+ * Each value is equivalent to a {@link Stemming} setting, and thereby to the stem mode carried
+ * by the indexing script and the index-info stem command:
+ * <pre>
+ *     original                  Stemming.NONE       StemMode.NONE
+ *     first-alternative         Stemming.BEST       StemMode.BEST
+ *     alternatives              Stemming.ALL_STEMS  StemMode.ALL_STEMS
+ *     original-and-alternatives Stemming.MULTIPLE   StemMode.ALL
+ * </pre>
+ * {@link Stemming#SHORTEST} is deliberately not expressible here, so a field which sets tokens
+ * cannot ask for it: tokens takes precedence over the stemming setting of the same field.
+ *
+ * @author arnej27959
+ */
+public enum TokensMode {
+
+    /** Produce the original token only */
+    ORIGINAL("original", Stemming.NONE),
+
+    /** Produce the "best" alternative to the original token */
+    FIRST_ALTERNATIVE("first-alternative", Stemming.BEST),
+
+    /** Produce all the alternatives to the original token, but not the original */
+    ALTERNATIVES("alternatives", Stemming.ALL_STEMS),
+
+    /** Produce all the alternatives to the original token, and the original */
+    ORIGINAL_AND_ALTERNATIVES("original-and-alternatives", Stemming.MULTIPLE);
+
+    private final String name;
+    private final Stemming stemming;
+
+    /**
+     * Returns the tokens mode for the given string.
+     * The legal names are the dashed names of the values: original, first-alternative, alternatives
+     * and original-and-alternatives, in any capitalization.
+     *
+     * @throws IllegalArgumentException if there is no tokens mode with the given name
+     */
+    public static TokensMode get(String tokensName) {
+        String name = tokensName.toLowerCase(Locale.ROOT);
+        for (TokensMode mode : values())
+            if (mode.name.equals(name)) return mode;
+        throw new IllegalArgumentException("'" + tokensName + "' is not a valid tokens setting");
+    }
+
+    TokensMode(String name, Stemming stemming) {
+        this.name = name;
+        this.stemming = stemming;
+    }
+
+    public String getName() { return name; }
+
+    @Override
+    public String toString() {
+        return "tokens " + getName();
+    }
+
+    /** Returns the equivalent stemming setting of this. */
+    public Stemming toStemming() { return stemming; }
+
+}

--- a/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
@@ -216,6 +216,8 @@ public class ConvertParsedFields {
         parsed.getNormalizing().ifPresent(value -> convertNormalizing(field, value));
         parsed.getIndexLinguisticsProfile().ifPresent(value -> field.setIndexLinguisticsProfile(value));
         parsed.getSearchLinguisticsProfile().ifPresent(value -> field.setSearchLinguisticsProfile(value));
+        parsed.getIndexLinguisticsTokens().ifPresent(value -> field.setIndexLinguisticsTokens(value));
+        parsed.getSearchLinguisticsTokens().ifPresent(value -> field.setSearchLinguisticsTokens(value));
         for (var attribute : parsed.getAttributes()) {
             convertAttribute(schema, field, attribute);
         }

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedField.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedField.java
@@ -2,6 +2,7 @@
 package com.yahoo.schema.parser;
 
 import com.yahoo.schema.document.Stemming;
+import com.yahoo.schema.document.TokensMode;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,6 +31,8 @@ public class ParsedField extends ParsedBlock {
     private String normalizing = null;
     private String searchLinguisticsProfile;
     private String indexLinguisticsProfile;
+    private TokensMode searchLinguisticsTokens;
+    private TokensMode indexLinguisticsTokens;
     private final ParsedMatchSettings matchInfo = new ParsedMatchSettings();
     private Stemming stemming = null;
     private ParsedIndexingOp indexingOp = null;
@@ -70,6 +73,8 @@ public class ParsedField extends ParsedBlock {
     Optional<String> getNormalizing() { return Optional.ofNullable(normalizing); }
     Optional<String> getIndexLinguisticsProfile() { return Optional.ofNullable(indexLinguisticsProfile); }
     Optional<String> getSearchLinguisticsProfile() { return Optional.ofNullable(searchLinguisticsProfile); }
+    Optional<TokensMode> getIndexLinguisticsTokens() { return Optional.ofNullable(indexLinguisticsTokens); }
+    Optional<TokensMode> getSearchLinguisticsTokens() { return Optional.ofNullable(searchLinguisticsTokens); }
     Optional<ParsedIndexingOp> getIndexing() { return Optional.ofNullable(indexingOp); }
     Optional<ParsedSorting> getSorting() { return Optional.ofNullable(sortSettings); }
     Map<String, String> getRankTypes() { return Collections.unmodifiableMap(rankTypes); }
@@ -129,8 +134,22 @@ public class ParsedField extends ParsedBlock {
     public void setLiteral(boolean value) { this.isLiteral = value; }
     public void setNormal(boolean value) { this.isNormal = value; }
     public void setNormalizing(String value) { this.normalizing = value; }
-    public void setIndexLinguisticsProfile(String profile) { this.indexLinguisticsProfile = profile; }
-    public void setSearchLinguisticsProfile(String profile) { this.searchLinguisticsProfile = profile; }
+    public void setIndexLinguisticsProfile(String profile) {
+        verifyThat(indexLinguisticsProfile == null, "already has linguistics profile for index", indexLinguisticsProfile);
+        this.indexLinguisticsProfile = profile;
+    }
+    public void setSearchLinguisticsProfile(String profile) {
+        verifyThat(searchLinguisticsProfile == null, "already has linguistics profile for search", searchLinguisticsProfile);
+        this.searchLinguisticsProfile = profile;
+    }
+    public void setIndexLinguisticsTokens(TokensMode tokens) {
+        verifyThat(indexLinguisticsTokens == null, "already has linguistics tokens for index");
+        this.indexLinguisticsTokens = tokens;
+    }
+    public void setSearchLinguisticsTokens(TokensMode tokens) {
+        verifyThat(searchLinguisticsTokens == null, "already has linguistics tokens for search");
+        this.searchLinguisticsTokens = tokens;
+    }
     public void setStemming(Stemming stemming) { this.stemming = stemming; }
     public void setWeight(int weight) { this.weight = weight; }
 

--- a/config-model/src/main/java/com/yahoo/schema/parser/ParsedLinguistics.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ParsedLinguistics.java
@@ -1,0 +1,55 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.parser;
+
+import com.yahoo.schema.document.TokensMode;
+
+/**
+ * The linguistics settings which can be given for one side (indexing or searching) of a field,
+ * as extracted when parsing a "linguistics" block.  Do not put advanced logic here!
+ *
+ * @author arnej27959
+ */
+public class ParsedLinguistics extends ParsedBlock {
+
+    private String profile = null;
+    private TokensMode tokens = null;
+    private boolean opened = false;
+
+    public ParsedLinguistics(String fieldName, String blockType) {
+        super(fieldName, blockType);
+    }
+
+    public String profile() { return profile; }
+    public TokensMode tokens() { return tokens; }
+
+    /** Returns whether the block holding these settings has been opened. */
+    public boolean isOpened() { return opened; }
+
+    public void setProfile(String profile) {
+        verifyThat(this.profile == null, "already has profile", this.profile);
+        this.profile = profile;
+    }
+
+    public void setTokens(TokensMode tokens) {
+        verifyThat(this.tokens == null, "already has tokens", this.tokens == null ? "" : this.tokens.getName());
+        this.tokens = tokens;
+    }
+
+    /** Records that the block holding these settings is opened. There can only be one of each. */
+    public void openBlock() {
+        verifyThat(! opened, "is given more than once");
+        opened = true;
+    }
+
+    /** Verifies that no profile is set in this, for the given reason. */
+    public void verifyNoProfile(String reason) {
+        verifyThat(profile == null, reason);
+    }
+
+    /** Sets any setting not set in this from the given settings. */
+    public void mergeDefaultsFrom(ParsedLinguistics other) {
+        if (profile == null) profile = other.profile();
+        if (tokens == null) tokens = other.tokens();
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/schema/processing/FieldSetSettings.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/FieldSetSettings.java
@@ -2,19 +2,23 @@
 package com.yahoo.schema.processing;
 
 import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.document.DataType;
 import com.yahoo.document.TensorDataType;
 import com.yahoo.schema.RankProfileRegistry;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.document.FieldSet;
 import com.yahoo.schema.document.ImmutableSDField;
+import com.yahoo.schema.document.MatchType;
 import com.yahoo.schema.document.Matching;
 import com.yahoo.schema.document.NormalizeLevel;
 import com.yahoo.schema.document.SDField;
 import com.yahoo.schema.document.Stemming;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 
@@ -45,7 +49,9 @@ public class FieldSetSettings extends Processor {
                 checkFieldNames(schema, fieldSet);
             checkMatching(schema, fieldSet);
             checkNormalization(schema, fieldSet);
+            checkLinguisticsTokens(schema, fieldSet);
             checkStemming(schema, fieldSet);
+            checkUnstemmedTextMix(schema, fieldSet);
             checkTypes(schema, fieldSet);
             assignLinguistics(schema, fieldSet);
         }
@@ -126,19 +132,64 @@ public class FieldSetSettings extends Processor {
         Stemming stemming = null;
         for (String fieldName : fieldSet.getFieldNames()) {
             ImmutableSDField field = schema.getField(fieldName);
-            Stemming fieldStemming = field.getStemming();
+            if ( ! field.isStemmable()) continue; // stemming does not apply to this field
+            Stemming fieldStemming = field.getEffectiveSearchStemming(schema);
             if (stemming == null) {
                 stemming = fieldStemming;
             } else {
                 if ( ! stemming.equals(fieldStemming)) {
                     warn(schema, field.asField(),
                          "The stemming settings for the fields in the fieldset '" + fieldSet.getName()+
-                         "' are inconsistent (explicitly or because of field type). " +
+                         "' are inconsistent. " +
                          "This may lead to recall and ranking issues. " +
                          "See " + fieldSetDocUrl);
                 }
             }
         }
+    }
+
+    /**
+     * The query terms of a fieldset are stemmed if any of its fields is stemmed, but a field which
+     * holds text that is not stemmed - a uri field, or an imported one, which is an attribute - will
+     * then not match those terms. Warn about that mix, which is silent otherwise: unlike a word,
+     * exact or gram matched field, such a field is text matched, so checkMatching sees nothing wrong
+     * with it. Fields which are not stemmed because of their matching are left to checkMatching, and
+     * fields which hold no text at all are not warned about: stemming a query term does not change
+     * whether it matches the content of, say, an int field.
+     */
+    private void checkUnstemmedTextMix(Schema schema, FieldSet fieldSet) {
+        if ( ! isStemmed(schema, fieldSet)) return;
+        for (String fieldName : fieldSet.getFieldNames()) {
+            ImmutableSDField field = schema.getField(fieldName);
+            if ( ! holdsUnstemmedText(field)) continue;
+            warn(schema, field.asField(),
+                 "The fields in " + fieldSet + " are stemmed when searched, but the content of this " +
+                 "field is not stemmed, so it will not match a stemmed term. " +
+                 "This may lead to recall and ranking issues. " +
+                 "See " + fieldSetDocUrl);
+        }
+    }
+
+    /** Returns whether the query terms of this fieldset are stemmed, as IndexInfo decides it. */
+    private static boolean isStemmed(Schema schema, FieldSet fieldSet) {
+        boolean anyStemmed = false;
+        for (String fieldName : fieldSet.getFieldNames()) {
+            ImmutableSDField field = schema.getField(fieldName);
+            // A word or exact matched field makes the whole fieldset match that way, and then
+            // IndexInfo emits no stem command for it at all
+            MatchType matching = field.getMatching().getType();
+            if (matching == MatchType.WORD || matching == MatchType.EXACT) return false;
+            if (field.isStemmable() && field.getEffectiveSearchStemming(schema) != Stemming.NONE)
+                anyStemmed = true;
+        }
+        return anyStemmed;
+    }
+
+    /** Returns whether this field holds text which is tokenized, but never stemmed. */
+    private static boolean holdsUnstemmedText(ImmutableSDField field) {
+        if (field.isStemmable()) return false; // stemmed, or inconsistent in a way checkStemming reports
+        if (field.getMatching().getType() != MatchType.TEXT) return false; // checkMatching reports these
+        return field.isOfTypeOrNested(DataType.STRING) || field.isOfTypeOrNested(DataType.URI);
     }
 
     private void checkTypes(Schema schema, FieldSet fieldSet) {
@@ -170,9 +221,40 @@ public class FieldSetSettings extends Processor {
                                                    "Illegal mixing of linguistics search profiles: " +
                                                    firstField + " sets '" + firstField.getSearchLinguisticsProfile() + "'" +
                                                    ", while " + field + " sets '" + field.getSearchLinguisticsProfile() + "'");
-
         }
         fieldSet.setLinguisticsProfile(firstField.getSearchLinguisticsProfile());
+    }
+
+    /**
+     * The fields of a fieldset are searched as one index, so they must agree on which tokens the
+     * query terms are turned into. This is an error when a 'tokens' setting is in play, and just a
+     * warning (see checkStemming) when it follows from plain stemming settings.
+     * <p>
+     * Both compare what the query side will actually do, as resolved by
+     * {@link ImmutableSDField#getEffectiveSearchStemming}, which is also what IndexInfo emits:
+     * an index level stemming setting must count here exactly as it counts there.
+     * <p>
+     * Every field is compared with every field before it, not just with the first one: comparing
+     * with the first only makes the outcome depend on the order of the fields of the fieldset.
+     */
+    private void checkLinguisticsTokens(Schema schema, FieldSet fieldSet) {
+        List<ImmutableSDField> checked = new ArrayList<>();
+        for (String fieldName : fieldSet.getFieldNames()) {
+            ImmutableSDField field = schema.getField(fieldName);
+            if ( ! field.isStemmable()) continue; // tokens does not apply to this field
+            Stemming fieldStemming = field.getEffectiveSearchStemming(schema);
+            for (ImmutableSDField earlier : checked) {
+                // Inconsistency which follows from plain stemming settings alone is only warned about
+                if (earlier.getSearchLinguisticsTokens() == null && field.getSearchLinguisticsTokens() == null) continue;
+                Stemming earlierStemming = earlier.getEffectiveSearchStemming(schema);
+                if ( ! earlierStemming.equals(fieldStemming))
+                    throw new IllegalArgumentException(forFieldSet(schema, fieldSet) +
+                                                       "Illegal mixing of linguistics search tokens/stemming settings: " +
+                                                       earlier + " resolves to '" + earlierStemming + "'" +
+                                                       ", while " + field + " resolves to '" + fieldStemming + "'");
+            }
+            checked.add(field);
+        }
     }
 
     private String forFieldSet(Schema schema, FieldSet fieldSet) {

--- a/config-model/src/main/java/com/yahoo/schema/processing/LinguisticsSettings.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/LinguisticsSettings.java
@@ -1,0 +1,128 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.processing;
+
+import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.document.DataType;
+import com.yahoo.schema.RankProfileRegistry;
+import com.yahoo.schema.Schema;
+import com.yahoo.schema.document.MatchType;
+import com.yahoo.schema.document.SDField;
+import com.yahoo.schema.document.Stemming;
+import com.yahoo.schema.document.TokensMode;
+import com.yahoo.vespa.model.container.search.QueryProfiles;
+
+/**
+ * Validates the linguistics settings of fields, and clears the tokens setting of fields which
+ * cannot produce alternative tokens, such that all the places which resolve the stemming of a
+ * field agree on the outcome.
+ * <p>
+ * This must run after the match type of a field is final (which it is after
+ * {@link AttributesImplicitWord}), and before {@link WordMatch}, {@link ExactMatch} and
+ * {@link NGramMatch} force the stemming of a field to NONE: until then the stemming setting of a
+ * field is still exactly what the user wrote, which is what the warnings here report on.
+ *
+ * @author arnej27959
+ */
+public class LinguisticsSettings extends Processor {
+
+    public LinguisticsSettings(Schema schema, DeployLogger deployLogger,
+                               RankProfileRegistry rankProfileRegistry, QueryProfiles queryProfiles) {
+        super(schema, deployLogger, rankProfileRegistry, queryProfiles);
+    }
+
+    @Override
+    public void process(boolean validate, boolean documentsOnly) {
+        if (documentsOnly) return;
+        // Struct fields are not visited: a linguistics block is only accepted in a field body,
+        // and its settings are not propagated to the struct fields of that field
+        for (SDField field : schema.allConcreteFields()) {
+            processField(field, validate);
+        }
+    }
+
+    private void processField(SDField field, boolean validate) {
+        if (field.getIndexLinguisticsTokens() == null && field.getSearchLinguisticsTokens() == null) return;
+
+        String cannotProduceAlternatives = cannotProduceAlternatives(field);
+        if (cannotProduceAlternatives != null) {
+            if (validate)
+                warn(schema, field,
+                     "tokens is set in the linguistics block, but " + cannotProduceAlternatives +
+                     ", so it is ignored.");
+            field.setIndexLinguisticsTokens(null);
+            field.setSearchLinguisticsTokens(null);
+            return;
+        }
+        if ( ! validate) return;
+
+        warnAboutOneSidedTokens(field);
+        warnAboutIgnoredStemming(field);
+        warnAboutIgnoredIndexStemming(field);
+    }
+
+    /**
+     * Returns why this field cannot produce alternatives to the original token, or null if it can.
+     * Word, exact and gram matching, and uri fields, are not compatible with stemming: WordMatch,
+     * ExactMatch, NGramMatch and UriHack all force the stemming of such fields to NONE.
+     */
+    private String cannotProduceAlternatives(SDField field) {
+        if (field.isOfTypeOrNested(DataType.URI))
+            return "this is a uri field, which is not tokenized by the linguistics implementation";
+        if ( ! field.isOfTypeOrNested(DataType.STRING))
+            return "this is not a string field";
+        MatchType matchType = field.getMatching().getType();
+        if (matchType != MatchType.TEXT)
+            return "matching is " + matchType.toString().toLowerCase() + ", which produces a single token";
+        return null;
+    }
+
+    private void warnAboutOneSidedTokens(SDField field) {
+        boolean indexTokensSet = field.getIndexLinguisticsTokens() != null;
+        boolean searchTokensSet = field.getSearchLinguisticsTokens() != null;
+        if (indexTokensSet == searchTokensSet) return;
+
+        String setFor = indexTokensSet ? "indexing" : "searching";
+        String notSetFor = indexTokensSet ? "searching" : "indexing";
+        warn(schema, field,
+             "tokens is set for " + setFor + " but not for " + notSetFor + ", which will use the " +
+             "stemming setting instead. This may lead to recall issues.");
+    }
+
+    /**
+     * The stemming setting of the field loses to its tokens setting: say so, but only for the
+     * sides where the two actually differ. A stemming setting which says the same as tokens is
+     * redundant, not ignored, and not worth a warning.
+     */
+    private void warnAboutIgnoredStemming(SDField field) {
+        Stemming stemming = field.getStemming();
+        if (stemming == null) return;
+
+        boolean ignoredWhenIndexing = overrides(field.getIndexLinguisticsTokens(), stemming);
+        boolean ignoredWhenSearching = overrides(field.getSearchLinguisticsTokens(), stemming);
+        if ( ! ignoredWhenIndexing && ! ignoredWhenSearching) return;
+
+        String ignoredWhen = ignoredWhenIndexing && ignoredWhenSearching ? ""
+                                                                         : ignoredWhenIndexing ? " when indexing" : " when searching";
+        warn(schema, field,
+             "stemming: " + stemming.getName() + " is ignored" + ignoredWhen +
+             " because this field sets tokens in its linguistics block.");
+    }
+
+    /** Returns whether the given tokens setting is set and says something else than the given stemming. */
+    private static boolean overrides(TokensMode tokens, Stemming stemming) {
+        return tokens != null && tokens.toStemming() != stemming;
+    }
+
+    /** An index level stemming setting loses to the tokens setting of the field: say so, if they differ. */
+    private void warnAboutIgnoredIndexStemming(SDField field) {
+        TokensMode tokens = field.getSearchLinguisticsTokens();
+        if (tokens == null) return;
+
+        Stemming indexStemming = field.getStemmingOfIndex(schema);
+        if (indexStemming == null || indexStemming == tokens.toStemming()) return;
+        warn(schema, field,
+             "stemming: " + indexStemming.getName() + " of index '" + field.getName() +
+             "' is ignored because this field sets tokens in its linguistics block.");
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/schema/processing/Processing.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/Processing.java
@@ -43,6 +43,7 @@ public class Processing {
                 OptimizeIlscript::new,
                 ValidateFieldWithIndexSettingsCreatesIndex::new,
                 AttributesImplicitWord::new,
+                LinguisticsSettings::new,
                 MutableAttributes::new,
                 CreatePositionZCurve::new,
                 DictionaryProcessor::new,

--- a/config-model/src/main/java/com/yahoo/schema/processing/TextMatch.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/TextMatch.java
@@ -9,7 +9,6 @@ import com.yahoo.schema.Schema;
 import com.yahoo.schema.document.Case;
 import com.yahoo.schema.document.MatchType;
 import com.yahoo.schema.document.SDField;
-import com.yahoo.schema.document.Stemming;
 import com.yahoo.vespa.indexinglanguage.ExpressionConverter;
 import com.yahoo.vespa.indexinglanguage.ExpressionVisitor;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
@@ -38,11 +37,7 @@ public class TextMatch extends Processor {
             ScriptExpression script = field.getIndexingScript();
             if (script == null) continue;
 
-            DataType fieldType = field.getDataType();
-            if (fieldType instanceof CollectionDataType) {
-                fieldType = fieldType.getNestedType();
-            }
-            if (fieldType != DataType.STRING) continue;
+            if ( ! field.isOfTypeOrNested(DataType.STRING)) continue;
 
             MyVisitor visitor = new MyVisitor();
             visitor.visit(script);
@@ -55,11 +50,7 @@ public class TextMatch extends Processor {
 
     private AnnotatorConfig findAnnotatorConfig(Schema schema, SDField field) {
         AnnotatorConfig config = new AnnotatorConfig();
-        Stemming activeStemming = field.getStemming();
-        if (activeStemming == null) {
-            activeStemming = schema.getStemming();
-        }
-        config.setStemMode(activeStemming.toStemMode());
+        config.setStemMode(field.getIndexStemming(schema).toStemMode());
         config.setRemoveAccents(field.getNormalizing().doRemoveAccents());
         config.setLowercase(field.getMatching().getCase() != Case.CASED);
         config.setProfile(field.getIndexLinguisticsProfile());

--- a/config-model/src/main/java/com/yahoo/schema/processing/multifieldresolver/StemmingResolver.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/multifieldresolver/StemmingResolver.java
@@ -28,11 +28,13 @@ public class StemmingResolver extends MultiFieldResolver {
         Stemming stemming = null;
         SDField stemmingField = null;
         for (SDField field : fields) {
-            if (stemming == null && stemmingField==null) {
-                stemming = field.getStemming(schema);
+            // These fields are indexed into a shared index, so it is the index side which must agree
+            Stemming fieldStemming = field.getIndexStemming(schema);
+            if (stemming == null && stemmingField == null) {
+                stemming = fieldStemming;
                 stemmingField = field;
-            } else if (stemming != field.getStemming(schema)) {
-                deployLogger.logApplicationPackage(Level.WARNING, "Field '" + field.getName() + "' has " + field.getStemming(schema) +
+            } else if (stemming != fieldStemming) {
+                deployLogger.logApplicationPackage(Level.WARNING, "Field '" + field.getName() + "' has " + fieldStemming +
                                                                   ", whereas field '" + stemmingField.getName() + "' has " + stemming +
                                                                   ". All fields indexing to the index '" + indexName + "' must have the same stemming." +
                                                                   " This should be corrected as it will make indexing fail in a few cases.");

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/search/IndexingScriptChangeMessageBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/search/IndexingScriptChangeMessageBuilder.java
@@ -56,8 +56,9 @@ public class IndexingScriptChangeMessageBuilder {
     }
 
     private void checkStemming(ChangeMessageBuilder builder) {
-        Stemming currentStemming = currentField.getStemming(currentSchema);
-        Stemming nextStemming = nextField.getStemming(nextSchema);
+        // This explains a change to an indexing script, so it is the index side which matters
+        Stemming currentStemming = currentField.getIndexStemming(currentSchema);
+        Stemming nextStemming = nextField.getIndexStemming(nextSchema);
         if (currentStemming != nextStemming) {
             builder.addChange("stemming", currentStemming.getName(), nextStemming.getName());
         }

--- a/config-model/src/main/javacc/SchemaParser.jj
+++ b/config-model/src/main/javacc/SchemaParser.jj
@@ -34,6 +34,7 @@ import com.yahoo.schema.document.MatchAlgorithm;
 import com.yahoo.schema.document.HnswIndexParams;
 import com.yahoo.schema.document.Sorting;
 import com.yahoo.schema.document.Stemming;
+import com.yahoo.schema.document.TokensMode;
 import com.yahoo.searchlib.ranking.features.FeatureNames;
 import com.yahoo.schema.fieldoperation.IndexingOperation;
 import com.yahoo.search.schema.RankProfile.InputType;
@@ -943,28 +944,70 @@ void indexingOperation(ParsedField field, boolean multiLine) : { }
  */
 void linguistics(ParsedField field) :
 {
-    String indexProfile = null;
-    String searchProfile = null;
+    ParsedLinguistics common = new ParsedLinguistics(field.name(), "linguistics");
+    ParsedLinguistics indexed = new ParsedLinguistics(field.name(), "linguistics index");
+    ParsedLinguistics searched = new ParsedLinguistics(field.name(), "linguistics search");
+    ParsedLinguistics profileBlock = new ParsedLinguistics(field.name(), "linguistics profile");
+    String str;
 }
 {
-    <LINGUISTICS> lbrace() <PROFILE> (
-      ( <COLON> indexProfile = identifier() (<NL>)* )
-      |
-      ( lbrace()
-          (
-              ( <INDEX>  <COLON> indexProfile  = identifier() (<NL>)* ) |
-              ( <SEARCH> <COLON> searchProfile = identifier() (<NL>)* )
-          )+
-        <RBRACE> (<NL>)*
+    <LINGUISTICS> lbrace()
+    (
+      ( <PROFILE>
+        (
+          ( <COLON> str = identifier() { common.setProfile(str); } (<NL>)* )
+          |
+          // Alternative form: profile { index: ... search: ... }
+          ( lbrace() { profileBlock.openBlock(); }
+              (
+                  ( <INDEX>  <COLON> str = identifier() { indexed.setProfile(str); }  (<NL>)* ) |
+                  ( <SEARCH> <COLON> str = identifier() { searched.setProfile(str); } (<NL>)* )
+              )+
+            <RBRACE> (<NL>)*
+          )
+        )
       )
-    )
+      |
+      ( <TOKENS> <COLON> str = identifierWithDash() { common.setTokens(TokensMode.get(str)); } (<NL>)* )
+      |
+      ( <INDEX>  lbrace() { indexed.openBlock(); }  ( linguisticsSettings(indexed)  )+ <RBRACE> (<NL>)* )
+      |
+      ( <SEARCH> lbrace() { searched.openBlock(); } ( linguisticsSettings(searched) )+ <RBRACE> (<NL>)* )
+    )+
     <RBRACE>
     {
-      if (searchProfile == null)
-          searchProfile = indexProfile;
-      field.setSearchLinguisticsProfile(searchProfile);
-      field.setIndexLinguisticsProfile(indexProfile);
+      if (profileBlock.isOpened()) {
+          // The legacy profile { index: ... search: ... } form is a way of saying the same thing,
+          // so it cannot be combined with any other way of setting a profile
+          common.verifyNoProfile("cannot set both a profile and a profile block");
+          // In this form the search profile defaults to the index profile
+          if (searched.profile() == null && indexed.profile() != null)
+              searched.setProfile(indexed.profile());
+      }
+      indexed.mergeDefaultsFrom(common);
+      searched.mergeDefaultsFrom(common);
+      // Only set what this block actually says, so a second linguistics block on the same
+      // field does not silently clear what the first one set
+      if (indexed.profile() != null)  field.setIndexLinguisticsProfile(indexed.profile());
+      if (searched.profile() != null) field.setSearchLinguisticsProfile(searched.profile());
+      if (indexed.tokens() != null)   field.setIndexLinguisticsTokens(indexed.tokens());
+      if (searched.tokens() != null)  field.setSearchLinguisticsTokens(searched.tokens());
     }
+}
+
+/**
+ * The settings which can be given for one side (indexing or searching) of a linguistics block.
+ */
+void linguisticsSettings(ParsedLinguistics settings) :
+{
+    String str;
+}
+{
+    (
+      ( <PROFILE> <COLON> str = identifier()         { settings.setProfile(str); } )
+      |
+      ( <TOKENS>  <COLON> str = identifierWithDash() { settings.setTokens(TokensMode.get(str)); } )
+    ) (<NL>)*
 }
 
 /**

--- a/config-model/src/test/examples/indexsettings.sd
+++ b/config-model/src/test/examples/indexsettings.sd
@@ -35,6 +35,26 @@ search indexsettings {
         }
     }
 
+    field l3 type string {
+        linguistics {
+            profile: p1
+            tokens: alternatives
+        }
+    }
+
+    field l4 type string {
+        linguistics {
+            index {
+                profile: p2
+                tokens: original
+            }
+            search {
+                profile: p1
+                tokens: original-and-alternatives
+            }
+        }
+    }
+
   }
 
 }

--- a/config-model/src/test/java/com/yahoo/schema/IndexSettingsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/IndexSettingsTestCase.java
@@ -3,6 +3,7 @@ package com.yahoo.schema;
 
 import com.yahoo.schema.document.SDField;
 import com.yahoo.schema.document.Stemming;
+import com.yahoo.schema.document.TokensMode;
 import com.yahoo.schema.parser.ParseException;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,7 @@ import java.io.IOException;
 
 import static com.yahoo.config.model.test.TestUtil.joinLines;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -34,6 +36,33 @@ public class IndexSettingsTestCase extends AbstractSchemaTestCase {
 
         SDField multiStemmed = (SDField) schema.getDocument().getField("multiplestems");
         assertEquals(Stemming.MULTIPLE, multiStemmed.getStemming(schema));
+    }
+
+    @Test
+    void testLinguisticsSettings() throws IOException, ParseException {
+        Schema schema = ApplicationBuilder.buildFromFile("src/test/examples/indexsettings.sd");
+
+        SDField l1 = (SDField) schema.getDocument().getField("l1");
+        assertEquals("p1", l1.getIndexLinguisticsProfile());
+        assertEquals("p1", l1.getSearchLinguisticsProfile());
+        assertNull(l1.getIndexLinguisticsTokens());
+        assertNull(l1.getSearchLinguisticsTokens());
+
+        SDField l2 = (SDField) schema.getDocument().getField("l2");
+        assertEquals("p2", l2.getIndexLinguisticsProfile());
+        assertEquals("p1", l2.getSearchLinguisticsProfile());
+
+        SDField l3 = (SDField) schema.getDocument().getField("l3");
+        assertEquals("p1", l3.getIndexLinguisticsProfile());
+        assertEquals("p1", l3.getSearchLinguisticsProfile());
+        assertEquals(TokensMode.ALTERNATIVES, l3.getIndexLinguisticsTokens());
+        assertEquals(TokensMode.ALTERNATIVES, l3.getSearchLinguisticsTokens());
+
+        SDField l4 = (SDField) schema.getDocument().getField("l4");
+        assertEquals("p2", l4.getIndexLinguisticsProfile());
+        assertEquals("p1", l4.getSearchLinguisticsProfile());
+        assertEquals(TokensMode.ORIGINAL, l4.getIndexLinguisticsTokens());
+        assertEquals(TokensMode.ORIGINAL_AND_ALTERNATIVES, l4.getSearchLinguisticsTokens());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/SchemaTestCase.java
@@ -6,7 +6,9 @@ import com.yahoo.search.config.IndexInfoConfig;
 import com.yahoo.search.config.SchemaInfoConfig;
 import com.yahoo.searchlib.ranking.features.FeatureNames;
 import com.yahoo.schema.derived.DerivedConfiguration;
+import com.yahoo.schema.document.ImmutableSDField;
 import com.yahoo.schema.document.Stemming;
+import com.yahoo.schema.document.TokensMode;
 import com.yahoo.schema.parser.ParseException;
 import com.yahoo.schema.processing.ImportedFieldsResolver;
 import com.yahoo.schema.processing.OnnxModelTypeResolver;
@@ -23,6 +25,8 @@ import static com.yahoo.config.model.test.TestUtil.joinLines;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -739,6 +743,371 @@ public class SchemaTestCase {
     }
 
     @Test
+    void testLinguisticsTokens() throws Exception {
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            linguistics {
+                                profile: p1
+                                tokens: alternatives
+                            }
+                        }
+                        field s2 type string {
+                            indexing: index
+                            linguistics {
+                                index {
+                                    profile: p2
+                                    tokens: alternatives
+                                }
+                                search {
+                                    profile: p3
+                                    tokens: original-and-alternatives
+                                }
+                            }
+                        }
+                        field s3 type string {
+                            indexing: index
+                            linguistics {
+                                tokens: original
+                            }
+                        }
+                        field s4 type string {
+                            indexing: index
+                            linguistics {
+                                profile: p4
+                                tokens: first-alternative
+                                search {
+                                    tokens: original
+                                }
+                            }
+                        }
+                    }
+                }""";
+        ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+        builder.addSchema(schema);
+        var application = builder.build(true);
+        var derived = new DerivedConfiguration(application.schemas().get("doc"), application.rankProfileRegistry());
+
+        var ilConfigBuilder = new IlscriptsConfig.Builder();
+        derived.getIndexingScript().getConfig(ilConfigBuilder);
+        var ilscript = ilConfigBuilder.build().ilscript().get(0);
+        assertEquals("clear_state | guard { input s1 | tokenize normalize profile:\"p1\" stem:\"ALL_STEMS\" | index s1; }",
+                     ilscript.content(0));
+        assertEquals("clear_state | guard { input s2 | tokenize normalize profile:\"p2\" stem:\"ALL_STEMS\" | index s2; }",
+                     ilscript.content(1));
+        // tokens: original means no stemming, which is not written to the script
+        assertEquals("clear_state | guard { input s3 | tokenize normalize | index s3; }",
+                     ilscript.content(2));
+        // the common setting applies to indexing, the search block only overrides searching
+        assertEquals("clear_state | guard { input s4 | tokenize normalize profile:\"p4\" stem:\"BEST\" | index s4; }",
+                     ilscript.content(3));
+
+        var indexInfoConfigBuilder = new IndexInfoConfig.Builder();
+        derived.getIndexInfo().getConfig(indexInfoConfigBuilder);
+        var config = indexInfoConfigBuilder.build();
+        assertCommand("s1", "stem:ALL_STEMS", config);
+        assertCommand("s2", "stem:ALL", config);
+        assertCommand("s2", "linguistics-profile p3", config);
+        assertNoCommand("s3", "stem:NONE", config);
+        assertNoCommand("s3", "stem:BEST", config);
+        assertNoCommand("s4", "stem:BEST", config);
+    }
+
+    @Test
+    void testLinguisticsTokensOverridesStemming() throws Exception {
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            stemming: shortest
+                            linguistics {
+                                tokens: alternatives
+                            }
+                        }
+                    }
+                }""";
+        var logger = new DeployLoggerStub();
+        ApplicationBuilder builder = new ApplicationBuilder(logger);
+        builder.addSchema(schema);
+        var application = builder.build(true);
+        var derived = new DerivedConfiguration(application.schemas().get("doc"), application.rankProfileRegistry());
+
+        var ilConfigBuilder = new IlscriptsConfig.Builder();
+        derived.getIndexingScript().getConfig(ilConfigBuilder);
+        assertEquals("clear_state | guard { input s1 | tokenize normalize stem:\"ALL_STEMS\" | index s1; }",
+                     ilConfigBuilder.build().ilscript().get(0).content(0));
+        assertTrue(logger.entries.stream().anyMatch(entry -> entry.message.contains("stemming: shortest is ignored")),
+                   "Expected a warning about the ignored stemming setting, got " + logger.entries);
+    }
+
+    @Test
+    void testLinguisticsTokensSetForOneSideOnly() throws Exception {
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            linguistics {
+                                index {
+                                    tokens: alternatives
+                                }
+                            }
+                        }
+                        field s2 type string {
+                            indexing: index
+                            linguistics {
+                                search {
+                                    tokens: alternatives
+                                }
+                            }
+                        }
+                        field s3 type string {
+                            indexing: index
+                            linguistics {
+                                tokens: alternatives
+                            }
+                        }
+                    }
+                }""";
+        var logger = new DeployLoggerStub();
+        ApplicationBuilder builder = new ApplicationBuilder(logger);
+        builder.addSchema(schema);
+        builder.build(true);
+
+        assertEquals(List.of("For schema 'doc', field 's1': tokens is set for indexing but not for searching, " +
+                             "which will use the stemming setting instead. This may lead to recall issues.",
+                             "For schema 'doc', field 's2': tokens is set for searching but not for indexing, " +
+                             "which will use the stemming setting instead. This may lead to recall issues."),
+                     logger.entries.stream().map(entry -> entry.message).toList());
+    }
+
+    @Test
+    void testIllegalLinguisticsTokens() throws Exception {
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            linguistics {
+                                tokens: shortest
+                            }
+                        }
+                    }
+                }""";
+        try {
+            ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+            builder.addSchema(schema);
+            builder.build(true);
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("'shortest' is not a valid tokens setting"),
+                       "Unexpected message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testDuplicateLinguisticsTokensIsIllegal() throws Exception {
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            linguistics {
+                                tokens: alternatives
+                                tokens: original
+                            }
+                        }
+                    }
+                }""";
+        try {
+            ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+            builder.addSchema(schema);
+            builder.build(true);
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("linguistics 's1' error: already has tokens alternatives"),
+                       "Unexpected message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testDuplicateLinguisticsProfileIsIllegal() throws Exception {
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            linguistics {
+                                profile: p1
+                                profile: p2
+                            }
+                        }
+                    }
+                }""";
+        try {
+            ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+            builder.addSchema(schema);
+            builder.build(true);
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("linguistics 's1' error: already has profile p1"),
+                       "Unexpected message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testRepeatedLinguisticsIndexBlockIsIllegal() throws Exception {
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            linguistics {
+                                index {
+                                    tokens: alternatives
+                                }
+                                index {
+                                    tokens: original
+                                }
+                            }
+                        }
+                    }
+                }""";
+        try {
+            ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+            builder.addSchema(schema);
+            builder.build(true);
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("linguistics index 's1' error: is given more than once"),
+                       "Unexpected message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testDuplicateLinguisticsProfileForIndexIsIllegal() throws Exception {
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            linguistics {
+                                profile {
+                                    index: p1
+                                    index: p2
+                                }
+                            }
+                        }
+                    }
+                }""";
+        try {
+            ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+            builder.addSchema(schema);
+            builder.build(true);
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("linguistics index 's1' error: already has profile p1"),
+                       "Unexpected message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testLinguisticsProfileBlockCombinedWithOtherSettings() throws Exception {
+        // The profile { index: ... } form defaults the search profile to the index profile
+        var field = linguisticsField("linguistics { profile { index: p1 } }");
+        assertEquals("p1", field.getIndexLinguisticsProfile());
+        assertEquals("p1", field.getSearchLinguisticsProfile());
+
+        // ... but an explicit search profile wins, regardless of the order of the two blocks
+        for (var block : List.of("linguistics { profile { index: p1 } search { profile: p3 } }",
+                                 "linguistics { search { profile: p3 } profile { index: p1 } }")) {
+            field = linguisticsField(block);
+            assertEquals("p1", field.getIndexLinguisticsProfile(), block);
+            assertEquals("p3", field.getSearchLinguisticsProfile(), block);
+        }
+
+        // A search block which sets something else does not stop the defaulting
+        field = linguisticsField("linguistics { profile { index: p1 } search { tokens: original } }");
+        assertEquals("p1", field.getIndexLinguisticsProfile());
+        assertEquals("p1", field.getSearchLinguisticsProfile());
+        assertEquals(TokensMode.ORIGINAL, field.getSearchLinguisticsTokens());
+
+        // The profile block is a way of saying the same thing as a flat profile, so combining
+        // the two is rejected rather than given a precedence nobody would guess
+        for (var block : List.of("linguistics { profile: p1 profile { index: p2 } }",
+                                 "linguistics { profile { index: p2 } profile: p1 }",
+                                 "linguistics { profile { index: p2 } index { profile: p1 } }")) {
+            var e = assertThrows(IllegalArgumentException.class, () -> linguisticsField(block), block);
+            assertTrue(e.getMessage().contains("cannot set both a profile and a profile block") ||
+                       e.getMessage().contains("already has profile"),
+                       "Unexpected message for " + block + ": " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testRepeatedLinguisticsBlockDoesNotClearEarlierSettings() throws Exception {
+        // A second linguistics block used to silently null out what the first one set
+        var field = linguisticsField("linguistics { profile: p1 }\n                            linguistics { tokens: original }");
+        assertEquals("p1", field.getIndexLinguisticsProfile());
+        assertEquals("p1", field.getSearchLinguisticsProfile());
+        assertEquals(TokensMode.ORIGINAL, field.getIndexLinguisticsTokens());
+
+        var e = assertThrows(IllegalArgumentException.class,
+                             () -> linguisticsField("linguistics { profile: p1 }\n                            linguistics { profile: p2 }"));
+        assertTrue(e.getMessage().contains("already has linguistics profile for index"),
+                   "Unexpected message: " + e.getMessage());
+    }
+
+    /** Returns the 's1' field of a schema having the given linguistics block on it */
+    private ImmutableSDField linguisticsField(String linguistics) throws Exception {
+        String schema =
+                """
+                schema doc {
+                    document doc {
+                        field s1 type string {
+                            indexing: index
+                            %s
+                        }
+                    }
+                }""".formatted(linguistics);
+        ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+        builder.addSchema(schema);
+        return builder.build(true).schemas().get("doc").getField("s1");
+    }
+
+    @Test
     void testCasedWordMatching() throws Exception {
         String schema =
                 """
@@ -1079,6 +1448,351 @@ public class SchemaTestCase {
         assertNotNull(schema.temporaryImportedFields().get().fields().get("parent_imported"));
         assertTrue(schema.documentIdAttributeEnabled());
         assertTrue(schema.isRawAsBase64());
+    }
+
+    @Test
+    void testLinguisticsTokensIsIgnoredWhenAlternativesAreImpossible() throws Exception {
+        // Word, exact and gram matching, and uri fields, cannot produce alternatives to the
+        // original token: WordMatch, ExactMatch, NGramMatch and UriHack all force stemming to
+        // NONE for them. A tokens setting must not be able to sneak stemming back in on the
+        // query side only, which would give zero recall for any stemmable term.
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            match: word
+                            linguistics { tokens: alternatives }
+                        }
+                        field s2 type string {
+                            indexing: index
+                            match: exact
+                            linguistics { tokens: alternatives }
+                        }
+                        field s3 type string {
+                            indexing: index
+                            match {
+                                gram
+                                gram-size: 3
+                            }
+                            linguistics { tokens: alternatives }
+                        }
+                        field s4 type uri {
+                            indexing: index
+                            linguistics { tokens: alternatives }
+                        }
+                        field s5 type int {
+                            indexing: attribute
+                            linguistics { tokens: alternatives }
+                        }
+                    }
+                }""";
+        var logger = new DeployLoggerStub();
+        ApplicationBuilder builder = new ApplicationBuilder(logger);
+        builder.addSchema(schema);
+        var application = builder.build(true);
+        var derived = new DerivedConfiguration(application.schemas().get("doc"), application.rankProfileRegistry());
+
+        var indexInfoConfigBuilder = new IndexInfoConfig.Builder();
+        derived.getIndexInfo().getConfig(indexInfoConfigBuilder);
+        var config = indexInfoConfigBuilder.build();
+        for (String field : List.of("s1", "s2", "s3", "s4")) {
+            assertNoCommand(field, "stem:ALL_STEMS", config);
+            assertNoCommand(field, "stem:BEST", config);
+        }
+        assertCommand("s1", "word", config);
+
+        // The setting is cleared, so every place resolving stemming agrees
+        var doc = application.schemas().get("doc");
+        for (String field : List.of("s1", "s2", "s3", "s4", "s5")) {
+            assertNull(doc.getField(field).getIndexLinguisticsTokens(), field);
+            assertNull(doc.getField(field).getSearchLinguisticsTokens(), field);
+        }
+
+        assertEquals(List.of("For schema 'doc', field 's1': tokens is set in the linguistics block, but matching is word, which produces a single token, so it is ignored.",
+                             "For schema 'doc', field 's2': tokens is set in the linguistics block, but matching is exact, which produces a single token, so it is ignored.",
+                             "For schema 'doc', field 's3': tokens is set in the linguistics block, but matching is gram, which produces a single token, so it is ignored.",
+                             "For schema 'doc', field 's4': tokens is set in the linguistics block, but this is a uri field, which is not tokenized by the linguistics implementation, so it is ignored.",
+                             "For schema 'doc', field 's5': tokens is set in the linguistics block, but this is not a string field, so it is ignored."),
+                     logger.entries.stream().map(entry -> entry.message)
+                                            .filter(message -> message.contains("tokens is set in the linguistics block"))
+                                            .toList());
+    }
+
+    @Test
+    void testLinguisticsTokensOverridesIndexStemming() throws Exception {
+        // An index level stemming setting loses to the tokens setting of the field, as the field
+        // level stemming setting does. Say so rather than dropping it silently.
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                            linguistics { tokens: alternatives }
+                        }
+                    }
+                    index s1 {
+                        stemming: none
+                    }
+                }""";
+        var logger = new DeployLoggerStub();
+        ApplicationBuilder builder = new ApplicationBuilder(logger);
+        builder.addSchema(schema);
+        var application = builder.build(true);
+        var derived = new DerivedConfiguration(application.schemas().get("doc"), application.rankProfileRegistry());
+
+        var indexInfoConfigBuilder = new IndexInfoConfig.Builder();
+        derived.getIndexInfo().getConfig(indexInfoConfigBuilder);
+        assertCommand("s1", "stem:ALL_STEMS", indexInfoConfigBuilder.build());
+        assertEquals(List.of("For schema 'doc', field 's1': stemming: none of index 's1' is ignored " +
+                             "because this field sets tokens in its linguistics block."),
+                     logger.entries.stream().map(entry -> entry.message).toList());
+    }
+
+    @Test
+    void testNoWarningWhenStemmingAgreesWithLinguisticsTokens() throws Exception {
+        // A stemming setting saying the same as tokens is redundant, not ignored: no warning
+        assertEquals(List.of(), linguisticsWarnings("""
+                field s1 type string {
+                    indexing: index
+                    stemming: none
+                    linguistics { tokens: original }
+                }
+                """, """
+                index s1 {
+                    stemming: none
+                }
+                """));
+        // ... which is decided per side when tokens differ between indexing and searching
+        assertEquals(List.of("For schema 'doc', field 's1': stemming: none is ignored when searching " +
+                             "because this field sets tokens in its linguistics block."),
+                     linguisticsWarnings("""
+                field s1 type string {
+                    indexing: index
+                    stemming: none
+                    linguistics {
+                        index { tokens: original }
+                        search { tokens: alternatives }
+                    }
+                }
+                """, ""));
+        // An index level setting agreeing with tokens is not warned about either
+        assertEquals(List.of(), linguisticsWarnings("""
+                field s1 type string {
+                    indexing: index
+                    linguistics { tokens: alternatives }
+                }
+                """, """
+                index s1 {
+                    stemming: all-stems
+                }
+                """));
+    }
+
+    /** Returns the warnings from building a schema 'doc' with the given fields in its document, and the given content outside it */
+    private List<String> linguisticsWarnings(String documentFields, String schemaContent) throws Exception {
+        String schema =
+                """
+                schema doc {
+                    document doc {
+                        %s
+                    }
+                    %s
+                }""".formatted(documentFields, schemaContent);
+        var logger = new DeployLoggerStub();
+        ApplicationBuilder builder = new ApplicationBuilder(logger);
+        builder.addSchema(schema);
+        builder.build(true);
+        return logger.entries.stream().map(entry -> entry.message).toList();
+    }
+
+    @Test
+    void testImportedFieldWithLinguisticsTokensOnTargetIsNotStemmed() throws Exception {
+        // An imported field is an attribute and is never stemmed, whatever its target says.
+        // Its tokens getters delegate to the target, so every place resolving stemming must
+        // check for an imported field first: resolving stemming for one is not supported.
+        String parent =
+                """
+                schema parent {
+                    document parent {
+                        field name type string {
+                            indexing: attribute
+                            match: text  # keep tokens: implicit word matching would clear it
+                            linguistics { tokens: alternatives }
+                        }
+                    }
+                }""";
+        String child =
+                """
+                schema child {
+                    document child {
+                        field parent_ref type reference<parent> {
+                            indexing: attribute
+                        }
+                        field title type string {
+                            indexing: index
+                        }
+                    }
+                    import field parent_ref.name as imported_name {}
+                    fieldset fs {
+                        fields: title, imported_name
+                    }
+                }""";
+        ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+        builder.addSchema(parent);
+        builder.addSchema(child);
+        var application = builder.build(true);
+        var childSchema = application.schemas().get("child");
+        var importedName = childSchema.getField("imported_name");
+        assertTrue(importedName.isImportedField());
+        assertEquals(TokensMode.ALTERNATIVES, importedName.getSearchLinguisticsTokens());
+        assertThrows(UnsupportedOperationException.class, () -> importedName.getEffectiveSearchStemming(childSchema));
+
+        var derived = new DerivedConfiguration(childSchema, application.rankProfileRegistry());
+        var indexInfoConfigBuilder = new IndexInfoConfig.Builder();
+        derived.getIndexInfo().getConfig(indexInfoConfigBuilder);
+        var config = indexInfoConfigBuilder.build();
+        assertNoCommand("imported_name", "stem:ALL_STEMS", config);
+        assertNoCommand("imported_name", "stem:BEST", config);
+        assertCommand("fs", "stem:BEST", config);
+    }
+
+    @Test
+    void testIndexLevelStemmingAppliesEquallyToFieldsAndFieldsets() throws Exception {
+        // The stem command of a fieldset must agree with that of its fields, whichever way the
+        // stemming of those fields was set. Both go through ImmutableSDField.getEffectiveSearchStemming.
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field s1 type string {
+                            indexing: index
+                        }
+                        field s2 type string {
+                            indexing: index
+                            index {
+                                stemming: shortest
+                            }
+                        }
+                        field s3 type string {
+                            indexing: index
+                            stemming: none
+                            index {
+                                stemming: best
+                            }
+                        }
+                    }
+                    index s1 {
+                        stemming: shortest
+                    }
+                    fieldset shortest {
+                        fields: s1, s2
+                    }
+                    fieldset none {
+                        fields: s3
+                    }
+                }""";
+        ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+        builder.addSchema(schema);
+        var application = builder.build(true);
+        var derived = new DerivedConfiguration(application.schemas().get("doc"), application.rankProfileRegistry());
+
+        var indexInfoConfigBuilder = new IndexInfoConfig.Builder();
+        derived.getIndexInfo().getConfig(indexInfoConfigBuilder);
+        var config = indexInfoConfigBuilder.build();
+        // A schema level index block counts as much as one in the field, for fields and fieldsets alike
+        assertCommand("s1", "stem:SHORTEST", config);
+        assertCommand("s2", "stem:SHORTEST", config);
+        assertCommand("shortest", "stem:SHORTEST", config);
+        assertNoCommand("shortest", "stem:BEST", config);
+        // An index level setting cannot turn stemming on for a field which has it off
+        assertNoCommand("s3", "stem:BEST", config);
+        assertNoCommand("none", "stem:BEST", config);
+    }
+
+    @Test
+    void testOnlyStemmableFieldsDecideTheStemCommandOfAFieldset() throws Exception {
+        // A field which cannot be stemmed must not decide the stem command of a fieldset it is in.
+        // FieldSetSettings skips such fields when checking that the fields of a fieldset agree on
+        // what the query side should do, so if one of them could still win here, index-info would
+        // emit a stem command which that check never validated, and which contradicts the tokens
+        // setting of the field which does decide it.
+        //
+        // The fields of a fieldset are ordered by Field.compareTo, which compares the hash of the
+        // field name, so which field is seen last is a property of the names: 'n26' is a name which
+        // sorts after 's1' and therefore reproduces this, while for instance 'i1' does not.
+        for (String nonStemmableField : List.of("n26", "i1")) {
+            String schema =
+                    """
+                    schema doc {
+
+                        document doc {
+
+                            field %s type int {
+                                indexing: attribute
+                            }
+                            field s1 type string {
+                                indexing: index
+                                linguistics { tokens: alternatives }
+                            }
+                        }
+                        fieldset fs {
+                            fields: %s, s1
+                        }
+                    }""".formatted(nonStemmableField, nonStemmableField);
+            ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+            builder.addSchema(schema);
+            var application = builder.build(true);
+            var derived = new DerivedConfiguration(application.schemas().get("doc"), application.rankProfileRegistry());
+
+            var indexInfoConfigBuilder = new IndexInfoConfig.Builder();
+            derived.getIndexInfo().getConfig(indexInfoConfigBuilder);
+            var config = indexInfoConfigBuilder.build();
+            assertCommand("s1", "stem:ALL_STEMS", config);
+            assertCommand("fs", "stem:ALL_STEMS", config);
+            assertNoCommand("fs", "stem:BEST", config);
+        }
+    }
+
+    @Test
+    void testFieldsetOfNonStemmableFieldsOnlyGetsNoStemCommand() throws Exception {
+        // With no stemmable field there is nothing to tell the query side to stem
+        String schema =
+                """
+                schema doc {
+
+                    document doc {
+
+                        field i1 type int {
+                            indexing: attribute
+                        }
+                        field s1 type string {
+                            indexing: index
+                            match: word
+                        }
+                    }
+                    fieldset fs {
+                        fields: i1, s1
+                    }
+                }""";
+        ApplicationBuilder builder = new ApplicationBuilder(new DeployLoggerStub());
+        builder.addSchema(schema);
+        var application = builder.build(true);
+        var derived = new DerivedConfiguration(application.schemas().get("doc"), application.rankProfileRegistry());
+
+        var indexInfoConfigBuilder = new IndexInfoConfig.Builder();
+        derived.getIndexInfo().getConfig(indexInfoConfigBuilder);
+        var config = indexInfoConfigBuilder.build();
+        for (var stemMode : List.of("NONE", "BEST", "SHORTEST", "ALL_STEMS", "ALL"))
+            assertNoCommand("fs", "stem:" + stemMode, config);
     }
 
     private void assertCommand(String field, String command, IndexInfoConfig config) {

--- a/config-model/src/test/java/com/yahoo/schema/processing/FieldSetSettingsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/FieldSetSettingsTestCase.java
@@ -7,6 +7,8 @@ import com.yahoo.schema.derived.TestableDeployLogger;
 import com.yahoo.schema.document.MatchType;
 import com.yahoo.schema.parser.ParseException;
 import com.yahoo.text.Text;
+
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -89,6 +91,435 @@ public class FieldSetSettingsTestCase {
         var e = assertThrows(IllegalArgumentException.class, () -> createFromStrings(new BaseDeployLogger(), schema));
         assertEquals("For schema 'test', fieldset 'p1p3': Illegal mixing of linguistics search profiles" +
                      ": field 's1' sets 'p1', while field 's3' sets 'p2'", e.getMessage());
+    }
+
+    @Test
+    public void illegalLinguisticsTokensMix() {
+        var schema = """
+                schema test {
+                  document test {
+                    field s1 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: alternatives
+                      }
+                    }
+                    field s2 type string {
+                      indexing: index
+                      linguistics {
+                        index {
+                          tokens: original
+                        }
+                        search {
+                          tokens: alternatives   # Legal combination with s1 since only the query side need to be consistent
+                        }
+                      }
+                    }
+                    field s3 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: original-and-alternatives   # Not legal combination with s1
+                      }
+                    }
+                  }
+                  fieldset t1t2 {
+                    fields: s1, s2
+                  }
+                  fieldset t1t3 {
+                    fields: s1, s3
+                  }
+                }
+                """;
+        var e = assertThrows(IllegalArgumentException.class, () -> createFromStrings(new BaseDeployLogger(), schema));
+        assertEquals("For schema 'test', fieldset 't1t3': Illegal mixing of linguistics search tokens/stemming settings" +
+                     ": field 's1' resolves to 'stemming all-stems', while field 's3' resolves to 'stemming multiple'",
+                     e.getMessage());
+    }
+
+    @Test
+    public void illegalLinguisticsTokensMixIsIndependentOfFieldOrder() {
+        // s2 and s3 are inconsistent, and s3 sets tokens, so this is an error. Whether s1 is
+        // declared first must not change that: comparing every field with the first one only
+        // made an error disappear as soon as an agreeing field was put in front of the pair.
+        var conflicting = """
+                    field s2 type string {
+                      indexing: index
+                      stemming: shortest
+                    }
+                    field s3 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: original
+                      }
+                    }
+                """;
+        var leading = """
+                    field s1 type string {
+                      indexing: index
+                      stemming: none
+                    }
+                """;
+        var expected = "For schema 'test', fieldset 'fs': Illegal mixing of linguistics search tokens/stemming " +
+                       "settings: field 's2' resolves to 'stemming shortest', while field 's3' resolves to 'stemming none'";
+        for (var fields : List.of(conflicting, leading + conflicting)) {
+            var schema = "schema test {\n  document test {\n" + fields + "  }\n  fieldset fs { fields: " +
+                         (fields.contains("s1") ? "s1, " : "") + "s2, s3 }\n}\n";
+            var e = assertThrows(IllegalArgumentException.class,
+                                 () -> createFromStrings(new BaseDeployLogger(), schema));
+            assertEquals(expected, e.getMessage(), schema);
+        }
+    }
+
+    @Test
+    public void tokensMixedWithAWordMatchedFieldIsLegal() {
+        // A word matched field produces a single token and cannot stem, so it cannot be
+        // inconsistent with anything: LinguisticsSettings has cleared its tokens setting.
+        var logger = new TestableDeployLogger();
+        var schema = """
+                schema test {
+                  document test {
+                    field s1 type string {
+                      indexing: index
+                      match: word
+                    }
+                    field s2 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: alternatives
+                      }
+                    }
+                  }
+                  fieldset t1t2 {
+                    fields: s1, s2
+                  }
+                }
+                """;
+        assertDoesNotThrow(() -> createFromStrings(logger, schema));
+        // The matching and normalization inconsistencies of a word/text mix are warned about
+        // elsewhere and are not the subject here: no stemming inconsistency must be reported.
+        assertArrayEquals(new String[]{},
+                          logger.warnings.stream().filter(warning -> warning.contains("stemming")).toArray());
+    }
+
+    @Test
+    public void stemmingConsistencyIsCheckedOnTheResolvedSetting() {
+        // Pins the behaviour of checkStemming for plain stemming settings, which changed when
+        // the tokens setting was added: it used to compare the raw, nullable setting of each
+        // field, where null doubled as the "no field seen yet" sentinel. A field which simply
+        // uses the schema default must not be reported as inconsistent with a field which sets
+        // that same value explicitly, and an actual mismatch must be reported in either order.
+        assertStemmingWarnings("stemming: best", "", new String[]{});
+        assertStemmingWarnings("", "stemming: best", new String[]{});
+
+        var expected = new String[]{"For schema 'test', field 's2': The stemming settings for the fields in the " +
+                                    "fieldset 't1t2' are inconsistent. This may lead to recall and ranking issues. " +
+                                    "See " + FIELDSET_DOC_URL};
+        assertStemmingWarnings("stemming: shortest", "", expected);
+        assertStemmingWarnings("", "stemming: shortest", expected);
+    }
+
+    private void assertStemmingWarnings(String s1Stemming, String s2Stemming, String[] expectedWarnings) {
+        var logger = new TestableDeployLogger();
+        var schema = """
+                schema test {
+                  document test {
+                    field s1 type string {
+                      indexing: index
+                      %s
+                    }
+                    field s2 type string {
+                      indexing: index
+                      %s
+                    }
+                  }
+                  fieldset t1t2 {
+                    fields: s1, s2
+                  }
+                }
+                """.formatted(s1Stemming, s2Stemming);
+        assertDoesNotThrow(() -> createFromStrings(logger, schema));
+        assertArrayEquals(expectedWarnings, logger.warnings.toArray(), schema);
+    }
+
+    private static final String FIELDSET_DOC_URL = "https://docs.vespa.ai/en/reference/schemas/schemas.html#fieldset";
+
+    @Test
+    public void tokensMixedWithTheDefaultStemmingIsLegal() {
+        // s2 has no stemming setting and so uses the schema default, best, which is what
+        // 'tokens: first-alternative' resolves to
+        var logger = new TestableDeployLogger();
+        var schema = """
+                schema test {
+                  document test {
+                    field s1 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: first-alternative
+                      }
+                    }
+                    field s2 type string {
+                      indexing: index
+                    }
+                  }
+                  fieldset t1t2 {
+                    fields: s1, s2
+                  }
+                }
+                """;
+        assertDoesNotThrow(() -> createFromStrings(logger, schema));
+        assertArrayEquals(new String[]{}, logger.warnings.toArray());
+    }
+
+    @Test
+    public void tokensMixedWithADifferentDefaultStemmingIsIllegal() {
+        var schema = """
+                schema test {
+                  document test {
+                    field s1 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: alternatives
+                      }
+                    }
+                    field s2 type string {
+                      indexing: index
+                    }
+                  }
+                  fieldset t1t2 {
+                    fields: s1, s2
+                  }
+                }
+                """;
+        var e = assertThrows(IllegalArgumentException.class, () -> createFromStrings(new BaseDeployLogger(), schema));
+        assertEquals("For schema 'test', fieldset 't1t2': Illegal mixing of linguistics search tokens/stemming settings" +
+                     ": field 's1' resolves to 'stemming all-stems', while field 's2' resolves to 'stemming best'",
+                     e.getMessage());
+    }
+
+    @Test
+    public void tokensMixedWithANonStringFieldIsLegal() {
+        // Stemming, and thereby tokens, does not apply to an int field
+        var logger = new TestableDeployLogger();
+        var schema = """
+                schema test {
+                  document test {
+                    field i1 type int {
+                      indexing: attribute
+                    }
+                    field s1 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: alternatives
+                      }
+                    }
+                  }
+                  fieldset i1s1 {
+                    fields: i1, s1
+                  }
+                }
+                """;
+        assertDoesNotThrow(() -> createFromStrings(logger, schema));
+        assertArrayEquals(new String[]{}, logger.warnings.toArray());
+    }
+
+    @Test
+    public void equivalentLinguisticsTokensAndStemmingMixIsLegal() {
+        // 'tokens: first-alternative' and 'stemming: best' both resolve to the same effective
+        // search stemming, so mixing them in a fieldset is not an error.
+        var schema = """
+                schema test {
+                  document test {
+                    field s1 type string {
+                      indexing: index
+                      stemming: best
+                    }
+                    field s2 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: first-alternative
+                      }
+                    }
+                  }
+                  fieldset t1t2 {
+                    fields: s1, s2
+                  }
+                }
+                """;
+        assertDoesNotThrow(() -> createFromStrings(new BaseDeployLogger(), schema));
+    }
+
+    @Test
+    public void checkStemmingUsesEffectiveTokensAwareStemming() {
+        // Same schema as above: 'tokens: first-alternative' and 'stemming: best' resolve to the same
+        // effective stemming, so checkStemming (which only warns) must not flag this as inconsistent either.
+        var logger = new TestableDeployLogger();
+        var schema = """
+                schema test {
+                  document test {
+                    field s1 type string {
+                      indexing: index
+                      stemming: best
+                    }
+                    field s2 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: first-alternative
+                      }
+                    }
+                  }
+                  fieldset t1t2 {
+                    fields: s1, s2
+                  }
+                }
+                """;
+        assertDoesNotThrow(() -> createFromStrings(logger, schema));
+        assertArrayEquals(new String[]{}, logger.warnings.toArray());
+    }
+
+    @Test
+    public void tokensMixedWithIndexLevelStemmingIsCheckedOnTheEffectiveSetting() {
+        // The stemming of an index block, in the field or at the schema level, is what the query
+        // side actually uses (see IndexInfo), so the fieldset check must resolve it the same way:
+        // neither reject a fieldset index-info would have made consistent, nor accept one it would not.
+        var fieldLevel = "index { stemming: none }";
+        var schemaLevel = "index s2 { stemming: none }";
+        for (var indexBlocks : List.of(new String[]{fieldLevel, ""}, new String[]{"", schemaLevel})) {
+            var logger = new TestableDeployLogger();
+            var agreeing = tokensAndIndexStemmingSchema("original", indexBlocks[0], indexBlocks[1]);
+            assertDoesNotThrow(() -> createFromStrings(logger, agreeing), agreeing);
+            assertArrayEquals(new String[]{}, logger.warnings.toArray(), agreeing);
+
+            var conflicting = tokensAndIndexStemmingSchema("first-alternative", indexBlocks[0], indexBlocks[1]);
+            var e = assertThrows(IllegalArgumentException.class,
+                                 () -> createFromStrings(new BaseDeployLogger(), conflicting), conflicting);
+            assertEquals("For schema 'test', fieldset 't1t2': Illegal mixing of linguistics search tokens/stemming " +
+                         "settings: field 's1' resolves to 'stemming best', while field 's2' resolves to 'stemming none'",
+                         e.getMessage(), conflicting);
+        }
+    }
+
+    /** Returns a schema where s1 sets the given tokens, and s2 has the given index block in it and at the schema level */
+    private static String tokensAndIndexStemmingSchema(String tokens, String fieldIndexBlock, String schemaIndexBlock) {
+        return """
+                schema test {
+                  document test {
+                    field s1 type string {
+                      indexing: index
+                      linguistics {
+                        tokens: %s
+                      }
+                    }
+                    field s2 type string {
+                      indexing: index
+                      %s
+                    }
+                  }
+                  %s
+                  fieldset t1t2 {
+                    fields: s1, s2
+                  }
+                }
+                """.formatted(tokens, fieldIndexBlock, schemaIndexBlock);
+    }
+
+
+    @Test
+    public void unstemmedTextInAStemmedFieldsetIsWarnedAbout() {
+        // A uri field is text matched, so checkMatching sees nothing wrong with mixing it into a
+        // text fieldset, but UriHack turns its stemming off: the query side would stem terms for
+        // the fieldset which this field's content was never stemmed with. Nothing warned about this.
+        assertArrayEquals(new String[]{
+                "For schema 'test', field 'u1': The fields in fieldset 't1t2' are stemmed when searched, " +
+                "but the content of this field is not stemmed, so it will not match a stemmed term. " +
+                "This may lead to recall and ranking issues. See " + FIELDSET_DOC_URL},
+                unstemmedTextWarnings("""
+                    field s1 type string {
+                      indexing: index
+                    }
+                    field u1 type uri {
+                      indexing: index
+                    }
+                """, "s1, u1"));
+    }
+
+    @Test
+    public void unstemmedTextInAFieldsetWhichIsNotStemmedIsLegal() {
+        // Nothing is stemmed here, so there is no mismatch to warn about
+        assertArrayEquals(new String[]{}, unstemmedTextWarnings("""
+                    field s1 type string {
+                      indexing: index
+                      stemming: none
+                    }
+                    field u1 type uri {
+                      indexing: index
+                    }
+                """, "s1, u1"));
+    }
+
+    @Test
+    public void unstemmedTextFromATokensSettingIsWarnedAbout() {
+        // The fieldset is stemmed because of a tokens setting rather than a stemming one
+        assertArrayEquals(new String[]{
+                "For schema 'test', field 'u1': The fields in fieldset 't1t2' are stemmed when searched, " +
+                "but the content of this field is not stemmed, so it will not match a stemmed term. " +
+                "This may lead to recall and ranking issues. See " + FIELDSET_DOC_URL},
+                unstemmedTextWarnings("""
+                    field s1 type string {
+                      indexing: index
+                      linguistics { tokens: alternatives }
+                    }
+                    field u1 type uri {
+                      indexing: index
+                    }
+                """, "s1, u1"));
+    }
+
+    @Test
+    public void aWordMatchedFieldIsLeftToTheMatchingCheck() {
+        // A word matched field makes the whole fieldset word matched, so IndexInfo emits no stem
+        // command for it and there is nothing to warn about here. checkMatching reports the mix.
+        var warnings = unstemmedTextWarnings("""
+                    field s1 type string {
+                      indexing: index
+                    }
+                    field w1 type string {
+                      indexing: index
+                      match: word
+                    }
+                """, "s1, w1");
+        assertArrayEquals(new String[]{}, java.util.Arrays.stream(warnings)
+                                                         .filter(warning -> warning.contains("stemmed"))
+                                                         .toArray());
+    }
+
+    @Test
+    public void aFieldWhichHoldsNoTextIsNotWarnedAbout() {
+        // Stemming a query term does not change whether it matches the content of an int field
+        assertArrayEquals(new String[]{}, unstemmedTextWarnings("""
+                    field s1 type string {
+                      indexing: index
+                    }
+                    field i1 type int {
+                      indexing: attribute
+                    }
+                """, "s1, i1"));
+    }
+
+    /** Returns the warnings from building a schema with the given document fields and fieldset fields */
+    private String[] unstemmedTextWarnings(String documentFields, String fieldSetFields) {
+        var logger = new TestableDeployLogger();
+        var schema = """
+                schema test {
+                  document test {
+                %s
+                  }
+                  fieldset t1t2 {
+                    fields: %s
+                  }
+                }
+                """.formatted(documentFields, fieldSetFields);
+        assertDoesNotThrow(() -> createFromStrings(logger, schema), schema);
+        return logger.warnings.toArray(new String[0]);
     }
 
     @Test

--- a/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/SchemaParser.ccc
@@ -29,6 +29,7 @@ INJECT SchemaParser:
     import com.yahoo.schema.document.MatchAlgorithm;
     import com.yahoo.schema.document.Sorting;
     import com.yahoo.schema.document.Stemming;
+    import com.yahoo.schema.document.TokensMode;
 
     import com.yahoo.schema.fieldoperation.IndexingOperation;
 
@@ -38,6 +39,7 @@ INJECT SchemaParser:
     import com.yahoo.schema.parser.ParsedDocument;
     import com.yahoo.schema.parser.ParsedDocumentSummary;
     import com.yahoo.schema.parser.ParsedField;
+    import com.yahoo.schema.parser.ParsedLinguistics;
     import com.yahoo.schema.parser.ParsedFieldSet;
     import com.yahoo.schema.parser.ParsedIndex;
     import com.yahoo.schema.parser.ParsedIndexingOp;
@@ -202,6 +204,36 @@ INJECT SchemaParser:
         inputString = inputString.substring(startSplit, endSplit);
 
         return new SubLanguageData(inputString, leadingStripped);
+    }
+
+    /*
+     * ParsedLinguistics rejects contradictory settings by throwing, as the other Parsed* classes
+     * do. Report those on the offending token rather than letting them escape the parser, which
+     * would abort parsing and mark the whole document as bad.
+     */
+
+    private void setProfile(ParsedLinguistics settings, String profile, Token token) {
+        try {
+            settings.setProfile(profile);
+        } catch (IllegalArgumentException e) {
+            token.addIllegalArgumentException(e);
+        }
+    }
+
+    private void setTokens(ParsedLinguistics settings, String tokens, Token token) {
+        try {
+            settings.setTokens(TokensMode.get(tokens));
+        } catch (IllegalArgumentException e) {
+            token.addIllegalArgumentException(e);
+        }
+    }
+
+    private void openBlock(ParsedLinguistics settings, Token token) {
+        try {
+            settings.openBlock();
+        } catch (IllegalArgumentException e) {
+            token.addIllegalArgumentException(e);
+        }
     }
 }
 
@@ -1251,27 +1283,73 @@ SubLanguageData indexingOperationElm(ParsedField field, boolean multiLine) : {
  */
 void linguisticsElm(ParsedField field) :
 {
-    String indexProfile = null;
-    String searchProfile = null;
+    ParsedLinguistics common = new ParsedLinguistics(field.name(), "linguistics");
+    ParsedLinguistics indexed = new ParsedLinguistics(field.name(), "linguistics index");
+    ParsedLinguistics searched = new ParsedLinguistics(field.name(), "linguistics search");
+    ParsedLinguistics profileBlock = new ParsedLinguistics(field.name(), "linguistics profile");
+    Token beginToken = null;
+    String str;
 }
-    <LINGUISTICS> openLbrace() <PROFILE> (
-      ( <COLON> indexProfile = identifierStr() (<NL>)* )
-      |
-      ( openLbrace()
-          (
-              ( <INDEX>  <COLON> indexProfile  = identifierStr() (<NL>)* ) |
-              ( <SEARCH> <COLON> searchProfile = identifierStr() (<NL>)* )
-          )+
-        <RBRACE> (<NL>)*
+    <LINGUISTICS> { beginToken = lastConsumedToken; } openLbrace()
+    (
+      ( <PROFILE>
+        (
+          ( <COLON> str = identifierStr() { setProfile(common, str, lastConsumedToken); } (<NL>)* )
+          |
+          // Alternative form: profile { index: ... search: ... }
+          ( openLbrace() { openBlock(profileBlock, lastConsumedToken); }
+              (
+                  ( <INDEX>  <COLON> str = identifierStr() { setProfile(indexed, str, lastConsumedToken); }  (<NL>)* ) |
+                  ( <SEARCH> <COLON> str = identifierStr() { setProfile(searched, str, lastConsumedToken); } (<NL>)* )
+              )+
+            <RBRACE> (<NL>)*
+          )
+        )
       )
-    )
+      |
+      ( <TOKENS> <COLON> str = identifierWithDashStr() { setTokens(common, str, lastConsumedToken); } (<NL>)* )
+      |
+      ( <INDEX>  openLbrace() { openBlock(indexed, lastConsumedToken); }  ( linguisticsSettingsElm(indexed)  )+ <RBRACE> (<NL>)* )
+      |
+      ( <SEARCH> openLbrace() { openBlock(searched, lastConsumedToken); } ( linguisticsSettingsElm(searched) )+ <RBRACE> (<NL>)* )
+    )+
     <RBRACE>
     {
-      if (searchProfile == null)
-          searchProfile = indexProfile;
-      field.setSearchLinguisticsProfile(searchProfile);
-      field.setIndexLinguisticsProfile(indexProfile);
+      try {
+          if (profileBlock.isOpened()) {
+              // The legacy profile { index: ... search: ... } form is a way of saying the same thing,
+              // so it cannot be combined with any other way of setting a profile
+              common.verifyNoProfile("cannot set both a profile and a profile block");
+              // In this form the search profile defaults to the index profile
+              if (searched.profile() == null && indexed.profile() != null)
+                  searched.setProfile(indexed.profile());
+          }
+          indexed.mergeDefaultsFrom(common);
+          searched.mergeDefaultsFrom(common);
+          // Only set what this block actually says, so a second linguistics block on the same
+          // field does not silently clear what the first one set
+          if (indexed.profile() != null)  field.setIndexLinguisticsProfile(indexed.profile());
+          if (searched.profile() != null) field.setSearchLinguisticsProfile(searched.profile());
+          if (indexed.tokens() != null)   field.setIndexLinguisticsTokens(indexed.tokens());
+          if (searched.tokens() != null)  field.setSearchLinguisticsTokens(searched.tokens());
+      } catch (IllegalArgumentException e) {
+          beginToken.addIllegalArgumentException(e);
+      }
     }
+;
+
+/**
+ * The settings which can be given for one side (indexing or searching) of a linguistics block.
+ */
+void linguisticsSettingsElm(ParsedLinguistics settings) :
+{
+    String str;
+}
+    (
+      ( <PROFILE> <COLON> str = identifierStr()         { setProfile(settings, str, lastConsumedToken); } )
+      |
+      ( <TOKENS>  <COLON> str = identifierWithDashStr() { setTokens(settings, str, lastConsumedToken); } )
+    ) (<NL>)*
 ;
 
 /**

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
@@ -1,6 +1,8 @@
 package ai.vespa.schemals.lsp.schema.completion.provider;
 
 import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -32,11 +34,14 @@ import ai.vespa.schemals.parser.ast.globalPhase;
 import ai.vespa.schemals.parser.ast.hnswIndex;
 import ai.vespa.schemals.parser.ast.indexInsideField;
 import ai.vespa.schemals.parser.ast.indexOutsideDoc;
+import ai.vespa.schemals.parser.ast.INDEX;
 import ai.vespa.schemals.parser.ast.linguisticsElm;
 import ai.vespa.schemals.parser.ast.onnxModel;
 import ai.vespa.schemals.parser.ast.openLbrace;
+import ai.vespa.schemals.parser.ast.PROFILE;
 import ai.vespa.schemals.parser.ast.rankProfile;
 import ai.vespa.schemals.parser.ast.rootSchema;
+import ai.vespa.schemals.parser.ast.SEARCH;
 import ai.vespa.schemals.parser.ast.secondPhase;
 import ai.vespa.schemals.parser.ast.significanceElm;
 import ai.vespa.schemals.parser.ast.sortingElm;
@@ -248,9 +253,14 @@ public class BodyKeywordCompletion implements CompletionProvider {
         }
     }};
 
+    private static final String TOKENS_MODE_CHOICE = "${1|original,first-alternative,alternatives,original-and-alternatives|}";
+
     private static final List<CompletionItem> linguisticsBodySnippets = List.of(
         CompletionUtils.constructSnippet("profile", "profile: $0", "profile:"),
-        CompletionUtils.constructSnippet("profile", "profile {\n\tindex: $1\n\tsearch: $0\n}", "profile {}")
+        CompletionUtils.constructSnippet("profile", "profile {\n\tindex: $1\n\tsearch: $0\n}", "profile {}"),
+        CompletionUtils.constructSnippet("tokens", "tokens: " + TOKENS_MODE_CHOICE, "tokens:"),
+        CompletionUtils.constructSnippet("index", "index {\n\t$0\n}", "index {}"),
+        CompletionUtils.constructSnippet("search", "search {\n\t$0\n}", "search {}")
     );
 
     private static final List<CompletionItem> linguisticsProfileBodySnippets = List.of(
@@ -258,21 +268,39 @@ public class BodyKeywordCompletion implements CompletionProvider {
         CompletionUtils.constructSnippet("search", "search: $0")
     );
 
+    private static final List<CompletionItem> linguisticsSettingsBodySnippets = List.of(
+        CompletionUtils.constructSnippet("profile", "profile: $0"),
+        CompletionUtils.constructSnippet("tokens", "tokens: " + TOKENS_MODE_CHOICE)
+    );
+
     /**
-     * A linguistics element holds two nested bodies, <code>linguistics { profile { ... } }</code>,
-     * which the grammar represents as a single flat node. Which keywords are valid therefore depends on
-     * the brace depth at the cursor rather than on the enclosing AST class alone.
+     * A linguistics element holds nested bodies, e.g. <code>linguistics { profile { ... } }</code> or
+     * <code>linguistics { index { ... } }</code>, which the grammar represents as a single flat node.
+     * Which keywords are valid therefore depends on which keyword opened the brace enclosing the cursor
+     * (tracked here as a stack), not just the brace depth.
      */
     private static List<CompletionItem> linguisticsCompletionItems(Node linguisticsNode, Position position) {
-        int braceDepth = 0;
+        Deque<String> blockStack = new ArrayDeque<>();
+        String pendingKeyword = null;
         for (Node child : linguisticsNode) {
             if (CSTUtils.positionLT(position, child.getRange().getStart())) break;
-            if (child.isASTInstance(openLbrace.class) || child.isASTInstance(LBRACE.class)) ++braceDepth;
-            else if (child.isASTInstance(RBRACE.class)) --braceDepth;
+            if (child.isASTInstance(PROFILE.class)) pendingKeyword = "profile";
+            else if (child.isASTInstance(INDEX.class)) pendingKeyword = "index";
+            else if (child.isASTInstance(SEARCH.class)) pendingKeyword = "search";
+            else if (child.isASTInstance(openLbrace.class) || child.isASTInstance(LBRACE.class)) {
+                // The very first brace is the outer 'linguistics {' body itself, not a keyword-tagged
+                // sub-block, and has no preceding PROFILE/INDEX/SEARCH keyword: don't push a context for it.
+                if (pendingKeyword != null) blockStack.push(pendingKeyword);
+                pendingKeyword = null;
+            } else if (child.isASTInstance(RBRACE.class)) {
+                if (!blockStack.isEmpty()) blockStack.pop();
+            }
         }
 
-        if (braceDepth == 1) return linguisticsBodySnippets;
-        if (braceDepth == 2) return linguisticsProfileBodySnippets;
+        if (blockStack.isEmpty()) return linguisticsBodySnippets;
+        if (blockStack.size() == 1) {
+            return "profile".equals(blockStack.peek()) ? linguisticsProfileBodySnippets : linguisticsSettingsBodySnippets;
+        }
         return List.of();
     }
 

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/LSPTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/LSPTest.java
@@ -105,8 +105,10 @@ public class LSPTest {
     }
 
     /**
-     * The linguistics element nests two bodies, linguistics { profile { ... } }, which the grammar
-     * flattens into a single node, so {@link BodyKeywordCompletion} has to tell them apart by brace depth.
+     * The linguistics element nests bodies, e.g. linguistics { profile { ... } } or
+     * linguistics { index { ... } }, which the grammar flattens into a single node, so
+     * {@link BodyKeywordCompletion} has to tell them apart by which keyword opened the
+     * enclosing brace, not just brace depth.
      */
     @Test
     void linguisticsCompletionTest() throws IOException, InvalidContextException {
@@ -129,10 +131,15 @@ public class LSPTest {
         DocumentManager document = scheduler.getDocument(fileURI);
 
         // Positions are 0-indexed and point at the start of a line inside the given body.
-        assertEquals(List.of("profile", "profile"), completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(8, 16)),
-                     "Inside a linguistics body only profile should be suggested.");
+        assertEquals(List.of("index", "profile", "profile", "search", "tokens"),
+                     completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(8, 16)),
+                     "Directly inside a linguistics body, profile, tokens, index and search should be suggested.");
         assertEquals(List.of("index", "search"), completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(10, 20)),
                      "Inside a linguistics profile body index and search should be suggested.");
+        assertEquals(List.of("profile", "tokens"), completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(25, 20)),
+                     "Inside a linguistics index body profile and tokens should be suggested.");
+        assertEquals(List.of("profile", "tokens"), completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(29, 20)),
+                     "Inside a linguistics search body profile and tokens should be suggested.");
         assertTrue(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(16, 12)).contains("linguistics"),
                    "linguistics should be suggested in a field body.");
     }

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -337,6 +337,7 @@ public class SchemaParserTest {
             new BadFileTestCase("src/test/sdfiles/single/bm25forlabelsattrbad.sd", 1),
             new BadFileTestCase("src/test/sdfiles/single/bm25labelbarebad.sd", 1),
             new BadFileTestCase("src/test/sdfiles/single/bm25labelemptybad.sd", 1),
+            new BadFileTestCase("src/test/sdfiles/single/badlinguistics.sd", 3),
             new BadFileTestCase("src/test/sdfiles/single/bm25quotelabelemptybad.sd", 1),
             new BadFileTestCase("src/test/sdfiles/single/bm25labelunknownfieldbad.sd", 1),
             new BadFileTestCase("src/test/sdfiles/single/bm25labelwrapperbad.sd", 1),

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/badlinguistics.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/badlinguistics.sd
@@ -1,0 +1,35 @@
+# Contradictory linguistics settings. Each must be reported on its own, without aborting the
+# parse of the rest of the file: the field after them must still be parsed and indexed.
+schema badlinguistics {
+    document badlinguistics {
+        field bad_tokens_value type string {
+            indexing: index
+            linguistics {
+                tokens: shortest
+            }
+        }
+        field duplicate_tokens type string {
+            indexing: index
+            linguistics {
+                tokens: original
+                tokens: alternatives
+            }
+        }
+        field combined_profile_forms type string {
+            indexing: index
+            linguistics {
+                profile: p1
+                profile {
+                    index: p2
+                }
+            }
+        }
+        field fine type string {
+            indexing: index
+            linguistics {
+                profile: p3
+                tokens: alternatives
+            }
+        }
+    }
+}

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/linguistics.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/linguistics.sd
@@ -16,6 +16,20 @@ schema linguistics {
             indexing: index | summary
             linguistics {
                 profile: de_index_and_search
+                tokens: alternatives
+            }
+        }
+        field body type string {
+            indexing: index | summary
+            linguistics {
+                index {
+                    profile: de_index_unstemmed
+                    tokens: original
+                }
+                search {
+                    profile: de_search_stemmed
+                    tokens: original-and-alternatives
+                }
             }
         }
     }


### PR DESCRIPTION
Lets a field say which of the tokens the linguistics implementation produces for a word are used, separately for indexing and searching:

    linguistics {
        profile: myprofile
        tokens: alternatives
    }

    linguistics {
        index  { profile: myprofile      tokens: original }
        search { profile: anotherprofile tokens: original-and-alternatives }
    }

Settings given directly in the block apply to both sides, an index or search block overrides for that side, and the existing profile { index: ... search: ... } form keeps working. The four values map onto existing stemming settings, and thereby onto the stem mode the indexing script and the index-info stem command already carry:

    original                  -> Stemming.NONE      StemMode.NONE
    first-alternative         -> Stemming.BEST      StemMode.BEST
    alternatives              -> Stemming.ALL_STEMS StemMode.ALL_STEMS
    original-and-alternatives -> Stemming.MULTIPLE  StemMode.ALL

Stemming.SHORTEST deliberately has no tokens name. Stemming.get lowercases with Locale.ROOT, as TokensMode.get does; both names are ASCII, so this only stops the two from differing for no reason.

Parsing. ParsedLinguistics, a ParsedBlock, collects the settings of a linguistics block and rejects contradictions in the format the other Parsed* classes use: a setting given twice, a repeated index, search or profile block, or the profile block form combined with any other way of setting a profile. A second linguistics block on the same field only sets what it says, and a real duplicate across blocks is rejected by ParsedField instead of silently overwriting. The schema-language-server grammar gets the same checks from the same place, reported on the offending token so the rest of the document still parses, and its completion offers tokens, index and search in the right bodies.

Resolution. ImmutableSDField gains never-null resolvers which every user of a field's stemming goes through: getIndexStemming for the indexing script, StemmingResolver and indexing script change messages; getSearchStemming and getEffectiveSearchStemming for index-info and fieldsets. The effective search stemming is: tokens if set, else a field or schema level 'none' (an index level setting can change how a field is stemmed but not turn stemming on, which word and exact matching rely on), else the stemming of the index block of the field or of the schema level index of the same name, else the field or schema setting. IndexInfo lost its StemmingOverrider and IndexOverrider, whose job this is now.

Validation. A new LinguisticsSettings processor, run after AttributesImplicitWord and before WordMatch, clears tokens with a warning on fields which cannot produce alternatives: word, exact and gram matched fields, uri fields and non-string fields. Otherwise index-info would have asked the query side to stem terms the indexing script did not. It also warns when tokens is set for one side only, and when a field or index level stemming setting is overridden by a different tokens value; agreeing settings are not warned about. A schema level setting is not, as a field differing from the schema default is normal. Resolving stemming for an imported field is unsupported, as before, and every resolver checks for one first.

FieldSetSettings gets checkLinguisticsTokens: the fields of a fieldset must resolve to the same effective search stemming when at least one of them sets tokens, every field compared with every field before it so the outcome does not depend on field order. checkStemming now compares the same effective setting, over the same fields, and only warns. Which fields those are is ImmutableSDField.isStemmable: a string field with text matching which is not imported. The stem command of a fieldset in index-info is decided by those fields and no others, so a field which cannot be stemmed can no longer win it over one which can and thereby emit a command these checks never validated.

checkUnstemmedTextMix warns about the other side of that: a fieldset which is stemmed, holding a field whose text is not. A uri field, and an imported one, are text matched, so the matching check sees nothing wrong with mixing them into a text fieldset, but their content is never stemmed and will not match a stemmed term. A field which is not stemmed because of its matching is left to the matching check, and a field holding no text at all is not warned about: stemming a query term does not change whether it matches the content of an int field.

Behavior changes for schemas using only the stemming keywords ------------------------------------------------------------

Schemas without a linguistics block are affected by the shared resolution and the reworked fieldset check as follows. Derived config in config-model/src/test/derived is byte identical.

- Fieldset stemming warning. It used to compare the raw stemming setting of each field, with 'not set' doubling as 'no field seen yet', over all fields of the fieldset. It now compares the effective search stemming of the string fields with text matching only. Consequences:
  * A field relying on the schema default is no longer reported as inconsistent with a field setting that same value explicitly.
  * The outcome no longer depends on the order of the fields: a leading field without a stemming setting used to hide a mismatch between two later fields, and a leading field with one used to report a mismatch against every later field without one.
  * Word, exact and gram matched fields, non-string fields and imported fields no longer trigger the warning. Mixing a word, exact or gram matched field with a text matched one is still warned about by the matching check.
  * An index level stemming setting now counts, so a field with 'index { stemming: none }' agrees with a field with 'stemming: none'.
  * The message lost the '(explicitly or because of field type)' clause.

- New fieldset warning for unstemmed text. A uri field, or an imported field, in a fieldset which is stemmed is now warned about. Both are text matched, so the matching check passed them, and nothing else looked: index-info told the query side to stem terms which the content of those fields was never stemmed with.

- Fieldset stem command in index-info. A schema level 'index <field> { stemming: ... }' block now applies to the fieldsets the field is in, as it already did to the field itself; only an index block inside the field used to count there. Only the fields which can be stemmed decide the command: it used to be set by the last field of the fieldset resolving to anything but none, in the order the hash of the field names happens to give, so a non-string field could give a fieldset the schema default where its string fields say something else. A fieldset with no stemmable field in it now gets no stem command at all rather than one following from the schema default.

- Field stem command in index-info. When a field has an index block both inside it and at the schema level, the stemming of the field level block is used, then the schema level one. Consolidating the two through Schema.getIndex used to drop both.

- Imported fields in fieldsets. A fieldset containing an imported field whose target sets an explicit stemming other than none used to fail deployment with an UnsupportedOperationException from index-info, since the imported field was counted as stemmed and then asked to resolve its stemming. Imported fields are now skipped before anything else.

Everything else is unchanged for such schemas: the indexing script, StemmingResolver, and the change messages for indexing scripts resolve to the same values as before.
