### PR TITLE
add semantic token and completion for fast map search

### DIFF
--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
@@ -60,7 +60,7 @@ import ai.vespa.schemals.parser.ast.weightedsetElm;
 import ai.vespa.schemals.tree.CSTUtils;
 import ai.vespa.schemals.tree.Node;
 
-public class    BodyKeywordCompletion implements CompletionProvider {
+public class BodyKeywordCompletion implements CompletionProvider {
     // Currently key is the classLeafIdentifierString of a node with a body
     private static Map<Class<?>, List<CompletionItem>> bodyKeywordSnippets = new HashMap<>() {{
         put(rootSchema.class, List.of(

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
@@ -2,17 +2,22 @@ package ai.vespa.schemals.lsp.schema.completion.provider;
 
 import java.nio.file.Path;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+
+import com.yahoo.schema.parser.ParsedType;
+import com.yahoo.schema.parser.ParsedType.Variant;
 
 import ai.vespa.schemals.SchemaLanguageServer;
 import ai.vespa.schemals.context.EventCompletionContext;
@@ -25,6 +30,7 @@ import ai.vespa.schemals.parser.ast.RBRACE;
 import ai.vespa.schemals.parser.ast.RootRankProfile;
 import ai.vespa.schemals.parser.ast.annotationBody;
 import ai.vespa.schemals.parser.ast.attributeElm;
+import ai.vespa.schemals.parser.ast.dataType;
 import ai.vespa.schemals.parser.ast.dictionaryElm;
 import ai.vespa.schemals.parser.ast.documentElm;
 import ai.vespa.schemals.parser.ast.fieldElm;
@@ -36,6 +42,7 @@ import ai.vespa.schemals.parser.ast.indexInsideField;
 import ai.vespa.schemals.parser.ast.indexOutsideDoc;
 import ai.vespa.schemals.parser.ast.INDEX;
 import ai.vespa.schemals.parser.ast.linguisticsElm;
+import ai.vespa.schemals.parser.ast.mapElm;
 import ai.vespa.schemals.parser.ast.onnxModel;
 import ai.vespa.schemals.parser.ast.openLbrace;
 import ai.vespa.schemals.parser.ast.PROFILE;
@@ -53,7 +60,7 @@ import ai.vespa.schemals.parser.ast.weightedsetElm;
 import ai.vespa.schemals.tree.CSTUtils;
 import ai.vespa.schemals.tree.Node;
 
-public class BodyKeywordCompletion implements CompletionProvider {
+public class    BodyKeywordCompletion implements CompletionProvider {
     // Currently key is the classLeafIdentifierString of a node with a body
     private static Map<Class<?>, List<CompletionItem>> bodyKeywordSnippets = new HashMap<>() {{
         put(rootSchema.class, List.of(
@@ -229,6 +236,8 @@ public class BodyKeywordCompletion implements CompletionProvider {
 
         put(weightedsetElm.class, FixedKeywordBodies.WEIGHTEDSET.completionItems());
 
+        put(mapElm.class, FixedKeywordBodies.MAP.completionItems());
+
         put(hnswIndex.class, FixedKeywordBodies.HNSW.completionItems());
 
         put(dictionaryElm.class, FixedKeywordBodies.DICTIONARY.completionItems());
@@ -240,18 +249,64 @@ public class BodyKeywordCompletion implements CompletionProvider {
         put(indexInsideField.class, FixedKeywordBodies.INDEX.completionItems());
         put(indexOutsideDoc.class, FixedKeywordBodies.INDEX.completionItems());
 
-        Path schemaHoverPath = SchemaLanguageServer.getDefaultDocumentationPath().resolve("schema");
-        // compute docs
         for (var entry : this.entrySet()) {
-            for (CompletionItem item : entry.getValue()) {
-                String markdownKey = item.getLabel().toUpperCase(Locale.ROOT).replaceAll("-", "_");
-                Optional<Hover> hover = SchemaHover.getFileHoverInformation(schemaHoverPath, markdownKey, new Range());
-                if (hover.isPresent() && hover.get().getContents().isRight()) {
-                    item.setDocumentation(hover.get().getContents().getRight());
-                }
-            }
+            withDocumentation(entry.getValue());
         }
     }};
+
+    /**
+     * Attaches hover documentation to each completion item, looked up by the item label.
+     * Returns the same list to allow use in field initializers.
+     */
+    private static List<CompletionItem> withDocumentation(List<CompletionItem> items) {
+        Path schemaHoverPath = SchemaLanguageServer.getDefaultDocumentationPath().resolve("schema");
+        for (CompletionItem item : items) {
+            String markdownKey = item.getLabel().toUpperCase(Locale.ROOT).replaceAll("-", "_");
+            Optional<Hover> hover = SchemaHover.getFileHoverInformation(schemaHoverPath, markdownKey, new Range());
+            if (hover.isPresent() && hover.get().getContents().isRight()) {
+                item.setDocumentation(hover.get().getContents().getRight());
+            }
+        }
+        return items;
+    }
+
+    /**
+     * The config model only accepts 'map: fast-search' on maps whose key and value types are among these,
+     * see CreateFastMapSearch and ConvertParsedFields in config-model.
+     */
+    private static final Set<String> FAST_MAP_SEARCH_KEY_VALUE_TYPES = Set.of("string", "int");
+
+    /** Snippets for the map settings block, only offered in fields where fast map search is allowed. */
+    private static final List<CompletionItem> mapFieldSnippets = withDocumentation(List.of(
+        FixedKeywordBodies.MAP.getColonSnippet(),
+        FixedKeywordBodies.MAP.getBodySnippet()
+    ));
+
+    private static boolean isFastMapSearchKeyValueType(ParsedType type) {
+        return type != null
+            && type.getVariant() == Variant.BUILTIN
+            && FAST_MAP_SEARCH_KEY_VALUE_TYPES.contains(type.name());
+    }
+
+    /**
+     * Returns true if the given field element has a map type on which 'map: fast-search' can be set.
+     */
+    private static boolean supportsFastMapSearch(Node fieldNode) {
+        for (Node child : fieldNode) {
+            if (!child.isASTInstance(dataType.class)) {
+                continue;
+            }
+            if (!(child.getSchemaNode().getOriginalSchemaNode() instanceof dataType typeNode)) {
+                return false;
+            }
+            ParsedType type = typeNode.getParsedType();
+            if (type == null || type.getVariant() != Variant.MAP) {
+                return false;
+            }
+            return isFastMapSearchKeyValueType(type.mapKeyType()) && isFastMapSearchKeyValueType(type.mapValueType());
+        }
+        return false;
+    }
 
     private static final String TOKENS_MODE_CHOICE = "${1|original,first-alternative,alternatives,original-and-alternatives|}";
 
@@ -327,6 +382,12 @@ public class BodyKeywordCompletion implements CompletionProvider {
 
         List<CompletionItem> result = bodyKeywordSnippets.get(searchNode.getASTClass());
         if (result == null) return List.of();
+
+        if (searchNode.isASTInstance(fieldElm.class) && supportsFastMapSearch(searchNode)) {
+            List<CompletionItem> withMap = new ArrayList<>(result);
+            withMap.addAll(mapFieldSnippets);
+            return withMap;
+        }
         return result;
     }
 }

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/FixedKeywordBodies.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/FixedKeywordBodies.java
@@ -17,6 +17,7 @@ import ai.vespa.schemals.parser.ast.fieldRankFilter;
 import ai.vespa.schemals.parser.ast.fieldStemming;
 import ai.vespa.schemals.parser.ast.hnswIndex;
 import ai.vespa.schemals.parser.ast.indexInsideField;
+import ai.vespa.schemals.parser.ast.mapElm;
 import ai.vespa.schemals.parser.ast.matchSettingsElm;
 import ai.vespa.schemals.parser.ast.normalizingElm;
 import ai.vespa.schemals.parser.ast.onnxModelItem;
@@ -134,6 +135,10 @@ public class FixedKeywordBodies {
     public static FixedKeywordBody WEIGHTEDSET = new FixedKeywordBody("weightedset", TokenType.WEIGHTEDSET, weightedsetElm.class, List.of(
         CompletionUtils.constructBasic("create-if-nonexistent"),
         CompletionUtils.constructBasic("remove-if-zero")
+    ));
+
+    public static FixedKeywordBody MAP = new FixedKeywordBody("map", TokenType.MAP, mapElm.class, List.of(
+        CompletionUtils.constructBasic("fast-search")
     ));
 
     public static FixedKeywordBody HNSW = new FixedKeywordBody("hnsw", TokenType.HNSW, hnswIndex.class, List.of(

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/SimpleColonCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/SimpleColonCompletion.java
@@ -20,6 +20,7 @@ public class SimpleColonCompletion implements CompletionProvider {
         FixedKeywordBodies.ATTRIBUTE,
         FixedKeywordBodies.DISTANCE_METRIC,
         FixedKeywordBodies.INDEX,
+        FixedKeywordBodies.MAP,
         FixedKeywordBodies.MATCH,
         FixedKeywordBodies.RANK,
         FixedKeywordBodies.RANK_TYPE,

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokenConfig.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokenConfig.java
@@ -94,6 +94,7 @@ class SchemaSemanticTokenConfig {
         add(TokenType.LINGUISTICS);
         add(TokenType.LOWER_BOUND);
         add(TokenType.MACRO);
+        add(TokenType.MAP);
         add(TokenType.MATCH);
         add(TokenType.MATCH_FEATURES);
         add(TokenType.MATCH_PHASE);

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokens.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/semantictokens/SchemaSemanticTokens.java
@@ -36,6 +36,7 @@ import ai.vespa.schemals.parser.ast.documentElm;
 import ai.vespa.schemals.parser.ast.documentIdElm;
 import ai.vespa.schemals.parser.ast.fieldRankType;
 import ai.vespa.schemals.parser.ast.integerElm;
+import ai.vespa.schemals.parser.ast.mapElm;
 import ai.vespa.schemals.parser.ast.matchItem;
 import ai.vespa.schemals.parser.ast.matchType;
 import ai.vespa.schemals.parser.ast.quotedString;
@@ -141,7 +142,7 @@ public class SchemaSemanticTokens {
                 tokenType = CommonSemanticTokens.getType(SemanticTokenTypes.Property); 
                 modifier = SemanticTokenModifiers.Readonly;
             }
-            if (tokenType == null) {
+            if (tokenType == null && !isMapTypeConstructor(node)) {
                 tokenType = schemaTokenTypeMap.get(schemaType);
             }
 
@@ -185,6 +186,19 @@ public class SchemaSemanticTokens {
 
 
         return ret;
+    }
+
+    /**
+     * 'map' is both a type constructor, as in map&lt;string, int&gt;, and the keyword opening the map settings
+     * block, as in 'map: fast-search'. In a type it is already colored by the dataType handling above,
+     * so it should only get the keyword color when it opens a map settings block.
+     */
+    private static boolean isMapTypeConstructor(SchemaNode node) {
+        if (node.getSchemaType() != TokenType.MAP) {
+            return false;
+        }
+        Node parent = node.getParent();
+        return parent == null || !parent.isASTInstance(mapElm.class);
     }
 
     private static final Set<Class<?>> enumLikeItems = new HashSet<>() {{

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/LSPTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/LSPTest.java
@@ -1,6 +1,7 @@
 package ai.vespa.schemals;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -17,6 +18,8 @@ import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SemanticTokensLegend;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +28,7 @@ import com.yahoo.io.IOUtils;
 
 import ai.vespa.schemals.common.ClientLogger;
 import ai.vespa.schemals.context.EventCompletionContext;
+import ai.vespa.schemals.context.EventDocumentContext;
 import ai.vespa.schemals.context.EventPositionContext;
 import ai.vespa.schemals.context.InvalidContextException;
 import ai.vespa.schemals.context.ParseContext;
@@ -32,7 +36,9 @@ import ai.vespa.schemals.index.SchemaIndex;
 import ai.vespa.schemals.lsp.schema.completion.SchemaCompletion;
 import ai.vespa.schemals.lsp.schema.completion.provider.BodyKeywordCompletion;
 import ai.vespa.schemals.lsp.schema.definition.SchemaDefinition;
+import ai.vespa.schemals.lsp.common.semantictokens.CommonSemanticTokens;
 import ai.vespa.schemals.lsp.schema.hover.SchemaHover;
+import ai.vespa.schemals.lsp.schema.semantictokens.SchemaSemanticTokens;
 import ai.vespa.schemals.schemadocument.DocumentManager;
 import ai.vespa.schemals.schemadocument.SchemaDocumentScheduler;
 import ai.vespa.schemals.schemadocument.parser.schema.IdentifySymbolDefinition;
@@ -142,6 +148,99 @@ public class LSPTest {
                      "Inside a linguistics search body profile and tokens should be suggested.");
         assertTrue(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(16, 12)).contains("linguistics"),
                    "linguistics should be suggested in a field body.");
+    }
+
+    /**
+     * 'map: fast-search' is only accepted by the config model on maps with string or int keys and values,
+     * so {@link BodyKeywordCompletion} should only suggest the map block in such fields.
+     */
+    @Test
+    void mapFastSearchCompletionTest() throws IOException, InvalidContextException {
+        String fileName = "src/test/sdfiles/single/mapcompletion.sd";
+        File file = new File(fileName);
+        String fileURI = file.toURI().toString();
+        String fileContent = IOUtils.readFile(file);
+
+        SchemaLanguageServer.serverPath = Paths.get("target");
+
+        TestSchemaMessageHandler messageHandler = new TestSchemaMessageHandler();
+        TestSchemaProgressHandler progressHandler = new TestSchemaProgressHandler();
+        ClientLogger logger = new TestLogger(messageHandler);
+        SchemaIndex schemaIndex = new SchemaIndex(logger);
+        TestSchemaDiagnosticsHandler diagnosticsHandler = new TestSchemaDiagnosticsHandler(new ArrayList<>());
+        SchemaDocumentScheduler scheduler = new SchemaDocumentScheduler(logger, diagnosticsHandler, schemaIndex, messageHandler, progressHandler);
+
+        scheduler.openDocument(new TextDocumentItem(fileURI, "vespaSchema", 0, fileContent));
+        DocumentManager document = scheduler.getDocument(fileURI);
+
+        // Positions are 0-indexed and point at the empty line inside the given field body.
+        assertTrue(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(4, 12)).contains("map"),
+                   "map should be suggested in a map<string, string> field.");
+        assertTrue(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(8, 12)).contains("map"),
+                   "map should be suggested in a map<string, int> field.");
+        assertFalse(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(12, 12)).contains("map"),
+                    "map should not be suggested in a map<string, long> field.");
+        assertFalse(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(16, 12)).contains("map"),
+                    "map should not be suggested in a string field.");
+        assertFalse(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(20, 12)).contains("map"),
+                    "map should not be suggested in an array<string> field.");
+        assertEquals(List.of("fast-search"), completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(24, 17)),
+                     "fast-search should be the only suggestion after 'map: '.");
+        assertEquals(List.of("fast-search"), completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(29, 16)),
+                     "fast-search should be the only suggestion inside a map block.");
+    }
+
+    /**
+     * 'map' is both a type constructor and the keyword opening a map settings block.
+     * It should be colored as a type in the former case and as a keyword in the latter.
+     */
+    @Test
+    void mapSemanticTokenTest() throws IOException, InvalidContextException {
+        String fileName = "src/test/sdfiles/single/mapcompletion.sd";
+        File file = new File(fileName);
+        String fileURI = file.toURI().toString();
+        String fileContent = IOUtils.readFile(file);
+
+        TestSchemaMessageHandler messageHandler = new TestSchemaMessageHandler();
+        TestSchemaProgressHandler progressHandler = new TestSchemaProgressHandler();
+        ClientLogger logger = new TestLogger(messageHandler);
+        SchemaIndex schemaIndex = new SchemaIndex(logger);
+        TestSchemaDiagnosticsHandler diagnosticsHandler = new TestSchemaDiagnosticsHandler(new ArrayList<>());
+        SchemaDocumentScheduler scheduler = new SchemaDocumentScheduler(logger, diagnosticsHandler, schemaIndex, messageHandler, progressHandler);
+
+        scheduler.openDocument(new TextDocumentItem(fileURI, "vespaSchema", 0, fileContent));
+
+        // Building the legend also initializes the token type tables used when producing tokens.
+        SemanticTokensLegend legend = CommonSemanticTokens.getSemanticTokensRegistrationOptions().getLegend();
+        EventDocumentContext context = new EventDocumentContext(scheduler, schemaIndex, messageHandler, new TextDocumentIdentifier(fileURI));
+        List<Integer> data = SchemaSemanticTokens.getSemanticTokens(context).getData();
+
+        // Positions are 0-indexed: the 'map' of 'type map<string, string>' on line 2 and of 'map: fast-search' on line 24.
+        assertEquals(List.of("type"), semanticTokenTypesAt(data, legend, new Position(2, 33)),
+                     "map in a field type should be colored as a type.");
+        assertEquals(List.of("keyword"), semanticTokenTypesAt(data, legend, new Position(24, 12)),
+                     "map opening a map settings block should be colored as a keyword.");
+        assertEquals(List.of("keyword"), semanticTokenTypesAt(data, legend, new Position(28, 12)),
+                     "map opening a map settings block should be colored as a keyword.");
+        assertEquals(List.of("keyword"), semanticTokenTypesAt(data, legend, new Position(24, 17)),
+                     "fast-search in a map settings block should be colored as a keyword.");
+    }
+
+    /** Decodes the delta-encoded semantic token data and returns the type names of the tokens starting at the given position. */
+    private List<String> semanticTokenTypesAt(List<Integer> data, SemanticTokensLegend legend, Position position) {
+        List<String> ret = new ArrayList<>();
+        int line = 0;
+        int column = 0;
+        for (int i = 0; i + 4 < data.size(); i += 5) {
+            int deltaLine = data.get(i);
+            int deltaColumn = data.get(i + 1);
+            line += deltaLine;
+            column = (deltaLine == 0) ? column + deltaColumn : deltaColumn;
+            if (line == position.getLine() && column == position.getCharacter()) {
+                ret.add(legend.getTokenTypes().get(data.get(i + 3)));
+            }
+        }
+        return ret;
     }
 
     private List<String> completionLabelsAt(SchemaDocumentScheduler scheduler,

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/SchemaParserTest.java
@@ -249,6 +249,7 @@ public class SchemaParserTest {
             "src/test/sdfiles/single/embed.sd",
             "src/test/sdfiles/single/foreach.sd",
             "src/test/sdfiles/single/linguistics.sd",
+            "src/test/sdfiles/single/mapcompletion.sd",
             "src/test/sdfiles/single/mapfastsearch.sd",
             "src/test/sdfiles/single/rankprofilebuiltin.sd",
             "src/test/sdfiles/single/sortfeatures.sd",

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/mapcompletion.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/mapcompletion.sd
@@ -1,0 +1,34 @@
+schema mapcompletion {
+    document mapcompletion {
+        field string_values type map<string, string> {
+            indexing: summary
+
+        }
+        field int_values type map<string, int> {
+            indexing: summary
+
+        }
+        field long_values type map<string, long> {
+            indexing: summary
+
+        }
+        field plain type string {
+            indexing: summary
+
+        }
+        field strings type array<string> {
+            indexing: summary
+
+        }
+        field short_form type map<string, string> {
+            indexing: summary
+            map: fast-search
+        }
+        field block_form type map<int, int> {
+            indexing: summary
+            map {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add semantic token for `map: fast-search`.
- Add completion for `map` that only appears if the type is `map<string,string>` or `map <string,int>`. It has one completion item: `fast-search`.

_Written by Claude Code 🤖_ 