### PR TITLE
Add support for long in fast map search

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedFields.java
@@ -279,7 +279,7 @@ public class ConvertParsedFields {
         if (!isSupportedFastMapKeyValueType(type)) {
             throw new IllegalArgumentException(
                     String.format(
-                            "For schema '%s', field '%s': 'map: fast-search' requires %s to be of type string or int, but the type is %s.",
+                            "For schema '%s', field '%s': 'map: fast-search' requires %s to be of type string, int or long, but the type is %s.",
                             schema.getName(),
                             field.getName(),
                             keyOrValue,
@@ -289,7 +289,8 @@ public class ConvertParsedFields {
 
     private boolean isSupportedFastMapKeyValueType(DataType dataType) {
         return dataType.equals(DataType.STRING)
-                || dataType.equals(DataType.INT);
+                || dataType.equals(DataType.INT)
+                || dataType.equals(DataType.LONG);
     }
 
     private void convertStructField(Schema schema, SDField field, ParsedField parsed) {

--- a/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/CreateFastMapSearch.java
@@ -17,6 +17,7 @@ import com.yahoo.searchlib.document.FastMapSearch;
 import com.yahoo.vespa.indexinglanguage.expressions.AttributeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.CatExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ConstantExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.ExcessHex16EncodeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExcessHex8EncodeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
 import com.yahoo.vespa.indexinglanguage.expressions.ForEachExpression;
@@ -113,7 +114,7 @@ public class CreateFastMapSearch extends Processor {
 
     /**
      * Returns whether the synthetic attribute of the given map field is matched cased. Key and value share one
-     * term, so a string value must be matched like the key. An int value is hex encoded, and so is matched the
+     * term, so a string value must be matched like the key. An int or long value is hex encoded, and so is matched the
      * same way whichever casing the term has.
      */
     private boolean isCasedKeyValue(SDField inputField, DataType valueType, boolean validate) {
@@ -138,7 +139,8 @@ public class CreateFastMapSearch extends Processor {
 
     /**
      * Builds "input mapField | for_each { get_field $key . separator . VALUE_EXP } | attribute",
-     * where VALUE_EXP is "(get_field $value | exhex8encode)" if the value type is int
+     * where VALUE_EXP is "(get_field $value | exhex8encode)" if the value type is int,
+     * "(get_field $value | exhex16encode)" if the value type is long,
      * and "get_field $value" otherwise (if the value type is string).
      * */
     private static ScriptExpression keyValueScript(SDField inputField, String fieldName, DataType valueType) {
@@ -157,7 +159,8 @@ public class CreateFastMapSearch extends Processor {
     }
 
     /**
-     * Builds "(get_field $value | exhex8encode)" if the value type is int and
+     * Builds "(get_field $value | exhex8encode)" if the value type is int,
+     * "(get_field $value | exhex16encode)" if the value type is long, and
      * "get_field $value" otherwise.
      * */
     private static Expression valueExpression(DataType valueType) {
@@ -165,6 +168,8 @@ public class CreateFastMapSearch extends Processor {
 
         if (valueType == DataType.INT) {
             return new ParenthesisExpression(new StatementExpression(field, new ExcessHex8EncodeExpression()));
+        } else if (valueType == DataType.LONG) {
+            return new ParenthesisExpression(new StatementExpression(field, new ExcessHex16EncodeExpression()));
         } else { // DataType.STRING
             return field;
         }

--- a/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
@@ -62,15 +62,17 @@ public class MapFastSearchTestCase {
     @Test
     void requireFastMapRejectedForUnsupportedKeyAndValueTypes() throws ParseException {
         assertRejected("field m type map<double, string> { map: fast-search }", true,
-                       "For schema 'test', field 'm': 'map: fast-search' requires key to be of type string or int, but the type is double.");
+                       "For schema 'test', field 'm': 'map: fast-search' requires key to be of type string, int or long, but the type is double.");
         assertRejected("field m type map<string, bool> { map: fast-search }", true,
-                       "For schema 'test', field 'm': 'map: fast-search' requires value to be of type string or int, but the type is bool.");
+                       "For schema 'test', field 'm': 'map: fast-search' requires value to be of type string, int or long, but the type is bool.");
     }
 
     @Test
-    void requireFastMapAcceptsIntAndStringKeyAndValue() throws ParseException {
+    void requireFastMapAcceptsStringIntAndLongKeyAndValue() throws ParseException {
         assertTrue(fastMapSearchOf("field m type map<int, string> { map: fast-search }", true));
         assertTrue(fastMapSearchOf("field m type map<string, int> { map: fast-search }", true));
+        assertTrue(fastMapSearchOf("field m type map<long, string> { map: fast-search }", true));
+        assertTrue(fastMapSearchOf("field m type map<string, long> { map: fast-search }", true));
     }
 
     private static void assertRejected(String field, boolean flagEnabled, String expectedMessage) throws ParseException {

--- a/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/CreateFastMapSearchTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author johsol
  */
 public class CreateFastMapSearchTest {
-    private static String[] supportedValueTypes = { "string", "int" };
+    private static String[] supportedValueTypes = { "string", "int", "long" };
 
     @Test
     void requireKeyValueFieldIsCreatedForFastSearchMap() throws ParseException {
@@ -74,11 +74,13 @@ public class CreateFastMapSearchTest {
         assertEquals(Case.CASED, attribute.getDictionary().getMatch());
     }
 
-    /** An int value is hex encoded the same way at index and query time, so only the key decides the casing. */
+    /** An int or long value is hex encoded the same way at index and query time, so only the key decides the casing. */
     @Test
-    void requireKeyValueAttributeOfAnIntMapFollowsTheKeyCasing() throws ParseException {
-        assertEquals(Case.CASED, keyValueAttribute(build(casedFastSearchMap("foo", "int", true, false)), "foo").getCase());
-        assertEquals(Case.UNCASED, keyValueAttribute(build(casedFastSearchMap("foo", "int", false, false)), "foo").getCase());
+    void requireKeyValueAttributeOfANumericMapFollowsTheKeyCasing() throws ParseException {
+        for (String valueType : new String[] { "int", "long" }) {
+            assertEquals(Case.CASED, keyValueAttribute(build(casedFastSearchMap("foo", valueType, true, false)), "foo").getCase());
+            assertEquals(Case.UNCASED, keyValueAttribute(build(casedFastSearchMap("foo", valueType, false, false)), "foo").getCase());
+        }
     }
 
     @Test
@@ -107,6 +109,14 @@ public class CreateFastMapSearchTest {
 
         String script = schema.getConcreteField("foo$keyvalue").getIndexingScript().toString();
         assertEquals("{ input foo | for_each { get_field $key . \"\\x7f\" . (get_field $value | exhex8encode) } | attribute \"foo$keyvalue\"; }", script);
+    }
+
+    @Test
+    void requireKeyValueAttributeHasCorrectIndexingScriptForLongValues() throws ParseException {
+        var schema = build(fastSearchMap("foo", "string", "long"));
+
+        String script = schema.getConcreteField("foo$keyvalue").getIndexingScript().toString();
+        assertEquals("{ input foo | for_each { get_field $key . \"\\x7f\" . (get_field $value | exhex16encode) } | attribute \"foo$keyvalue\"; }", script);
     }
 
     @Test

--- a/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/FastMapSearcher.java
@@ -144,6 +144,18 @@ public class FastMapSearcher extends Searcher {
             return makeIntRange(key, valueItem, fieldName);
         }
 
+        if (mapType.valueType().kind() == Field.Type.Kind.LONG) {
+            var key = getString(keyItem);
+            if (key == null) {
+                return null;
+            }
+            var value = getLong(valueItem);
+            if (value != null) {
+                return makeWord(key, value, fieldName);
+            }
+            return makeLongRange(key, valueItem, fieldName);
+        }
+
         return null;
     }
 
@@ -168,12 +180,8 @@ public class FastMapSearcher extends Searcher {
 
     /** Gets value as integer or null. */
     private Integer getInteger(TermItem term) {
-       String number;
-       if (term instanceof IntItem intItem) {
-           number = intItem.getNumber();
-       } else if (term.getClass() == WordItem.class) {
-           number = ((WordItem) term).getWord();
-       } else {
+       String number = getNumberString(term);
+       if (number == null) {
            return null;
        }
        try {
@@ -181,6 +189,30 @@ public class FastMapSearcher extends Searcher {
        } catch (NumberFormatException e) {
            return null; // a range expression, or not an int: the caller tries the range form
        }
+    }
+
+    /** Gets value as long or null. */
+    private Long getLong(TermItem term) {
+        String number = getNumberString(term);
+        if (number == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(number.trim());
+        } catch (NumberFormatException e) {
+            return null; // a range expression, or not a long: the caller tries the range form
+        }
+    }
+
+    /** Returns the text of a numeric or word term, or null if the term is neither. */
+    private static String getNumberString(TermItem term) {
+        if (term instanceof IntItem intItem) {
+            return intItem.getNumber();
+        }
+        if (term.getClass() == WordItem.class) {
+            return ((WordItem) term).getWord();
+        }
+        return null;
     }
 
     /** Package-private for unit testing. */
@@ -231,6 +263,56 @@ public class FastMapSearcher extends Searcher {
     /** Package-private for unit testing. */
     WordItem makeWord(String key, Integer value, String fieldName) {
         return new WordItem(FastMapSearch.toKeyValue8Term(key, value),
+                            FastMapSearch.toKeyValueFieldName(fieldName), false);
+    }
+
+    /**
+     * Returns the lexical range over the synthetic attribute equivalent to the given numeric
+     * range on the long value of one map key, or null if it cannot be expressed as one.
+     */
+    StringRangeItem makeLongRange(String key, TermItem valueItem, String fieldName) {
+        if (!(valueItem instanceof IntItem intItem)) {
+            return null;
+        }
+        if (intItem.getHitLimit() != 0) {
+            return null; // a hit limit counts entries in the value attribute, not the synthetic one
+        }
+        Limit fromLimit = intItem.getFromLimit();
+        Limit toLimit = intItem.getToLimit();
+        Long from = toLongBound(fromLimit, Long.MIN_VALUE);
+        Long to = toLongBound(toLimit, Long.MAX_VALUE);
+        if (from == null || to == null) {
+            return null;
+        }
+        return new StringRangeItem(FastMapSearch.toKeyValue16Term(key, from), fromLimit.isInclusive(),
+                                   FastMapSearch.toKeyValue16Term(key, to), toLimit.isInclusive(),
+                                   FastMapSearch.toKeyValueFieldName(fieldName), false, null);
+    }
+
+    /**
+     * Returns the long to encode for the given range endpoint, using the given value when the
+     * endpoint is unbounded, or null if the endpoint has no exact long form.
+     */
+    private static Long toLongBound(Limit limit, long whenInfinite) {
+        if (limit.isInfinite()) {
+            return whenInfinite;
+        }
+        Number number = limit.number();
+        if (number instanceof Long || number instanceof Integer) {
+            return number.longValue();
+        }
+        // A fractional or out-of-range endpoint has no exact long form. Every double in the long
+        // range which equals its own rounding is an integer, and is cast exactly.
+        double asDouble = number.doubleValue();
+        if (asDouble != Math.rint(asDouble) || asDouble < -0x1p63 || asDouble >= 0x1p63) {
+            return null; // fall back to the regular sameElement
+        }
+        return (long) asDouble;
+    }
+
+    /** Package-private for unit testing. */
+    WordItem makeWord(String key, Long value, String fieldName) {
+        return new WordItem(FastMapSearch.toKeyValue16Term(key, value),
                             FastMapSearch.toKeyValueFieldName(fieldName), false);
     }
 

--- a/container-search/src/test/java/com/yahoo/search/querytransform/FastMapSearcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/FastMapSearcherTest.java
@@ -90,9 +90,36 @@ public class FastMapSearcherTest {
     }
 
     @Test
+    public void requireLongValueEncodedInExcessHex() {
+        long beyondInt = 1L << 32;
+        String expected = "longvaluemap$keyvalue:" + FastMapSearch.toKeyValue16Term("foo", beyondInt);
+
+        // The value arrives as an IntItem
+        assertRewritten(expected, sameElement("longvaluemap", new WordItem("foo", "key"), new IntItem(Long.toString(beyondInt), "value")));
+
+        // The value arrives as a WordItem holding a long
+        assertRewritten(expected, sameElement("longvaluemap", new WordItem("foo", "key"), new WordItem(Long.toString(beyondInt), "value")));
+
+        // A value which fits in an int is still encoded with 16 digits
+        assertRewritten("longvaluemap$keyvalue:" + FastMapSearch.toKeyValue16Term("foo", 10L),
+                        sameElement("longvaluemap", new WordItem("foo", "key"), new IntItem("10", "value")));
+
+        // Negative values encode across zero
+        assertRewritten("longvaluemap$keyvalue:" + FastMapSearch.toKeyValue16Term("foo", -beyondInt),
+                        sameElement("longvaluemap", new WordItem("foo", "key"), new IntItem(Long.toString(-beyondInt), "value")));
+    }
+
+    @Test
     public void requireFallbackWhenTermsDoNotMatchOneEntry() {
         // Not parseable as an int for an int-valued map
         assertUntouched(sameElement("intvaluemap", new WordItem("foo", "key"), new WordItem("bar", "value")));
+
+        // Beyond the int range for an int-valued map
+        assertUntouched(sameElement("intvaluemap", new WordItem("foo", "key"), new IntItem(Long.toString(1L << 32), "value")));
+
+        // Not parseable as a long for a long-valued map
+        assertUntouched(sameElement("longvaluemap", new WordItem("foo", "key"), new WordItem("bar", "value")));
+        assertUntouched(sameElement("longvaluemap", new WordItem("foo", "key"), new IntItem("99999999999999999999", "value")));
 
         // A prefix term matches more than one string
         assertUntouched(sameElement("mymap", new PrefixItem("fo", "key"), new WordItem("bar", "value")));
@@ -162,6 +189,68 @@ public class FastMapSearcherTest {
                                     new StringRangeItem("a", true, "z", true, "value", false, null)));
     }
 
+    @Test
+    public void requireLongRangeRewrittenToLexicalRange() {
+        var searcher = new FastMapSearcher();
+        long low = 1L << 32;
+        long high = (1L << 32) + 100;
+
+        // A closed range becomes a closed lexical range over the encoded endpoints.
+        var closed = searcher.makeLongRange("foo", new IntItem("[" + low + ";" + high + "]", "value"), "longvaluemap");
+        assertEquals("longvaluemap$keyvalue", closed.getIndexName());
+        assertEquals(FastMapSearch.toKeyValue16Term("foo", low), closed.getFrom());
+        assertEquals(FastMapSearch.toKeyValue16Term("foo", high), closed.getTo());
+        assertTrue(closed.isFromInclusive());
+        assertTrue(closed.isToInclusive());
+
+        // Exclusive endpoints stay exclusive.
+        var open = searcher.makeLongRange("foo", intRange(new Limit(low, false), new Limit(high, false)), "longvaluemap");
+        assertFalse(open.isFromInclusive());
+        assertFalse(open.isToInclusive());
+
+        // An unbounded end becomes the extreme long value, so that the range cannot run past
+        // this key into the entries of the neighbouring keys.
+        var toInfinity = searcher.makeLongRange("foo", intRange(new Limit(low, true), Limit.POSITIVE_INFINITY), "longvaluemap");
+        assertEquals(FastMapSearch.toKeyValue16Term("foo", low), toInfinity.getFrom());
+        assertEquals(FastMapSearch.toKeyValue16Term("foo", Long.MAX_VALUE), toInfinity.getTo());
+        assertTrue(toInfinity.isToInclusive());
+
+        var fromInfinity = searcher.makeLongRange("foo", intRange(Limit.NEGATIVE_INFINITY, new Limit(high, true)), "longvaluemap");
+        assertEquals(FastMapSearch.toKeyValue16Term("foo", Long.MIN_VALUE), fromInfinity.getFrom());
+        assertEquals(FastMapSearch.toKeyValue16Term("foo", high), fromInfinity.getTo());
+        assertTrue(fromInfinity.isFromInclusive());
+
+        // Int endpoints, and integral double endpoints, are exact longs.
+        var small = searcher.makeLongRange("foo", intRange(new Limit(5, true), new Limit(10.0, true)), "longvaluemap");
+        assertEquals(FastMapSearch.toKeyValue16Term("foo", 5L), small.getFrom());
+        assertEquals(FastMapSearch.toKeyValue16Term("foo", 10L), small.getTo());
+
+        // Negative endpoints encode across zero and stay ordered.
+        var negative = searcher.makeLongRange("foo", intRange(new Limit(-high, true), new Limit(-low, true)), "longvaluemap");
+        assertTrue(negative.getFrom().compareTo(negative.getTo()) < 0);
+
+        // End to end, through the searcher.
+        String expected = "STRING_RANGE longvaluemap$keyvalue:[\"" + FastMapSearch.toKeyValue16Term("foo", low) + "\";\""
+                          + FastMapSearch.toKeyValue16Term("foo", high) + "\"]";
+        assertRewritten(expected, sameElement("longvaluemap", new WordItem("foo", "key"),
+                                              new IntItem("[" + low + ";" + high + "]", "value")));
+    }
+
+    @Test
+    public void requireFallbackForRangesWhichAreNotPlainLongRanges() {
+        var searcher = new FastMapSearcher();
+
+        // A fractional endpoint has no exact long encoding.
+        assertNull(searcher.makeLongRange("foo", intRange(new Limit(1.5, true), new Limit(10, true)), "longvaluemap"));
+
+        // An endpoint beyond the long range has no encoding.
+        assertNull(searcher.makeLongRange("foo", new IntItem("[0;99999999999999999999]", "value"), "longvaluemap"));
+        assertNull(searcher.makeLongRange("foo", intRange(new Limit(0, true), new Limit(1e19, true)), "longvaluemap"));
+
+        // A hit limit counts entries in the value attribute, not in the synthetic one.
+        assertNull(searcher.makeLongRange("foo", new IntItem("[5;10;100]", "value"), "longvaluemap"));
+    }
+
     private static IntItem intRange(Limit from, Limit to) {
         return new IntItem(from, to, "value");
     }
@@ -184,6 +273,7 @@ public class FastMapSearcherTest {
                 .add(new Field.Builder("mymap", "map<string,string>").setFastMapSearch(true).build())
                 .add(new Field.Builder("intvaluemap", "map<string,int>").setFastMapSearch(true).build())
                 .add(new Field.Builder("intkeymap", "map<int,string>").setFastMapSearch(true).build())
+                .add(new Field.Builder("longvaluemap", "map<string,long>").setFastMapSearch(true).build())
                 .add(new Field.Builder("othermap", "map<string,string>").build())
                 .build();
         var schemaInfo = new SchemaInfo(List.of(schema), List.of());

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExcessHex16EncodeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExcessHex16EncodeExpression.java
@@ -1,0 +1,48 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage.expressions;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.datatypes.LongFieldValue;
+import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.text.Text;
+
+/**
+ * Converts a long into its 16-hex-digit string excess representation such that
+ * the strings sort in the same order as the long values, cf. {@link Text#toExcessHex16(long)}.
+ *
+ * @author johsol
+ */
+public final class ExcessHex16EncodeExpression extends Expression {
+
+    @Override
+    public DataType setInputType(DataType inputType, TypeContext context) {
+        super.setInputType(inputType, DataType.LONG, context);
+        return DataType.STRING;
+    }
+
+    @Override
+    public DataType setOutputType(DataType outputType, TypeContext context) {
+        super.setOutputType(DataType.STRING, outputType, null, context);
+        return DataType.LONG;
+    }
+
+    @Override
+    protected void doExecute(ExecutionContext context) {
+        long input = ((LongFieldValue) context.getCurrentValue()).getLong();
+        context.setCurrentValue(new StringFieldValue(Text.toExcessHex16(input)));
+    }
+
+    @Override
+    public String toString() { return "exhex16encode"; }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof ExcessHex16EncodeExpression;
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+}

--- a/indexinglanguage/src/main/javacc/IndexingParser.jj
+++ b/indexinglanguage/src/main/javacc/IndexingParser.jj
@@ -53,6 +53,7 @@ import com.yahoo.vespa.indexinglanguage.expressions.EchoExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.EmbedExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExactExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExcessHex8EncodeExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.ExcessHex16EncodeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExecutionValueExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExpressionList;
@@ -263,6 +264,7 @@ TOKEN :
     <GENERATE: "generate"> |
     <EXACT: "exact"> |
     <EXHEX8_ENCODE: "exhex8encode"> |
+    <EXHEX16_ENCODE: "exhex16encode"> |
     <FLATTEN: "flatten"> |
     <FOR_EACH: "for_each"> |
     <GET_FIELD: "get_field"> |
@@ -422,6 +424,7 @@ Expression value() :
       val = exactExp()              |
       val = executionValueExp()     |
       val = exHex8EncodeExp()       |
+      val = exHex16EncodeExp()      |
       val = flattenExp()            |
       val = forEachExp()            |
       val = getFieldExp()           |
@@ -568,6 +571,12 @@ Expression exHex8EncodeExp() : { }
 {
     ( <EXHEX8_ENCODE> )
     { return new ExcessHex8EncodeExpression(); }
+}
+
+Expression exHex16EncodeExp() : { }
+{
+    ( <EXHEX16_ENCODE> )
+    { return new ExcessHex16EncodeExpression(); }
 }
 
 Expression flattenExp() : { }

--- a/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExcessHex16EncodeTestCase.java
+++ b/indexinglanguage/src/test/java/com/yahoo/vespa/indexinglanguage/expressions/ExcessHex16EncodeTestCase.java
@@ -1,0 +1,63 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.indexinglanguage.expressions;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.datatypes.FieldValue;
+import com.yahoo.document.datatypes.LongFieldValue;
+import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.vespa.indexinglanguage.SimpleTestAdapter;
+import com.yahoo.vespa.indexinglanguage.parser.ParseException;
+import org.junit.Test;
+
+import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerify;
+import static com.yahoo.vespa.indexinglanguage.expressions.ExpressionAssert.assertVerifyThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author johsol
+ */
+public class ExcessHex16EncodeTestCase {
+
+    @Test
+    public void requireThatHashCodeAndEqualsAreImplemented() {
+        Expression exp = new ExcessHex16EncodeExpression();
+        assertFalse(exp.equals(new Object()));
+        assertFalse(exp.equals(new ExcessHex8EncodeExpression()));
+        assertEquals(exp, new ExcessHex16EncodeExpression());
+        assertEquals(exp.hashCode(), new ExcessHex16EncodeExpression().hashCode());
+    }
+
+    @Test
+    public void requireThatExpressionCanBeParsed() throws ParseException {
+        assertEquals(new ExcessHex16EncodeExpression(), Expression.fromString("exhex16encode"));
+        assertEquals("exhex16encode", Expression.fromString("exhex16encode").toString());
+    }
+
+    @Test
+    public void requireThatExpressionCanBeVerified() {
+        Expression exp = new ExcessHex16EncodeExpression();
+        assertVerify(DataType.LONG, exp, DataType.STRING);
+        assertVerifyThrows("Invalid expression 'exhex16encode': Expected long input, but no input is provided", null, exp);
+        assertVerifyThrows("Invalid expression 'exhex16encode': Expected long input, got string", DataType.STRING, exp);
+        assertVerifyThrows("Invalid expression 'exhex16encode': Expected long input, got int", DataType.INT, exp);
+    }
+
+    @Test
+    public void requireThatInputIsEncoded() {
+        long[] values = new long[] { Long.MIN_VALUE, Integer.MIN_VALUE, -1L, 0L, 1L, Integer.MAX_VALUE, 1L << 32, Long.MAX_VALUE };
+        String[] strings = new String[] { "0000000000000000", "7fffffff80000000", "7fffffffffffffff", "8000000000000000",
+                                          "8000000000000001", "800000007fffffff", "8000000100000000", "ffffffffffffffff" };
+        for (int i = 0; i < values.length; i++) {
+            ExecutionContext ctx = new ExecutionContext(new SimpleTestAdapter());
+            ctx.setCurrentValue(new LongFieldValue(values[i]));
+            new ExcessHex16EncodeExpression().execute(ctx);
+
+            FieldValue val = ctx.getCurrentValue();
+            assertTrue(val instanceof StringFieldValue);
+            assertEquals(strings[i], ((StringFieldValue)val).getString());
+        }
+    }
+
+}

--- a/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
+++ b/integration/schema-language-server/language-server/src/main/ccc/indexinglanguage/IndexingParser.ccc
@@ -192,6 +192,7 @@ TOKEN :
     <EMBED: "embed"> |
     <EXACT: "exact"> |
     <EXHEX8_ENCODE: "exhex8encode"> |
+    <EXHEX16_ENCODE: "exhex16encode"> |
     <FLATTEN: "flatten"> |
     <FOR_EACH: "for_each"> |
     <GENERATE: "generate"> |
@@ -356,6 +357,7 @@ Expression value() :
       val = embedExp()              |
       val = exactExp()              |
       val = exHex8EncodeExp()       |
+      val = exHex16EncodeExp()      |
       val = flattenExp()            |
       val = forEachExp()            |
       val = generateExp()           |
@@ -510,6 +512,11 @@ Expression exHex8EncodeExp() : { }
  
     ( <EXHEX8_ENCODE> )
     { return new ExcessHex8EncodeExpression(); }
+;
+
+Expression exHex16EncodeExp() : { }
+    ( <EXHEX16_ENCODE> )
+    { return new ExcessHex16EncodeExpression(); }
 ;
 
 Expression flattenExp() : { }

--- a/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
+++ b/integration/schema-language-server/language-server/src/main/java/ai/vespa/schemals/lsp/schema/completion/provider/BodyKeywordCompletion.java
@@ -274,7 +274,7 @@ public class BodyKeywordCompletion implements CompletionProvider {
      * The config model only accepts 'map: fast-search' on maps whose key and value types are among these,
      * see CreateFastMapSearch and ConvertParsedFields in config-model.
      */
-    private static final Set<String> FAST_MAP_SEARCH_KEY_VALUE_TYPES = Set.of("string", "int");
+    private static final Set<String> FAST_MAP_SEARCH_KEY_VALUE_TYPES = Set.of("string", "int", "long");
 
     /** Snippets for the map settings block, only offered in fields where fast map search is allowed. */
     private static final List<CompletionItem> mapFieldSnippets = withDocumentation(List.of(

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/IndexingParserTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/IndexingParserTest.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.indexinglanguage.expressions.DocumentIdExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ChunkExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ConstantExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.EmbedExpression;
+import com.yahoo.vespa.indexinglanguage.expressions.ExcessHex16EncodeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.ExcessHex8EncodeExpression;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
 import com.yahoo.vespa.indexinglanguage.expressions.ForEachExpression;
@@ -93,6 +94,12 @@ public class IndexingParserTest {
             InputExpression.class,
             ExcessHex8EncodeExpression.class,
             AttributeExpression.class}, "input weight_src | exhex8encode | attribute");
+
+        assertEqualsParsedFlattened(new Class<?>[] {
+            StatementExpression.class,
+            InputExpression.class,
+            ExcessHex16EncodeExpression.class,
+            AttributeExpression.class}, "input weight_src | exhex16encode | attribute");
     }
 
     private static void assertEqualsParsedFlattened(Class<?>[] expectedFlattened, String input) {

--- a/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/LSPTest.java
+++ b/integration/schema-language-server/language-server/src/test/java/ai/vespa/schemals/LSPTest.java
@@ -151,7 +151,7 @@ public class LSPTest {
     }
 
     /**
-     * 'map: fast-search' is only accepted by the config model on maps with string or int keys and values,
+     * 'map: fast-search' is only accepted by the config model on maps with string, int or long keys and values,
      * so {@link BodyKeywordCompletion} should only suggest the map block in such fields.
      */
     @Test
@@ -178,8 +178,8 @@ public class LSPTest {
                    "map should be suggested in a map<string, string> field.");
         assertTrue(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(8, 12)).contains("map"),
                    "map should be suggested in a map<string, int> field.");
-        assertFalse(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(12, 12)).contains("map"),
-                    "map should not be suggested in a map<string, long> field.");
+        assertTrue(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(12, 12)).contains("map"),
+                   "map should be suggested in a map<string, long> field.");
         assertFalse(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(16, 12)).contains("map"),
                     "map should not be suggested in a string field.");
         assertFalse(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(20, 12)).contains("map"),
@@ -188,6 +188,8 @@ public class LSPTest {
                      "fast-search should be the only suggestion after 'map: '.");
         assertEquals(List.of("fast-search"), completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(29, 16)),
                      "fast-search should be the only suggestion inside a map block.");
+        assertFalse(completionLabelsAt(scheduler, schemaIndex, messageHandler, document, new Position(34, 12)).contains("map"),
+                    "map should not be suggested in a map<string, double> field.");
     }
 
     /**

--- a/integration/schema-language-server/language-server/src/test/sdfiles/single/mapcompletion.sd
+++ b/integration/schema-language-server/language-server/src/test/sdfiles/single/mapcompletion.sd
@@ -30,5 +30,8 @@ schema mapcompletion {
 
             }
         }
+        field double_values type map<string, double> {
+            indexing: summary
+        }
     }
 }


### PR DESCRIPTION
I have divided this into three commits. The first commit adds support for rewriting sameElement when the value is a long (FastMapSearcher, indexing language). The second allows a map value to be of type long in the config model. The third adds this to the language server.

@boeker fyi
@arnej27959 please take a look