### PR TITLE
Show prepare restart costs for all non-gc flush targets in

### DIFF
--- a/searchcore/src/tests/proton/flushengine/flushengine_test.cpp
+++ b/searchcore/src/tests/proton/flushengine/flushengine_test.cpp
@@ -54,6 +54,7 @@ class SimpleGetSerialNum : public IGetSerialNum {
 class SimpleTlsStatsFactory : public flushengine::ITlsStatsFactory {
     flushengine::TlsStatsMap create() override {
         vespalib::hash_map<std::string, flushengine::TlsStats> map;
+        map.insert(std::make_pair("handler", TlsStats(1000000, 2, 200)));
         return flushengine::TlsStatsMap(std::move(map));
     }
 };
@@ -855,7 +856,7 @@ TEST(FlushEngineTest, require_that_state_explorer_can_list_flush_targets) {
     target->_initDone.await(LONG_TIMEOUT);
     target->_taskStart.await(LONG_TIMEOUT);
 
-    FlushEngineExplorer explorer(f.engine);
+    FlushEngineExplorer explorer(f.engine, PrepareRestartCostsConfig(1.0, 1.0, 1.0, 1.0));
     Slime               state;
     SlimeInserter       inserter(state);
     explorer.get_state(inserter, true);

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_engine_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_engine_explorer.cpp
@@ -4,11 +4,17 @@
 
 #include "flush_history_explorer.h"
 #include "flushengine.h"
+#include "i_tls_stats_factory.h"
+#include "prepare_restart_costs.h"
+#include "tls_stats_map.h"
 
 #include <vespa/vespalib/data/slime/cursor.h>
 #include <vespa/vespalib/data/slime/inserter.h>
 
 using proton::flushengine::FlushHistoryExplorer;
+using proton::flushengine::PrepareRestartCosts;
+using proton::flushengine::PrepareRestartCostsConfig;
+using proton::flushengine::TlsStatsMap;
 using searchcorespi::IFlushTarget;
 using vespalib::StateExplorer;
 using vespalib::slime::Cursor;
@@ -33,7 +39,15 @@ void sortTargetList(FlushContext::List& allTargets) {
     });
 }
 
-void convertToSlime(const FlushContext::List& allTargets, const vespalib::system_time& now, Cursor& array) {
+void convert_prepare_restart_costs(const PrepareRestartCosts& prepare_restart_costs, Cursor& object) {
+    object.setDouble("read_cost", prepare_restart_costs.read_cost());
+    object.setDouble("write_cost", prepare_restart_costs.write_cost());
+    object.setDouble("replay_cost", prepare_restart_costs.replay_cost());
+}
+
+void convertToSlime(const FlushContext::List& allTargets, const TlsStatsMap& tls_stats_map,
+                    const PrepareRestartCostsConfig& prepare_restart_costs_config, const vespalib::system_time& now,
+                    Cursor& array) {
     for (const auto& ctx : allTargets) {
         Cursor& object = array.addObject();
         object.setString("name", ctx->getName());
@@ -50,6 +64,12 @@ void convertToSlime(const FlushContext::List& allTargets, const vespalib::system
         object.setLong("estimated_flush_duration",
                        duration_cast<std::chrono::microseconds>(target->estimated_flush_duration()).count());
         object.setLong("reserved-memory-for-flush", target->reserved_memory_for_flush());
+        if (target->getType() != IFlushTarget::Type::GC) {
+            const auto&         tls_stats = tls_stats_map.getTlsStats(ctx->getHandler()->getName());
+            PrepareRestartCosts prepare_restart_costs(*target, tls_stats.getLastSerial(),
+                                                      target->getFlushedSerialNum(), prepare_restart_costs_config);
+            convert_prepare_restart_costs(prepare_restart_costs, object.setObject("prepare-restart-costs"));
+        }
     }
 }
 
@@ -57,7 +77,9 @@ const std::string FLUSH_HISTORY("flush_history");
 
 } // namespace
 
-FlushEngineExplorer::FlushEngineExplorer(const FlushEngine& engine) : _engine(engine) {
+FlushEngineExplorer::FlushEngineExplorer(const FlushEngine&                     engine,
+                                         flushengine::PrepareRestartCostsConfig prepare_restart_costs_config)
+    : _engine(engine), _prepare_restart_costs_config(prepare_restart_costs_config) {
 }
 
 void FlushEngineExplorer::get_state(const Inserter& inserter, bool full) const {
@@ -67,7 +89,8 @@ void FlushEngineExplorer::get_state(const Inserter& inserter, bool full) const {
         convertToSlime(_engine.getCurrentlyFlushingSet(), object.setArray("flushingTargets"));
         FlushContext::List allTargets = _engine.getTargetList(true);
         sortTargetList(allTargets);
-        convertToSlime(allTargets, now, object.setArray("allTargets"));
+        auto tls_stats_map = _engine.get_tls_stats_factory().create();
+        convertToSlime(allTargets, tls_stats_map, _prepare_restart_costs_config, now, object.setArray("allTargets"));
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_engine_explorer.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_engine_explorer.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "prepare_restart_costs_config.h"
+
 #include <vespa/vespalib/net/http/state_explorer.h>
 
 namespace proton {
@@ -13,10 +15,12 @@ class FlushEngine;
  */
 class FlushEngineExplorer : public vespalib::StateExplorer {
 private:
-    const FlushEngine& _engine;
+    const FlushEngine&                     _engine;
+    flushengine::PrepareRestartCostsConfig _prepare_restart_costs_config;
 
 public:
-    FlushEngineExplorer(const FlushEngine& engine);
+    FlushEngineExplorer(const FlushEngine&                     engine,
+                        flushengine::PrepareRestartCostsConfig prepare_restart_costs_config);
 
     void get_state(const vespalib::slime::Inserter& inserter, bool full) const override;
     std::vector<std::string> get_children_names() const override;

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
@@ -239,6 +239,7 @@ public:
     const std::shared_ptr<flushengine::FlushHistory>& get_flush_history() const noexcept { return _flush_history; }
     void configure(uint64_t max_summary_file_size, size_t each_max_memory, size_t global_max_memory);
     ReservedDiskSpaceAndMemory get_reserved_disk_space_and_memory() const override;
+    flushengine::ITlsStatsFactory& get_tls_stats_factory() const noexcept { return *_tlsStatsFactory; }
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -77,6 +77,7 @@ LOG_SETUP(".proton.server.proton");
 using CpuCategory = vespalib::CpuUsage::Category;
 
 using document::DocumentTypeRepo;
+using proton::flushengine::PrepareRestartCostsConfig;
 using proton::flushengine::SetStrategyResult;
 using search::DiskSpaceCalculator;
 using search::diskindex::IPostingListCache;
@@ -1093,7 +1094,11 @@ std::unique_ptr<vespalib::StateExplorer> Proton::get_child(std::string_view name
     } else if (name == DOCUMENT_DB) {
         return std::make_unique<DocumentDBMapExplorer>(_documentDBMap, _mutex);
     } else if (name == FLUSH_ENGINE && _flushEngine) {
-        return std::make_unique<FlushEngineExplorer>(*_flushEngine);
+        auto                      proton_config = getActiveConfigSnapshot()->getProtonConfigSP();
+        const auto&               cfg = proton_config->flush.preparerestart;
+        PrepareRestartCostsConfig prepare_restart_costs_config(cfg.replaycost, cfg.replayoperationcost, cfg.writecost,
+                                                               cfg.readcost);
+        return std::make_unique<FlushEngineExplorer>(*_flushEngine, prepare_restart_costs_config);
     } else if (name == TLS_NAME && _tls) {
         return std::make_unique<search::transactionlog::TransLogServerExplorer>(_tls->getTransLogServer());
     } else if (name == RESOURCE_USAGE && _diskMemUsageSampler && _persistenceEngine) {


### PR DESCRIPTION
flush engine explorer.

@vekterli : please review
