### PR TITLE
skip NaN in sum/average/stddev aggregators

### DIFF
--- a/searchlib/src/vespa/searchlib/aggregation/averageaggregationresult.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/averageaggregationresult.cpp
@@ -50,6 +50,9 @@ void AverageAggregationResult::onAggregate(const ResultNode& result) {
         static_cast<const ResultNodeVector&>(result).flattenSum(*_sum);
         _count += static_cast<const ResultNodeVector&>(result).size();
     } else {
+        if (std::isnan(result.getFloat())) {
+            return;
+        }
         _sum->add(result);
         _count++;
     }

--- a/searchlib/src/vespa/searchlib/aggregation/standarddeviationaggregationresult.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/standarddeviationaggregationresult.cpp
@@ -51,9 +51,12 @@ void StandardDeviationAggregationResult::onAggregate(const ResultNode& result) {
         static_cast<const ResultNodeVector&>(result).flattenSumOfSquared(_sumOfSquared);
         _count += static_cast<const ResultNodeVector&>(result).size();
     } else {
+        double v = result.getFloat();
+        if (std::isnan(v)) {
+            return;
+        }
         _sum.add(result);
-        FloatResultNode squared(result.getFloat());
-        squared.multiply(result);
+        FloatResultNode squared(v * v);
         _sumOfSquared.add(squared);
         _count++;
     }

--- a/searchlib/src/vespa/searchlib/aggregation/sumaggregationresult.cpp
+++ b/searchlib/src/vespa/searchlib/aggregation/sumaggregationresult.cpp
@@ -46,6 +46,9 @@ void SumAggregationResult::onAggregate(const ResultNode& result) {
     if (result.isMultiValue()) {
         static_cast<const ResultNodeVector&>(result).flattenSum(*_sum);
     } else {
+        if (std::isnan(result.getFloat())) {
+            return;
+        }
         _sum->add(result);
     }
 }


### PR DESCRIPTION
An missing floating point attribute value is represented as NaN, so a single missing value would poison the whole group: sum, average and standard deviation all returned NaN for the entire group instead of a result over the documents that actually have a value.

Ignore NaN input in the single-value path of SumAggregationResult, AverageAggregationResult and StandardDeviationAggregationResult; skipped values are also left out of the average/stddev counts, so those stay averages over the values actually aggregated.

This matches the NaN handling already done by the argmin/argmax aggregators, where a NaN key never selects a hit.

Also simplify the sum-of-squares computation to a plain double multiply now that the value has been fetched for the NaN check.

Note that the multi-value (flatten*) path is unchanged and still lets NaN elements through; missing values will be represented as an empty array.
