### PR TITLE
Propagate map casing to the fast map search attribute

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
@@ -9,6 +9,8 @@ import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.schema.RankProfileRegistry;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.document.Attribute;
+import com.yahoo.schema.document.Case;
+import com.yahoo.schema.document.Dictionary;
 import com.yahoo.schema.document.SDDocumentType;
 import com.yahoo.schema.document.SDField;
 import com.yahoo.searchlib.document.FastMapSearch;
@@ -94,9 +96,44 @@ public class CreateFastMapSearch extends Processor {
         Attribute attribute = new Attribute(fieldName, Attribute.Type.STRING, Attribute.CollectionType.ARRAY);
         attribute.setFastSearch(true);
         field.addAttribute(attribute);
+        if (isCasedKeyValue(inputField, valueType, validate)) {
+            // Uncased is the default, so only a cased map has anything to set. The field must carry the
+            // casing too, as later processors derive attribute casing from it, and the dictionary must be
+            // cased or the lookup would be folded.
+            field.setMatchingCase(Case.CASED);
+            attribute.setCase(Case.CASED);
+            Dictionary dictionary = field.getOrSetDictionary();
+            dictionary.updateMatch(Case.CASED);
+            attribute.setDictionary(dictionary);
+        }
         field.setIndexingScript(schema.getName(), keyValueScript(inputField, fieldName, valueType));
         field.setInternalField(true);
         return field;
+    }
+
+    /**
+     * Returns whether the synthetic attribute of the given map field is matched cased. Key and value share one
+     * term, so a string value must be matched like the key. An int value is hex encoded, and so is matched the
+     * same way whichever casing the term has.
+     */
+    private boolean isCasedKeyValue(SDField inputField, DataType valueType, boolean validate) {
+        boolean casedKey = isCased(inputField, "key");
+        if (valueType != DataType.STRING) {
+            return casedKey;
+        }
+        boolean casedValue = isCased(inputField, "value");
+        if (validate && casedKey != casedValue) {
+            throw newProcessException(schema.getName(), inputField.getName(),
+                                      "Map with fast search requires the same match casing on the key and the value, " +
+                                      "but only the " + (casedKey ? "key" : "value") + " is cased.");
+        }
+        return casedKey;
+    }
+
+    /** Returns whether the named struct field of the given map field is matched cased. */
+    private static boolean isCased(SDField mapField, String structFieldName) {
+        SDField structField = mapField.getStructField(structFieldName);
+        return structField != null && structField.getMatching().getCase() == Case.CASED;
     }
 
     /**

--- a/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
@@ -7,6 +7,7 @@ import com.yahoo.language.process.ProcessingException;
 import com.yahoo.schema.ApplicationBuilder;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.document.Attribute;
+import com.yahoo.schema.document.Case;
 import com.yahoo.schema.document.SDField;
 import com.yahoo.schema.parser.ParseException;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,47 @@ public class CreateFastMapSearchTest {
             assertEquals(Attribute.Type.STRING, attribute.getType());
             assertEquals(Attribute.CollectionType.ARRAY, attribute.getCollectionType());
             assertTrue(attribute.isFastSearch());
+        }
+    }
+
+    @Test
+    void requireKeyValueAttributeIsUncasedByDefault() throws ParseException {
+        for (String valueType : supportedValueTypes) {
+            var schema = build(fastSearchMap("foo", "string", valueType));
+
+            Attribute attribute = keyValueAttribute(schema, "foo");
+            assertEquals(Case.UNCASED, attribute.getCase());
+            assertNull(attribute.getDictionary(), "An uncased attribute keeps the default dictionary");
+        }
+    }
+
+    /** A cased key and value give a cased term, which needs a cased dictionary or the lookup would be folded. */
+    @Test
+    void requireKeyValueAttributeIsCasedWhenTheStringMapIsCased() throws ParseException {
+        var schema = build(casedFastSearchMap("foo", "string", true, true));
+
+        Attribute attribute = keyValueAttribute(schema, "foo");
+        assertEquals(Case.CASED, attribute.getCase());
+        assertNotNull(attribute.getDictionary());
+        assertEquals(Case.CASED, attribute.getDictionary().getMatch());
+    }
+
+    /** An int value is hex encoded the same way at index and query time, so only the key decides the casing. */
+    @Test
+    void requireKeyValueAttributeOfAnIntMapFollowsTheKeyCasing() throws ParseException {
+        assertEquals(Case.CASED, keyValueAttribute(build(casedFastSearchMap("foo", "int", true, false)), "foo").getCase());
+        assertEquals(Case.UNCASED, keyValueAttribute(build(casedFastSearchMap("foo", "int", false, false)), "foo").getCase());
+    }
+
+    @Test
+    void requireErrorWhenOnlyOneOfTheKeyAndValueOfAStringMapIsCased() {
+        for (boolean casedKey : new boolean[] { true, false }) {
+            var exception = assertThrows(IllegalArgumentException.class,
+                    () -> build(casedFastSearchMap("foo", "string", casedKey, !casedKey)));
+            assertTrue(exception.getMessage().contains("Map with fast search requires the same match casing " +
+                                                       "on the key and the value, but only the " +
+                                                       (casedKey ? "key" : "value") + " is cased."),
+                    "Unexpected message: " + exception.getMessage());
         }
     }
 
@@ -164,6 +206,28 @@ public class CreateFastMapSearchTest {
             assertNotNull(child.getConcreteField("bar$keyvalue"), "Expected key-value field for the child's own map");
             assertNull(parent.getConcreteField("bar$keyvalue"));
         }
+    }
+
+    private static Attribute keyValueAttribute(Schema schema, String mapName) {
+        String fieldName = mapName + "$keyvalue";
+        Attribute attribute = schema.getConcreteField(fieldName).getAttributes().get(fieldName);
+        assertNotNull(attribute);
+        return attribute;
+    }
+
+    private static String casedFastSearchMap(String name, String valueType, boolean casedKey, boolean casedValue) {
+        return joinLines("field " + name + " type map<string, " + valueType + "> {",
+                         "  indexing: summary",
+                         "  map: fast-search",
+                         "  struct-field key {",
+                         "    indexing: attribute",
+                         "    match: " + (casedKey ? "cased" : "uncased"),
+                         "  }",
+                         "  struct-field value {",
+                         "    indexing: attribute",
+                         "    match: " + (casedValue ? "cased" : "uncased"),
+                         "  }",
+                         "}");
     }
 
     private static String nonFastSearchMap(String name, String keyType, String valueType) {


### PR DESCRIPTION
Checks if the synthetic field has to be cased. Throws an exception if the key and value attributes using different casing.

Written by Claude, reviewed by me.