### PR TITLE
Add back sendProtobufQuerytree sendOldQueryStack to qr-searchers.def

### DIFF
--- a/container-disc/src/main/resources/configdefinitions/container.qr-searchers.def
+++ b/container-disc/src/main/resources/configdefinitions/container.qr-searchers.def
@@ -81,3 +81,11 @@ parserSettings.keepSegmentAnds bool default=false
 
 ## keep ideographic comma and full stop (default: replace with space)
 parserSettings.keepIdeographicPunctuation bool default=false
+
+## send query tree as protobuf (ignored, always true)
+## TODO: Remove Oct 2026 or when no longer used in config overrides
+sendProtobufQuerytree bool default=true
+
+## send query stack in legacy format in addition to protobuf format
+## TODO: Remove Oct 2026 or when no longer used in config overrides
+sendOldQueryStack bool default=false


### PR DESCRIPTION
Will fail if used in a config override, add back for now (used by some apps)

Followup to https://github.com/vespa-engine/vespa/pull/37806

