### PR TITLE
Log application IDs

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/ApplicationFileManager.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/ApplicationFileManager.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.config.server.filedistribution;
 
 import com.yahoo.config.FileReference;
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.io.IOUtils;
 import com.yahoo.path.Path;
 import net.jpountz.lz4.LZ4FrameOutputStream;
@@ -19,6 +20,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * @author baldersheim
@@ -28,11 +30,17 @@ public class ApplicationFileManager implements AddFileInterface {
     private final File applicationDir;
     private final FileDirectory fileDirectory;
     private final boolean isHosted;
+    private final Optional<ApplicationId> owner;
 
     ApplicationFileManager(File applicationDir, FileDirectory fileDirectory, boolean isHosted) {
+        this(applicationDir, fileDirectory, isHosted, Optional.empty());
+    }
+
+    ApplicationFileManager(File applicationDir, FileDirectory fileDirectory, boolean isHosted, Optional<ApplicationId> owner) {
         this.applicationDir = applicationDir;
         this.fileDirectory = fileDirectory;
         this.isHosted = isHosted;
+        this.owner = owner;
     }
 
     @Override
@@ -42,7 +50,7 @@ public class ApplicationFileManager implements AddFileInterface {
     }
 
     private FileReference addFile(File file) throws IOException {
-        return fileDirectory.addFile(file);
+        return fileDirectory.addFile(file, owner);
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDirectory.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDirectory.java
@@ -7,6 +7,7 @@ import com.yahoo.component.annotation.Inject;
 import com.yahoo.concurrent.Lock;
 import com.yahoo.concurrent.Locks;
 import com.yahoo.config.FileReference;
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.io.IOUtils;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.defaults.Defaults;
@@ -126,11 +127,15 @@ public class FileDirectory extends AbstractComponent {
     }
 
     public FileReference addFile(File source) throws IOException {
+        return addFile(source, Optional.empty());
+    }
+
+    public FileReference addFile(File source, Optional<ApplicationId> owner) throws IOException {
         Long hash = computeHash(source);
         FileReference fileReference = fileReferenceFromHash(hash);
 
         try (Lock lock = locks.lock(fileReference)) {
-            return addFile(source, fileReference, hash);
+            return addFile(source, fileReference, hash, owner);
         }
     }
 
@@ -156,15 +161,15 @@ public class FileDirectory extends AbstractComponent {
     }
 
     // Check if we should add file, it might already exist
-    private boolean shouldAddFile(File source, Long hashOfFileToBeAdded) throws IOException {
+    private boolean shouldAddFile(File source, Long hashOfFileToBeAdded, Optional<ApplicationId> owner) throws IOException {
         FileReference fileReference = fileReferenceFromHash(hashOfFileToBeAdded);
         File destinationDir = destinationDir(fileReference);
         if ( ! destinationDir.exists()) return true;
 
         File existingFile = destinationDir.toPath().resolve(source.getName()).toFile();
         if ( ! existingFile.exists() || ! computeHash(existingFile).equals(hashOfFileToBeAdded)) {
-            log.log(WARNING, "Directory for file reference '" + fileReference.value() +
-                    "' has content that does not match its hash, deleting everything in " +
+            log.log(WARNING, "Directory for file reference '" + fileReference.value() + "'" + ownerSuffix(owner) +
+                    " has content that does not match its hash, deleting everything in " +
                     destinationDir.getAbsolutePath());
             deleteDirRecursively(destinationDir);
             return true;
@@ -185,13 +190,13 @@ public class FileDirectory extends AbstractComponent {
     }
 
     // Pre-condition: Destination dir does not exist
-    private FileReference addFile(File source, FileReference reference, Long hash) throws IOException {
-        if ( ! shouldAddFile(source, hash)) return reference;
+    private FileReference addFile(File source, FileReference reference, Long hash, Optional<ApplicationId> owner) throws IOException {
+        if ( ! shouldAddFile(source, hash, owner)) return reference;
 
         ensureRootExist();
         Path tempDestinationDir = uncheck(() -> Files.createTempDirectory(root.toPath(), "writing"));
         try {
-            logfileInfo(source);
+            logfileInfo(source, owner);
 
             // Copy files to temp dir
             File tempDestination = new File(tempDestinationDir.toFile(), source.getName());
@@ -213,11 +218,15 @@ public class FileDirectory extends AbstractComponent {
         }
     }
 
-    private void logfileInfo(File file ) throws IOException {
+    private void logfileInfo(File file, Optional<ApplicationId> owner) throws IOException {
         BasicFileAttributes basicFileAttributes = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
-        log.log(FINE, () -> "Adding file " + file.getAbsolutePath() + " (created " + basicFileAttributes.creationTime() +
+        log.log(FINE, () -> "Adding file " + file.getAbsolutePath() + ownerSuffix(owner) + " (created " + basicFileAttributes.creationTime() +
                 ", modified " + basicFileAttributes.lastModifiedTime() +
                 ", size " + basicFileAttributes.size() + ")");
+    }
+
+    private static String ownerSuffix(Optional<ApplicationId> owner) {
+        return owner.map(id -> " for application '" + id.toFullString() + "'").orElse("");
     }
 
     private static void copyFile(File source, File dest) throws IOException {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDistributionFactory.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDistributionFactory.java
@@ -5,11 +5,13 @@ import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.config.application.api.FileRegistry;
 import com.yahoo.config.model.api.FileDistribution;
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Transport;
 import com.yahoo.vespa.flags.FlagSource;
 
 import java.io.File;
+import java.util.Optional;
 
 /**
  * Factory for creating providers that are used to interact with file distribution.
@@ -32,16 +34,16 @@ public class FileDistributionFactory implements AutoCloseable {
         this.flagSource = flagSource;
     }
 
-    public FileRegistry createFileRegistry(File applicationPackage) {
-        return new FileDBRegistry(createFileManager(applicationPackage));
+    public FileRegistry createFileRegistry(File applicationPackage, Optional<ApplicationId> owner) {
+        return new FileDBRegistry(createFileManager(applicationPackage, owner));
     }
 
     public FileDistribution createFileDistribution() {
         return new FileDistributionImpl(supervisor);
     }
 
-    public AddFileInterface createFileManager(File applicationDir) {
-        return new ApplicationFileManager(applicationDir, fileDirectory, configserverConfig.hostedVespa());
+    public AddFileInterface createFileManager(File applicationDir, Optional<ApplicationId> owner) {
+        return new ApplicationFileManager(applicationDir, fileDirectory, configserverConfig.hostedVespa(), owner);
     }
 
     public FileDirectory fileDirectory() { return fileDirectory; }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -220,7 +220,7 @@ public class SessionPreparer {
                     .flatMap(endpointCertificateRetriever::readEndpointCertificateSecrets);
             this.containerEndpoints = readEndpointsIfNull(params.containerEndpoints());
             this.athenzDomain = params.athenzDomain();
-            this.fileRegistry = fileDistributionFactory.createFileRegistry(serverDbSessionDir);
+            this.fileRegistry = fileDistributionFactory.createFileRegistry(serverDbSessionDir, Optional.of(applicationId));
             this.preparedModelsBuilder = new PreparedModelsBuilder(modelFactoryRegistry,
                                                                    flagSource,
                                                                    containerEndpoints,

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -1047,7 +1047,7 @@ public class SessionRepository {
                                           tenantName,
                                           sessionId,
                                           configserverConfig,
-                                          fileDistributionFactory.createFileManager(getSessionAppDir(sessionId)),
+                                          fileDistributionFactory.createFileManager(getSessionAppDir(sessionId), Optional.empty()),
                                           maxNodeSize);
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/MockFileDistributionFactory.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/MockFileDistributionFactory.java
@@ -3,9 +3,11 @@ package com.yahoo.vespa.config.server.filedistribution;
 
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.config.application.api.FileRegistry;
+import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
 
 import java.io.File;
+import java.util.Optional;
 
 /**
 * @author Ulf Lilleengen
@@ -17,12 +19,12 @@ public class MockFileDistributionFactory extends FileDistributionFactory {
     }
 
     @Override
-    public FileRegistry createFileRegistry(File applicationPackage) {
+    public FileRegistry createFileRegistry(File applicationPackage, Optional<ApplicationId> owner) {
         return new MockFileRegistry(applicationPackage, fileDirectory);
     }
 
     @Override
-    public AddFileInterface createFileManager(File applicationDir) {
+    public AddFileInterface createFileManager(File applicationDir, Optional<ApplicationId> owner) {
         return new MockFileManager();
     }
 


### PR DESCRIPTION
Include the application ID, when available, in file-addition and invalid-content logs. This makes configserver diagnostics easier to associate with the deployment that triggered the operation. Existing log levels are preserved.

Validated with configserver production and test compilation and the full configserver test suite.
