### PR TITLE
Wire attribute quantization config to internal Proton attribute config

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/QuantizedTensorValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/QuantizedTensorValidator.java
@@ -8,6 +8,8 @@ import com.yahoo.schema.document.ImmutableSDField;
 import com.yahoo.text.Text;
 import com.yahoo.vespa.model.search.SearchCluster;
 
+import java.util.logging.Level;
+
 /**
  * Validator for ensuring quantization is only used on compatible tensor types.
  */
@@ -19,6 +21,12 @@ public class QuantizedTensorValidator  implements Validator {
             if (!attr.isQuantized()) {
                 return;
             }
+            // TODO remove this message once no longer experimental
+            String experimentalMsg = "quantization support is currently EXPERIMENTAL and should only be used for " +
+                    "testing. It is not guaranteed that persisted, experimental quantized tensors will be " +
+                    "compatible across Vespa versions.";
+            context.deployState().getDeployLogger().logApplicationPackage(
+                    Level.WARNING, makeFieldMessage(schema, field, experimentalMsg));
             if (attr.tensorType().isEmpty()) {
                 context.illegal(makeFieldMessage(schema, field, "quantization can only be set on tensor fields"));
                 return;

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuantizedTensorValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuantizedTensorValidatorTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.application.api.ApplicationPackage;
+import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.NullConfigModelRegistry;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -12,6 +13,7 @@ import com.yahoo.vespa.model.content.utils.ContentClusterBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.logging.Level;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,6 +69,30 @@ public class QuantizedTensorValidatorTest {
         }
     }
 
+    // TODO remove this test once no longer experimental
+    @Test
+    void quantized_field_logs_experimental_feature_deployment_warning() {
+        var fieldSpec = quantizedField("tensor<float>(x[1024])");
+        var logger = new TestLogger();
+        assertDoesNotThrow(() -> createModelAndValidate(schema(fieldSpec), logger));
+        assertEquals("WARNING: For schema 'test', field 'f': quantization support is currently EXPERIMENTAL "+
+                "and should only be used for testing. It is not guaranteed that persisted, experimental " +
+                "quantized tensors will be compatible across Vespa versions.\n", logger.toString());
+    }
+
+    // TODO remove this test once no longer experimental
+    @Test
+    void non_quantized_fields_do_not_log_deployment_warnings() {
+        String fieldSpec = """
+               field f type tensor<float>(x[1024]) {
+                 indexing: attribute
+               }
+               """;
+        var logger = new TestLogger();
+        assertDoesNotThrow(() -> createModelAndValidate(schema(fieldSpec), logger));
+        assertEquals("", logger.toString());
+    }
+
     private static String quantizedField(String typeSpec, String extra) {
         return Text.format("""
                field f type %s {
@@ -95,8 +121,17 @@ public class QuantizedTensorValidatorTest {
                 """, fieldSpec);
     }
 
-    private static void createModelAndValidate(String schema) {
-        DeployState deployState = createDeployState(schema);
+    private static class TestLogger implements DeployLogger {
+        private final StringBuilder message = new StringBuilder();
+        @Override
+        public void log(Level level, String message) {
+            this.message.append(Text.format("%s: %s\n", level.getName(), message));
+        }
+        public String toString() { return message.toString(); }
+    }
+
+    private static void createModelAndValidate(String schema, DeployLogger logger) {
+        DeployState deployState = createDeployState(schema, logger);
         VespaModel model;
         try {
             model = new VespaModel(new NullConfigModelRegistry(), deployState);
@@ -106,7 +141,11 @@ public class QuantizedTensorValidatorTest {
         ValidationTester.validate(new QuantizedTensorValidator(), model, deployState);
     }
 
-    private static DeployState createDeployState(String schema) {
+    private static void createModelAndValidate(String schema) {
+        createModelAndValidate(schema, null);
+    }
+
+    private static DeployState createDeployState(String schema, DeployLogger logger) {
         String servicesXml = Text.format("<services version='1.0'>\n%s\n</services>",
                 new ContentClusterBuilder().getXml());
         ApplicationPackage app = new MockApplicationPackage.Builder()
@@ -116,6 +155,9 @@ public class QuantizedTensorValidatorTest {
         var builder = new DeployState.Builder()
                 .applicationPackage(app)
                 .properties(new TestProperties().setHostedVespa(false));
+        if (logger != null) {
+            builder.deployLogger(logger);
+        }
         return builder.build();
     }
 

--- a/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
+++ b/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
@@ -173,6 +173,18 @@ void expect_distance_metric(AttributesConfig::Attribute::Distancemetric in_metri
     EXPECT_TRUE(out.distance_metric() == out_metric);
 }
 
+void expect_quantization_mode(AttributesConfig::Attribute::Distancemetric in_metric,
+                              QuantizationParams::QuantizationMode        expected_mode) {
+    AttributesConfig::Attribute a;
+    a.distancemetric = in_metric;
+    a.datatype = AttributesConfig::Attribute::Datatype::TENSOR;
+    a.tensortype = "tensor(x[5])";
+    a.quantization.bits = 4;
+    auto out = ConfigConverter::convert(a);
+    ASSERT_TRUE(out.quantization_params().has_value());
+    EXPECT_TRUE(out.quantization_params()->quantization_mode() == expected_mode);
+}
+
 TEST(AttributeManagerTest, require_that_config_can_be_converted) {
     using AVBT = BT;
     using AVCT = CollectionType;
@@ -236,6 +248,22 @@ TEST(AttributeManagerTest, require_that_config_can_be_converted) {
         a.tensortype = "tensor(x[5])";
         Config out = ConfigConverter::convert(a);
         EXPECT_EQ("tensor(x[5])", out.tensorType().to_spec());
+        EXPECT_EQ("tensor(x[5])", out.unquantized_tensor_type().to_spec());
+        EXPECT_FALSE(out.quantization_params().has_value());
+    }
+    { // quantized tensor
+        CACA a;
+        a.datatype = CACAD::TENSOR;
+        a.tensortype = "tensor(x[5])";
+        a.quantization.bits = 4;
+        Config out = ConfigConverter::convert(a);
+        EXPECT_EQ("tensor<int8>(x[7])", out.tensorType().to_spec()); // sizeof(float) + ceil_bytes(4 bits * 5) => 7
+        EXPECT_EQ("tensor(x[5])", out.unquantized_tensor_type().to_spec());
+        ASSERT_TRUE(out.quantization_params().has_value());
+        const auto& qp = *out.quantization_params();
+        EXPECT_EQ(qp.bits(), 4);
+        EXPECT_EQ(qp.seed(), 0xd4517d0bd7375213);
+        EXPECT_EQ(qp.quantization_mode(), QuantizationParams::QuantizationMode::MSE); // for default Euclidean
     }
     { // distance metric (default)
         CACA a;
@@ -252,6 +280,16 @@ TEST(AttributeManagerTest, require_that_config_can_be_converted) {
         expect_distance_metric(AttributesConfig::Attribute::Distancemetric::PRENORMALIZED_ANGULAR,
                                DistanceMetric::PrenormalizedAngular);
         expect_distance_metric(AttributesConfig::Attribute::Distancemetric::DOTPRODUCT, DistanceMetric::Dotproduct);
+    }
+    { // explicit distance metric to quantization mode mapping
+        using DM = AttributesConfig::Attribute::Distancemetric;
+        using QM = QuantizationParams::QuantizationMode;
+
+        expect_quantization_mode(DM::EUCLIDEAN, QM::MSE);
+        expect_quantization_mode(DM::ANGULAR, QM::InnerProduct);
+        expect_quantization_mode(DM::INNERPRODUCT, QM::InnerProduct);
+        expect_quantization_mode(DM::PRENORMALIZED_ANGULAR, QM::InnerProduct);
+        expect_quantization_mode(DM::DOTPRODUCT, QM::InnerProduct);
     }
     { // hnsw index default params (enabled)
         CACA a;

--- a/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
@@ -137,9 +137,33 @@ Config ConfigConverter::convert(const AttributesConfig::Attribute& cfg) {
                                                      cfg.index.hnsw.neighborstoexploreatinsert, dm,
                                                      cfg.index.hnsw.multithreadedindexing));
     }
+    std::optional<QuantizationParams> quantization_params;
+    if (cfg.quantization.bits > 0) {
+        // For now, hardcode the randomization seed to make the quantization precision
+        // reproducible across nodes and deployments.
+        // We can make this configurable later if needed, but this will require persisting
+        // the seed as part of the attribute headers for cross-checking, as using the wrong
+        // seed for quantized operations yields completely bogus results.
+        // The default Most Blessed Seed is the 64 MSBs of sha256(utf8_bytes("Vinsjan på kaia")).
+        constexpr uint64_t quant_seed = 0xd4517d0bd7375213;
+        // Quantization mode depends on the chosen distance metric. We prefer inner-product
+        // optimized quantization for everything except Euclidean distance (which is the
+        // default if no distance metric is set, meaning we prioritize vector reconstruction
+        // precision over unbiased inner products).
+        // TODO consider adding explicit schema config that can override this; people may use quantized
+        //  vectors without a configured distance metric, but then use dot product etc for ranking...
+        const auto quant_mode = (dm == DistanceMetric::Euclidean)
+                                    ? QuantizationParams::QuantizationMode::MSE
+                                    : QuantizationParams::QuantizationMode::InnerProduct;
+        quantization_params = QuantizationParams(quant_seed, quant_mode, cfg.quantization.bits);
+    }
     if (retval.basicType().type() == BasicType::Type::TENSOR) {
         if (!cfg.tensortype.empty()) {
-            retval.setTensorType(ValueType::from_spec(cfg.tensortype));
+            if (!quantization_params) {
+                retval.setTensorType(ValueType::from_spec(cfg.tensortype));
+            } else {
+                retval.set_tensor_type_with_quantization(ValueType::from_spec(cfg.tensortype), *quantization_params);
+            }
         } else {
             retval.setTensorType(ValueType::double_type());
         }


### PR DESCRIPTION
@toregge please review
@arnej27959 FYI

At least for the time being, quantization mode (MSE vs. inner product) is chosen implicitly to be based on the distance metric configured for the tensor. That is, MSE for Euclidean distance and inner product for everything else. Euclidean is the default distance metric if nothing is specified, so we assume this means we should prioritize vector reconstruction accuracy (i.e. MSE).

The PRNG seed used for randomized vector rotations is currently fixed to ensure reproducible results. We may choose to make this dynamic or configurable in the future, but this will require adding more metadata to persisted tensor attribute files to detect the use of incompatible seed values.

Also add a noisy deployment warning when using a field configured with quantization, as it's currently considered an experimental feature and we may change things under the hood without prior notice.