### PR TITLE
Added onnx session sharing for triton

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1462,6 +1462,7 @@
       "public long zookeeperPreAllocSize()",
       "public int maxContentNodeMaintenanceOpConcurrency()",
       "public com.yahoo.config.model.api.ModelContext$FeatureFlag useTritonFlag()",
+      "public com.yahoo.config.model.api.ModelContext$FeatureFlag tritonShareOnnxSessionFlag()",
       "public boolean ignoreConnectivityChecksAtStartup()",
       "public boolean requireExplicitDocprocCluster()",
       "public com.yahoo.config.model.api.ModelContext$FeatureFlag metricsProxyHeapSizeInMibFlag()",

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -121,6 +121,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"hmusum"}) default long zookeeperPreAllocSize() { return 65536L; }
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxContentNodeMaintenanceOpConcurrency() { return -1; }
         @ModelFeatureFlag(owners = {"glebashnik"}) default FeatureFlag<Boolean> useTritonFlag() { return () -> false; }
+        @ModelFeatureFlag(owners = {"glebashnik"}) default FeatureFlag<Boolean> tritonShareOnnxSessionFlag() { return () -> false; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean ignoreConnectivityChecksAtStartup() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default boolean requireExplicitDocprocCluster() { return false; }
         @ModelFeatureFlag(owners = {"hmusum"}) default FeatureFlag<Integer> metricsProxyHeapSizeInMibFlag() { return () -> 0; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -79,6 +79,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private final Map<ClusterSpec.Type, String> mallocImpl = new HashMap<>();
     private final Map<String, Integer> searchNodeInitializerThreads = new HashMap<>();
     private boolean useTriton = false;
+    private boolean tritonShareOnnxSession = false;
     private OptionalInt metricsProxyHeapSizeInMib = OptionalInt.empty();
     private OptionalInt metricsProxyAdminNodeHeapSizeInMib = OptionalInt.empty();
     private boolean ignoreConnectivityChecksAtStartup = false;
@@ -142,6 +143,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
         return clusterType.map(c -> mallocImpl.get(c)).orElse(null);
     }
     @Override public ModelContext.FeatureFlag<Boolean> useTritonFlag() { return () -> useTriton; }
+    @Override public ModelContext.FeatureFlag<Boolean> tritonShareOnnxSessionFlag() { return () -> tritonShareOnnxSession; }
     @Override public ModelContext.FeatureFlag<Integer> metricsProxyHeapSizeInMibFlag() { return () -> metricsProxyHeapSizeInMib.orElse(0); }
     @Override public OptionalInt metricsProxyAdminNodeHeapSizeInMib() { return metricsProxyAdminNodeHeapSizeInMib; }
     @Override public boolean ignoreConnectivityChecksAtStartup() { return ignoreConnectivityChecksAtStartup; }
@@ -358,6 +360,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setUseTriton(boolean value) {
         this.useTriton = value;
+        return this;
+    }
+
+    public TestProperties setTritonShareOnnxSession(boolean value) {
+        this.tritonShareOnnxSession = value;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container;
 
+import ai.vespa.llm.clients.TritonConfig;
 import ai.vespa.metricsproxy.http.application.ApplicationMetricsHandler;
 import com.yahoo.cloud.config.CuratorConfig;
 import com.yahoo.cloud.config.ZookeeperServerConfig;
@@ -74,6 +75,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
         MetricsProxyApiConfig.Producer,
         ZookeeperServerConfig.Producer,
         DocumentOperationExecutorConfig.Producer,
+        TritonConfig.Producer,
         ApplicationClusterInfo {
 
     public static final String METRICS_V2_HANDLER_CLASS = MetricsV2Handler.class.getName();
@@ -106,6 +108,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     private int zookeeperSessionTimeoutSeconds = 30;
     private final int transport_events_before_wakeup;
     private final int transport_connections_per_target;
+    private final boolean tritonShareOnnxSession;
     private int maxDocumentOperationRequestSizeMib = new DocumentOperationExecutorConfig.Builder().build().maxDocumentOperationRequestSizeMib();
 
     /** The heap size % of total memory available to the JVM process. */
@@ -149,6 +152,10 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
         addTestrunnerComponentsIfTester(deployState);
         transport_connections_per_target = deployState.featureFlags().mbusJavaRpcNumTargets();
         transport_events_before_wakeup = deployState.featureFlags().mbusJavaEventsBeforeWakeup();
+        tritonShareOnnxSession = deployState.featureFlags().tritonShareOnnxSessionFlag()
+                                            .withClusterType(ClusterSpec.Type.container)
+                                            .withClusterId(id())
+                                            .value();
         var heapSizeFromFlag = deployState.featureFlags().heapSizePercentage(Optional.of(getName()));
         heapSizePercentageOfAvailableMemory = heapSizeFromFlag > 0
                 ? Math.min(99, heapSizeFromFlag)
@@ -451,6 +458,11 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     @Override
     public void getConfig(DocumentOperationExecutorConfig.Builder builder) {
         builder.maxDocumentOperationRequestSizeMib(maxDocumentOperationRequestSizeMib);
+    }
+
+    @Override
+    public void getConfig(TritonConfig.Builder builder) {
+        builder.shareOnnxSessionBetweenInstances(tritonShareOnnxSession);
     }
 
     public static class MbusParams {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForTritonOnnxRuntimeValidatorTest.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation.change;
 
+import ai.vespa.llm.clients.TritonConfig;
 import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.api.ConfigChangeRestartAction.ConfigChange;
 import com.yahoo.config.model.api.OnnxModelCost;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -120,6 +122,29 @@ public class RestartOnDeployForTritonOnnxRuntimeValidatorTest {
         assertEquals(ConfigChange.DEFER_UNTIL_RESTART, restartAction.configChange());
     }
 
+    // Session sharing is decided by a feature flag and written to the Triton config of the runtime component.
+    @Test
+    void session_sharing_feature_flag_is_written_to_triton_config() {
+        assertFalse(tritonConfig(createModel(SERVICES_XML_WITH_ONE_CLUSTER, true, false)).shareOnnxSessionBetweenInstances());
+        assertTrue(tritonConfig(createModel(SERVICES_XML_WITH_ONE_CLUSTER, true, true)).shareOnnxSessionBetweenInstances());
+    }
+
+    // Pins the restart marker on the session sharing field, which the feature flag flips.
+    @Test
+    void restart_when_triton_session_sharing_changes() {
+        var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER, true, false);
+        var next = createModel(SERVICES_XML_WITH_ONE_CLUSTER, true, true);
+        var result = validateModel(previous, next);
+
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).getMessage().contains("Triton config changed"));
+        assertTrue(result.get(0).getMessage().contains("shareOnnxSessionBetweenInstances"));
+        assertEquals(ConfigChangeAction.Type.RESTART, result.get(0).getType());
+
+        var restartAction = (VespaRestartAction) result.get(0);
+        assertEquals(ConfigChange.DEFER_UNTIL_RESTART, restartAction.configChange());
+    }
+
     @Test
     void no_restart_when_triton_runtime_remains_disabled() {
         var previous = createModel(SERVICES_XML_WITH_ONE_CLUSTER, false);
@@ -151,19 +176,29 @@ public class RestartOnDeployForTritonOnnxRuntimeValidatorTest {
         return ValidationTester.validateChanges(
                 new RestartOnDeployForTritonOnnxRuntimeValidator(),
                 next,
-                deployStateBuilder(false)
+                deployStateBuilder(false, false)
                         .properties(new TestProperties().setHostedVespa(true))
                         .previousModel(current)
                         .build());
     }
 
     private static VespaModel createModel(String servicesXml, boolean useTriton) {
-        var builder = deployStateBuilder(useTriton);
+        return createModel(servicesXml, useTriton, false);
+    }
+
+    private static VespaModel createModel(String servicesXml, boolean useTriton, boolean shareSession) {
+        var builder = deployStateBuilder(useTriton, shareSession);
         return new VespaModelCreatorWithMockPkg(null, servicesXml).create(builder);
     }
 
-    private static DeployState.Builder deployStateBuilder(boolean useTriton) {
-        var deployStateBuilder = new DeployState.Builder().properties(new TestProperties().setUseTriton(useTriton));
+    // The cluster produces the config for all its Triton components.
+    private static TritonConfig tritonConfig(VespaModel model) {
+        return model.getConfig(TritonConfig.class, "cluster1");
+    }
+
+    private static DeployState.Builder deployStateBuilder(boolean useTriton, boolean shareSession) {
+        var deployStateBuilder = new DeployState.Builder().properties(
+                new TestProperties().setUseTriton(useTriton).setTritonShareOnnxSession(shareSession));
 
         if (useTriton) {
             var mockModelCost = new OnnxModelCost.DisabledOnnxModelCost() {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -254,6 +254,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public long zookeeperPreAllocSize() { return flag(PermanentFlags.ZOOKEEPER_PRE_ALLOC_SIZE_KIB).value(); }
         @Override public int maxContentNodeMaintenanceOpConcurrency() { return flag(PermanentFlags.MAX_CONTENT_NODE_MAINTENANCE_OP_CONCURRENCY).value(); }
         @Override public ModelContext.FeatureFlag<Boolean> useTritonFlag() { return flag(Flags.USE_TRITON); }
+        @Override public ModelContext.FeatureFlag<Boolean> tritonShareOnnxSessionFlag() { return flag(Flags.TRITON_SHARE_ONNX_SESSION); }
         @Override public ModelContext.FeatureFlag<Integer> metricsProxyHeapSizeInMibFlag() { return flag(Flags.METRICS_PROXY_HEAP_SIZE_IN_MIB); }
         @Override public OptionalInt metricsProxyAdminNodeHeapSizeInMib() { return toOptionalInt(flag(Flags.METRICS_PROXY_ADMIN_HEAP_SIZE_IN_MIB).value()); }
         @Override public boolean ignoreConnectivityChecksAtStartup() { return flag(PermanentFlags.IGNORE_CONNECTIVITY_CHECKS_AT_STARTUP).value(); }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -193,7 +193,15 @@ public class Flags {
             "use-triton", false,
             List.of("glebashnik"), "2025-04-30", "2026-12-01",
             "Whether to use Triton as ONNX runtime",
-            "Takes effect at redeployment",
+            "Takes effect at redeployment (requires restart)",
+            TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_TYPE, CLUSTER_ID, VESPA_VERSION
+    );
+
+    public static final UnboundBooleanFlag TRITON_SHARE_ONNX_SESSION = defineFeatureFlag(
+            "triton-share-onnx-session", false,
+            List.of("glebashnik"), "2026-09-04", "2026-12-01",
+            "Whether model instances in Triton share one ONNX Runtime session per device instead of each loading the model",
+            "Takes effect at redeployment (requires restart)",
             TENANT_ID, APPLICATION, INSTANCE_ID, CLUSTER_TYPE, CLUSTER_ID, VESPA_VERSION
     );
 

--- a/model-integration/abi-spec.json
+++ b/model-integration/abi-spec.json
@@ -303,6 +303,7 @@
       "public ai.vespa.llm.clients.TritonConfig$Builder target(java.lang.String)",
       "public ai.vespa.llm.clients.TritonConfig$Builder modelRepositoryPath(java.lang.String)",
       "public ai.vespa.llm.clients.TritonConfig$Builder modelControlMode(ai.vespa.llm.clients.TritonConfig$ModelControlMode$Enum)",
+      "public ai.vespa.llm.clients.TritonConfig$Builder shareOnnxSessionBetweenInstances(boolean)",
       "public ai.vespa.llm.clients.TritonConfig$Builder timeout(long)",
       "public final boolean dispatchGetConfig(com.yahoo.config.ConfigInstance$Producer)",
       "public final java.lang.String getDefMd5()",
@@ -379,6 +380,7 @@
       "public java.lang.String target()",
       "public java.lang.String modelRepositoryPath()",
       "public ai.vespa.llm.clients.TritonConfig$ModelControlMode$Enum modelControlMode()",
+      "public boolean shareOnnxSessionBetweenInstances()",
       "public long timeout()"
     ],
     "fields" : [

--- a/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
+++ b/model-integration/src/main/java/ai/vespa/triton/TritonOnnxRuntime.java
@@ -44,6 +44,7 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
 
     private final TritonOnnxClient tritonClient;
     private final boolean isModelControlExplicit;
+    private final boolean shareSessionBetweenInstances;
     private final Path modelRepositoryPath;
 
     // The key is a model name containing hash of model content and options.
@@ -67,11 +68,12 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
     // Injectable tritonClient for testing.
     // Takes ownership of the client: deconstruct() closes it.
     TritonOnnxRuntime(TritonConfig config, TritonOnnxClient tritonClient) {
-        log.info("Creating Triton ONNX runtime");
-
         this.tritonClient = tritonClient;
 
         isModelControlExplicit = config.modelControlMode() == TritonConfig.ModelControlMode.EXPLICIT;
+        shareSessionBetweenInstances = config.shareOnnxSessionBetweenInstances();
+        log.info("Creating Triton ONNX runtime with session sharing between model instances "
+                 + (shareSessionBetweenInstances ? "enabled" : "disabled"));
         modelRepositoryPath = Path.of(Defaults.getDefaults().underVespaHome(config.modelRepositoryPath()));
 
         if (isModelControlExplicit) {
@@ -85,7 +87,7 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
 
     @Override
     public OnnxEvaluator evaluatorOf(String modelPath, OnnxEvaluatorOptions options) {
-        var modelName = generateModelName(modelPath, options);
+        var modelName = generateModelName(modelPath, options, shareSessionBetweenInstances);
         var modelReference = referenceModel(modelName, modelPath, options);
 
         try {
@@ -193,12 +195,13 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         }
     }
 
-    static String generateModelName(String modelPath, OnnxEvaluatorOptions options) {
+    static String generateModelName(String modelPath, OnnxEvaluatorOptions options, boolean shareSession) {
         var fileName = Paths.get(modelPath).getFileName().toString();
         var baseName = fileName.substring(0, fileName.lastIndexOf('.')); // remove file extension
         var modelHash = ModelPathOrData.of(modelPath).calculateHash();
         var optionsHash = options.calculateHash();
-        var combinedHash = Long.toHexString(31 * modelHash + optionsHash);
+        var shareSessionHash = shareSession ? 1 : 0;
+        var combinedHash = Long.toHexString(31 * modelHash + optionsHash + shareSessionHash);
         return baseName + "_" + combinedHash; // add hash to avoid conflicts
     }
 
@@ -249,14 +252,14 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         Files.setPosixFilePermissions(path, modelPerms);
     }
 
-    private static String createModelConfig(String modelName, OnnxEvaluatorOptions options) {
+    private String createModelConfig(String modelName, OnnxEvaluatorOptions options) {
         return options.modelConfigOverride()
                 .map(path -> createModelConfigFromFile(path, modelName))
                 .orElseGet(() -> createModelConfigFromOptions(modelName, options))
                 .toString();
     }
 
-    private static String createModelConfigFromOptions(String modelName, OnnxEvaluatorOptions options) {
+    private String createModelConfigFromOptions(String modelName, OnnxEvaluatorOptions options) {
         // Similar to EmbeddedOnnxRuntime.overrideOptions(), relies on Triton to fall back to CPU if GPU is
         // not available.
         var deviceKind = options.gpuDeviceRequired()
@@ -309,6 +312,8 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
                                 .setStringValue(Integer.toString(options.interOpThreads()))
                                 .build());
 
+        addSessionSharingParameter(configBuilder);
+
         if (options.batchingMaxSize() > 1) {
             configBuilder.setDynamicBatching(ModelConfigOuterClass.ModelDynamicBatching.newBuilder().build());
         }
@@ -326,7 +331,21 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         return configBuilder.build().toString();
     }
 
-    private static String createModelConfigFromFile(Path configPath, String modelName) {
+    // Sharing one session per device loads the model weights once per device instead of once per instance.
+    // The parameter is read by the patched ONNX Runtime backend in Vespa's Triton images and ignored by stock images.
+    private void addSessionSharingParameter(ModelConfigOuterClass.ModelConfig.Builder configBuilder) {
+        if (!shareSessionBetweenInstances) {
+            return;
+        }
+
+        configBuilder.putParameters(
+                "share_session_between_instances",
+                ModelConfigOuterClass.ModelParameter.newBuilder()
+                        .setStringValue("true")
+                        .build());
+    }
+
+    private String createModelConfigFromFile(Path configPath, String modelName) {
         String configStr;
 
         try {
@@ -344,7 +363,9 @@ public class TritonOnnxRuntime extends AbstractComponent implements OnnxRuntime 
         }
 
         // Replaces model name with the one that includes model content and options hash to avoid conflicts.
-        return config.toBuilder().setName(modelName).build().toString();
+        var configBuilder = config.toBuilder().setName(modelName);
+        addSessionSharingParameter(configBuilder);
+        return configBuilder.build().toString();
     }
 
     private void deleteAllModelFilesFromModelRepository() {

--- a/model-integration/src/main/resources/configdefinitions/triton.def
+++ b/model-integration/src/main/resources/configdefinitions/triton.def
@@ -16,6 +16,11 @@ modelRepositoryPath string default="/sidecars/triton/models" restart
 # Model control mode. Client will only issue model load/unload requests if mode is EXPLICIT.
 modelControlMode enum {NONE, POLL, EXPLICIT} default=EXPLICIT restart
 
+# Whether the instances of a model share one ONNX Runtime session per device instead of each loading the model.
+# Requires a Triton image with the share_session_between_instances patch of the ONNX Runtime backend.
+# Sharing keeps one copy of the model weights per device. Concurrency is still controlled by the instance count.
+shareOnnxSessionBetweenInstances bool default=false restart
+
 # Default per-call gRPC deadline for inference requests, in milliseconds.
 # Used as a fallback when the caller (e.g. an embedder) does not supply a deadline derived
 # from the Vespa request context. When the caller does supply one, that value takes precedence.

--- a/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonOnnxRuntimeTest.java
@@ -104,6 +104,14 @@ class TritonOnnxRuntimeTest {
     }
 
     @Test
+    void load_model_with_shared_session() throws IOException {
+        var opts = optsBuilder
+                .setConcurrency(2, OnnxEvaluatorOptions.ConcurrencyFactorType.ABSOLUTE)
+                .build();
+        assertLoadModel("src/test/triton/config_with_shared_session.pbtxt", opts, true);
+    }
+
+    @Test
     void load_model_with_model_config_override() throws IOException {
         var configPathInput = "src/test/triton/config_with_model_config_override_input.pbtxt";
         var configPathOutput = "src/test/triton/config_with_model_config_override_output.pbtxt";
@@ -111,6 +119,16 @@ class TritonOnnxRuntimeTest {
                 .setModelConfigOverride(Optional.of(Path.of(configPathInput)))
                 .build();
         assertLoadModel(configPathOutput, opts);
+    }
+
+    @Test
+    void load_model_with_model_config_override_and_shared_session() throws IOException {
+        var configPathInput = "src/test/triton/config_with_model_config_override_input.pbtxt";
+        var configPathOutput = "src/test/triton/config_with_model_config_override_shared_session_output.pbtxt";
+        var opts = optsBuilder
+                .setModelConfigOverride(Optional.of(Path.of(configPathInput)))
+                .build();
+        assertLoadModel(configPathOutput, opts, true);
     }
 
     @Test
@@ -133,11 +151,11 @@ class TritonOnnxRuntimeTest {
 
         var modelBaseName1 = "dummy_transformer";
         var modelPath1 = Text.format("src/test/models/onnx/transformer/%s.onnx", modelBaseName1);
-        var modelName1 = TritonOnnxRuntime.generateModelName(modelPath1, opts);
+        var modelName1 = TritonOnnxRuntime.generateModelName(modelPath1, opts, false);
 
         var modelBaseName2 = "dummy_transformer_mlm";
         var modelPath2 = Text.format("src/test/models/onnx/transformer/%s.onnx", modelBaseName2);
-        var modelName2 = TritonOnnxRuntime.generateModelName(modelPath2, opts);
+        var modelName2 = TritonOnnxRuntime.generateModelName(modelPath2, opts, false);
 
         var client = createClient();
         var runtime = createRuntime();
@@ -189,7 +207,7 @@ class TritonOnnxRuntimeTest {
     @Test
     void restore_requested_model_when_it_was_removed_independently() {
         var opts = optsBuilder.build();
-        var modelName = TritonOnnxRuntime.generateModelName(MODEL_PATH, opts);
+        var modelName = TritonOnnxRuntime.generateModelName(MODEL_PATH, opts, false);
         var client = createClient();
         var runtime = createRuntime();
 
@@ -217,7 +235,7 @@ class TritonOnnxRuntimeTest {
     @Test
     void clean_model_repository_when_runtime_is_created() {
         var opts = optsBuilder.build();
-        var modelName = TritonOnnxRuntime.generateModelName(MODEL_PATH, opts);
+        var modelName = TritonOnnxRuntime.generateModelName(MODEL_PATH, opts, false);
 
         var client = createClient();
         var runtime = createRuntime();
@@ -244,18 +262,23 @@ class TritonOnnxRuntimeTest {
     }
 
     private TritonOnnxClient createClient() {
-        return new TritonOnnxClient(testConfig(TritonConfig.ModelControlMode.EXPLICIT));
+        return new TritonOnnxClient(testConfig(TritonConfig.ModelControlMode.EXPLICIT, false));
     }
 
     private TritonOnnxRuntime createRuntime() {
-        return new TritonOnnxRuntime(testConfig(TritonConfig.ModelControlMode.EXPLICIT));
+        return createRuntime(false);
     }
 
-    private static TritonConfig testConfig(TritonConfig.ModelControlMode.Enum mode) {
+    private TritonOnnxRuntime createRuntime(boolean shareOnnxSessionBetweenInstances) {
+        return new TritonOnnxRuntime(testConfig(TritonConfig.ModelControlMode.EXPLICIT, shareOnnxSessionBetweenInstances));
+    }
+
+    private static TritonConfig testConfig(TritonConfig.ModelControlMode.Enum mode, boolean shareOnnxSessionBetweenInstances) {
         return new TritonConfig.Builder()
                 .target(tritonContainer.getGrpcEndpoint())
                 .modelControlMode(mode)
                 .modelRepositoryPath(tritonContainer.getModelRepositoryPath().toString())
+                .shareOnnxSessionBetweenInstances(shareOnnxSessionBetweenInstances)
                 .build();
     }
 
@@ -272,12 +295,17 @@ class TritonOnnxRuntimeTest {
 
     // expectedConfigPath == null means we expect an error during model loading
     private void assertLoadModel(String expectedConfigPath, OnnxEvaluatorOptions evalOpts) throws IOException {
+        assertLoadModel(expectedConfigPath, evalOpts, false);
+    }
+
+    private void assertLoadModel(String expectedConfigPath, OnnxEvaluatorOptions evalOpts, boolean shareSession)
+            throws IOException {
         var modelBaseName = "dummy_transformer";
         var testModelFilePath = Text.format("src/test/models/onnx/transformer/%s.onnx", modelBaseName);
-        var modelName = TritonOnnxRuntime.generateModelName(testModelFilePath, evalOpts);
+        var modelName = TritonOnnxRuntime.generateModelName(testModelFilePath, evalOpts, shareSession);
         var modelFilePath = Text.format("%s/1/model.onnx", modelName);
         var modelConfigPath = Text.format("%s/config.pbtxt", modelName);
-        var runtime = createRuntime();
+        var runtime = createRuntime(shareSession);
 
         try {
             ThrowingSupplier<OnnxEvaluator> evaluatorSupplier = () -> runtime.evaluatorOf(testModelFilePath, evalOpts);
@@ -297,6 +325,13 @@ class TritonOnnxRuntimeTest {
 
             var modelFile = tritonContainer.getModelRepositoryPath().resolve(modelFilePath);
             assertEquals(expectedFilePermissions, Files.getPosixFilePermissions(modelFile));
+
+            // The stock image ignores the parameter, so only the generated config can be checked there.
+            if (shareSession && tritonContainer.supportsSessionSharing()) {
+                assertTrue(tritonContainer.getLogs().contains("Reusing session for instance: " + modelName),
+                           "Triton did not reuse the session between instances of " + modelName);
+            }
+
             evaluator.close();
         } finally {
             runtime.deconstruct();
@@ -306,7 +341,7 @@ class TritonOnnxRuntimeTest {
     // Removes hash from model name before comparing configs.
     // This is to avoid updating hash in all test config files every time options are changed.
     private void assertEqualConfigs(String expectedConfig, String actualConfig) {
-        var regex = "(name:\\s*\"\\w+)_[a-f0-9]{16}\"";
+        var regex = "(name:\\s*\"\\w+)_[a-f0-9]+\"";
         var normalizedExpected = expectedConfig.replaceFirst(regex, "$1\"");
         var normalizedActual = actualConfig.replaceFirst(regex, "$1\"");
         assertEquals(normalizedExpected, normalizedActual);
@@ -349,7 +384,7 @@ class TritonOnnxRuntimeTest {
     @Test
     void concurrent_create_and_close_of_the_same_model() throws Exception {
         var opts = optsBuilder.build();
-        var modelName = TritonOnnxRuntime.generateModelName(MODEL_PATH, opts);
+        var modelName = TritonOnnxRuntime.generateModelName(MODEL_PATH, opts, false);
         var client = createClient();
         var runtime = createRuntime();
         var threads = 4;

--- a/model-integration/src/test/java/ai/vespa/triton/TritonServerContainer.java
+++ b/model-integration/src/test/java/ai/vespa/triton/TritonServerContainer.java
@@ -24,12 +24,20 @@ public class TritonServerContainer extends GenericContainer<TritonServerContaine
     private static final int GRPC_PORT = 8001;
     private static final int HTTP_PORT = 8000;
     private static final int METRICS_PORT = 8002;
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("nvcr.io/nvidia/tritonserver:25.03-py3");
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("nvcr.io/nvidia/tritonserver:26.08-py3");
+
+    // Overrides the image, e.g. to test against Vespa's Triton images: -DVESPA_TRITON_IMAGE=localhost/tritonserver:<tag>
+    private static final String IMAGE_NAME_PROPERTY = "VESPA_TRITON_IMAGE";
 
     private final Path modelRepositoryPath;
 
     public TritonServerContainer() throws IOException {
-        this(DEFAULT_IMAGE_NAME);
+        this(configuredImageName());
+    }
+
+    private static DockerImageName configuredImageName() {
+        var imageName = System.getProperty(IMAGE_NAME_PROPERTY);
+        return imageName == null ? DEFAULT_IMAGE_NAME : DockerImageName.parse(imageName).asCompatibleSubstituteFor(DEFAULT_IMAGE_NAME);
     }
 
     public TritonServerContainer(DockerImageName imageName) throws IOException {
@@ -40,6 +48,11 @@ public class TritonServerContainer extends GenericContainer<TritonServerContaine
         addExposedPorts(GRPC_PORT, HTTP_PORT, METRICS_PORT);
         addFileSystemBind(modelRepositoryPath.toString(), "/models", BindMode.READ_ONLY, SelinuxContext.NONE);
         setCommandParts(new String[]{"tritonserver", "--model-repository=/models", "--model-control-mode=explicit"});
+    }
+
+    // Only Vespa's Triton images, given with the image override, support ONNX session sharing.
+    public boolean supportsSessionSharing() {
+        return System.getProperty(IMAGE_NAME_PROPERTY) != null;
     }
 
     public String getGrpcEndpoint() {

--- a/model-integration/src/test/triton/config_with_model_config_override_shared_session_output.pbtxt
+++ b/model-integration/src/test/triton/config_with_model_config_override_shared_session_output.pbtxt
@@ -1,0 +1,46 @@
+name: "dummy_transformer_889cbfb0b13fd3c9"
+platform: "onnxruntime_onnx"
+max_batch_size: 2
+instance_group {
+  count: 2
+  kind: KIND_CPU
+}
+dynamic_batching {
+  max_queue_delay_microseconds: 20000
+}
+parameters {
+  key: "enable_mem_arena"
+  value {
+    string_value: "0"
+  }
+}
+parameters {
+  key: "enable_mem_pattern"
+  value {
+    string_value: "0"
+  }
+}
+parameters {
+  key: "execution_mode"
+  value {
+    string_value: "0"
+  }
+}
+parameters {
+  key: "inter_op_thread_count"
+  value {
+    string_value: "3"
+  }
+}
+parameters {
+  key: "intra_op_thread_count"
+  value {
+    string_value: "6"
+  }
+}
+parameters {
+  key: "share_session_between_instances"
+  value {
+    string_value: "true"
+  }
+}

--- a/model-integration/src/test/triton/config_with_shared_session.pbtxt
+++ b/model-integration/src/test/triton/config_with_shared_session.pbtxt
@@ -1,0 +1,43 @@
+name: "dummy_transformer_47d1bdde03c1063e"
+platform: "onnxruntime_onnx"
+max_batch_size: 1
+instance_group {
+  count: 2
+  kind: KIND_CPU
+}
+parameters {
+  key: "enable_mem_arena"
+  value {
+    string_value: "0"
+  }
+}
+parameters {
+  key: "enable_mem_pattern"
+  value {
+    string_value: "0"
+  }
+}
+parameters {
+  key: "execution_mode"
+  value {
+    string_value: "0"
+  }
+}
+parameters {
+  key: "inter_op_thread_count"
+  value {
+    string_value: "2"
+  }
+}
+parameters {
+  key: "intra_op_thread_count"
+  value {
+    string_value: "4"
+  }
+}
+parameters {
+  key: "share_session_between_instances"
+  value {
+    string_value: "true"
+  }
+}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Session sharing allows multiple onnx sessions in triton to use the model weights in memory instead of loading several copies of model weights. This saves memory. Works only with patched triton images. Otherwise ignored.