### PR TITLE
Disallow DOCTYPE declarations

### DIFF
--- a/config-application-package/src/main/java/com/yahoo/config/application/Xml.java
+++ b/config-application-package/src/main/java/com/yahoo/config/application/Xml.java
@@ -54,7 +54,9 @@ public class Xml {
         factory.setXIncludeAware(false);
 
         try {
-            // XXE prevention
+            // Prevent XXE and internal-entity expansion by disallowing DOCTYPE (matches com.yahoo.text.XML and SchemaValidator)
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            // The external-entity/DTD features below are redundant once DOCTYPE is disallowed, but kept as defense in depth.
             factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);

--- a/config-model/src/main/java/com/yahoo/config/model/builder/xml/XmlHelper.java
+++ b/config-model/src/main/java/com/yahoo/config/model/builder/xml/XmlHelper.java
@@ -184,7 +184,9 @@ public final class XmlHelper {
         factory.setXIncludeAware(false);
 
         try {
-            // XXE prevention
+            // Prevent XXE and internal-entity expansion by disallowing DOCTYPE (matches com.yahoo.text.XML and SchemaValidator)
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            // The external-entity/DTD features below are redundant once DOCTYPE is disallowed, but kept as defense in depth.
             factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);


### PR DESCRIPTION
Disallow DOCTYPE declarations in the two application-XML parser factories in
`config-application-package` (`com.yahoo.config.application.Xml`) and
`config-model` (`com.yahoo.config.model.builder.xml.XmlHelper`).

This brings both parsers in line with the hardening already present in
`com.yahoo.text.XML` and `SchemaValidator`, both of which disallow DOCTYPE.
The existing external-entity/DTD features are now redundant but kept as defense
in depth.

Vespa configuration files do not use DOCTYPE, and services.xml already passes
through the DOCTYPE-rejecting preprocess parser and schema validator, so no
functional change is expected.
