### PR TITLE
Fall back to AZ-unaware dispatch when zone info is unreliable

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/lb/LoadBalancer.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/lb/LoadBalancer.java
@@ -3,6 +3,7 @@ package com.yahoo.search.dispatch.lb;
 
 import com.yahoo.search.dispatch.RequestDuration;
 import com.yahoo.search.dispatch.searchcluster.Group;
+import com.yahoo.search.dispatch.searchcluster.Node;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -49,11 +50,17 @@ public class LoadBalancer {
             case LATENCY_AMORTIZED_OVER_TIME -> new AdaptiveScheduler(AdaptiveScheduler.Type.TIME, new Random(seed), scoreboard);
         };
 
-
-        this.remoteGroups = groups.stream()
-                                  .filter(group -> !group.availabilityZone().equals(localAvailabilityZone))
-                                  .map(Group::id)
-                                  .collect(Collectors.toUnmodifiableSet());
+        // Unless this container and every group has a proper AZ assigned, fall back to non-AZ-aware routing.
+        if (localAvailabilityZone.equals(Node.UNKNOWN_AVAILABILITY_ZONE) ||
+            groups.stream().anyMatch(group -> group.availabilityZone().equals(Node.UNKNOWN_AVAILABILITY_ZONE))) {
+            this.remoteGroups = Set.of();
+        }
+        else {
+            this.remoteGroups = groups.stream()
+                                      .filter(group -> !group.availabilityZone().equals(localAvailabilityZone))
+                                      .map(Group::id)
+                                      .collect(Collectors.toUnmodifiableSet());
+        }
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -29,10 +29,26 @@ public class Group {
     private volatile long targetActiveDocuments = 0;
     private volatile boolean isBalanced = true;
 
+    private static String azOf(List<Node> nodes) {
+        String found = null;
+        for (Node n : nodes) {
+            String az = n.availabilityZone();
+            if (found == null) {
+                found = az;
+            } else if (! found.equals(az)) {
+                log.warning("group of content nodes has conflicting availability zones: "
+                            + found + " != " + az);
+                found = null;
+                break;
+            }
+        }
+        return (found == null) ? Node.UNKNOWN_AVAILABILITY_ZONE : found;
+    }
+
     public Group(int id, List<Node> nodes) {
         this.id = id;
         this.nodes = List.copyOf(nodes);
-        this.availabilityZone = nodes.isEmpty() ? "default" : nodes.get(0).availabilityZone();
+        this.availabilityZone = azOf(nodes);
 
         int index = 0;
         for (var node: nodes) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Node.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Node.java
@@ -13,6 +13,13 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class Node {
 
+    /**
+     * The availability zone reported when none is configured; see the "default" value of
+     * node[].availabilityZone in dispatch-nodes.def and of availabilityZone in container.qr.def.
+     * Means "zone unknown", and makes dispatch fall back to availability zone unaware routing.
+     */
+    public static final String UNKNOWN_AVAILABILITY_ZONE = "default";
+
     private final String clusterName;
     private final int key;
     private final String hostname;
@@ -29,7 +36,7 @@ public class Node {
     private volatile boolean working = true;
 
     public Node(String clusterName, int key, String hostname, int group, boolean multipleGroups) {
-        this(clusterName, key, hostname, group, multipleGroups, "default");
+        this(clusterName, key, hostname, group, multipleGroups, UNKNOWN_AVAILABILITY_ZONE);
     }
 
     public Node(String clusterName, int key, String hostname, int group, boolean multipleGroups, String availabilityZone) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/lb/LoadBalancerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/lb/LoadBalancerTest.java
@@ -47,6 +47,11 @@ public class LoadBalancerTest {
     }
 
     @Test
+    void test_fallback_to_az_unaware_group_load_balancing() {
+        new LoadBalancerTester(LoadBalancer.Policy.ROUNDROBIN, 0.0).assertFallbackToAzUnawareLoadBalancing();
+    }
+
+    @Test
     void test_search_time_decay() {
         AdaptiveScheduler.DecayByRequests decayer = new AdaptiveScheduler.DecayByRequests(0, Duration.ofSeconds(1));
         TrackedGroup gs = newGroupStatus(1);

--- a/container-search/src/test/java/com/yahoo/search/dispatch/lb/LoadBalancerTester.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/lb/LoadBalancerTester.java
@@ -97,6 +97,42 @@ public class LoadBalancerTester {
         assertLb(List.of(0,   0, 50, 50), loadBalance(List.of(g0, g1, g2, g3), List.of(g0, g1), "az1"));
     }
 
+    /**
+     * Asserts that the availability zone preference is disabled entirely unless this container and
+     * every group has a zone, as a zone which is only known for some of them cannot be trusted.
+     */
+    void assertFallbackToAzUnawareLoadBalancing() {
+        Node n1 = new Node("test", 0, "test-node1", 0, true, "az1");
+        Node n2 = new Node("test", 1, "test-node2", 1, true, "az1");
+        Node n3 = new Node("test", 2, "test-node3", 2, true, "az2");
+        Node n4 = new Node("test", 3, "test-node4", 3, true, "az2");
+        Group g0 = new Group(0, List.of(n1));
+        Group g1 = new Group(1, List.of(n2));
+        Group g2 = new Group(2, List.of(n3));
+        Group g3 = new Group(3, List.of(n4));
+
+        // With a zone known for this container and for every group, only the local groups are used.
+        assertLb(List.of(50, 50,  0,  0), loadBalance(withSufficientCoverage(g0, g1, g2, g3), "az1"));
+
+        // This container has no zone configured, so every group is eligible.
+        assertLb(List.of(25, 25, 25, 25), loadBalance(withSufficientCoverage(g0, g1, g2, g3),
+                                                      Node.UNKNOWN_AVAILABILITY_ZONE));
+
+        // A group has no zone because none is configured for its node: every group is eligible.
+        Group unzoned = new Group(0, List.of(new Node("test", 0, "test-node1", 0, true)));
+        assertLb(List.of(25, 25, 25, 25), loadBalance(withSufficientCoverage(unzoned, g1, g2, g3), "az1"));
+
+        // A group has no zone because its nodes disagree on one: every group is eligible.
+        Group conflicted = new Group(0, List.of(n1, new Node("test", 4, "test-node5", 0, true, "az2")));
+        assertLb(List.of(25, 25, 25, 25), loadBalance(withSufficientCoverage(conflicted, g1, g2, g3), "az1"));
+    }
+
+    private static List<Group> withSufficientCoverage(Group... groups) {
+        for (Group group : groups)
+            group.setHasSufficientCoverage(true);
+        return List.of(groups);
+    }
+
     /** Asserts that the expected number of requests per group matches the actual. */
     public void assertLb(List<Integer> expected, List<Integer> actual) {
         if ( deviationPercentage == 0.0) { // Give better assert failure messages

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/GroupTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/GroupTest.java
@@ -1,0 +1,46 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.dispatch.searchcluster;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author arnej
+ */
+public class GroupTest {
+
+    private static Node node(int key, String availabilityZone) {
+        return new Node("test", key, "test-node" + key, 0, true, availabilityZone);
+    }
+
+    @Test
+    void group_is_in_the_availability_zone_all_its_nodes_agree_on() {
+        assertEquals("az1", new Group(0, List.of(node(0, "az1"))).availabilityZone());
+        assertEquals("az1", new Group(0, List.of(node(0, "az1"), node(1, "az1"), node(2, "az1"))).availabilityZone());
+    }
+
+    @Test
+    void group_has_no_availability_zone_when_its_nodes_disagree() {
+        assertEquals(Node.UNKNOWN_AVAILABILITY_ZONE,
+                     new Group(0, List.of(node(0, "az1"), node(1, "az2"))).availabilityZone());
+
+        // A conflict counts wherever in the group it appears, not just between the first two nodes.
+        assertEquals(Node.UNKNOWN_AVAILABILITY_ZONE,
+                     new Group(0, List.of(node(0, "az1"), node(1, "az1"), node(2, "az2"))).availabilityZone());
+
+        // A node without a zone configured conflicts with one which has it.
+        assertEquals(Node.UNKNOWN_AVAILABILITY_ZONE,
+                     new Group(0, List.of(node(0, Node.UNKNOWN_AVAILABILITY_ZONE), node(1, "az1"))).availabilityZone());
+    }
+
+    @Test
+    void group_has_no_availability_zone_when_unconfigured_or_empty() {
+        assertEquals(Node.UNKNOWN_AVAILABILITY_ZONE,
+                     new Group(0, List.of(new Node("test", 0, "test-node0", 0, true))).availabilityZone());
+        assertEquals(Node.UNKNOWN_AVAILABILITY_ZONE, new Group(0, List.of()).availabilityZone());
+    }
+
+}


### PR DESCRIPTION
AZ-aware dispatch prefers content groups in the container's own availability zone, so the local/remote classification of every group must be trustworthy. Both the container's own AZ (container.qr.def) and each content node's AZ (dispatch-nodes.def) come from config with the literal default "default", meaning "unknown" (now spelled Node.UNKNOWN_AVAILABILITY_ZONE), and a group is only meaningfully placed in a zone if all its nodes agree on one.

Group previously took the AZ of its first node, so a group whose nodes straddle zones, or whose nodes have no AZ configured, was silently classified as local or remote on the strength of one arbitrary node. That skews traffic: groups that are really remote get preferred, or all groups look remote and the preference does nothing useful, with no signal that the underlying config is off.

Group now requires all its nodes to report the same AZ, logs a warning when they conflict, and reports "default" otherwise. LoadBalancer treats "default" - its own or any group's - as missing zone information and falls back to AZ-unaware routing, leaving every group eligible rather than acting on a classification it cannot trust.

Unit tests by: Claude Opus 5 (1M context) <noreply@anthropic.com>
