### PR TITLE
Enable InsertBraces in clang-format for C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 ---
 Language: Cpp
+InsertBraces: true
 AccessModifierOffset: -4
 ColumnLimit: 118
 IndentWidth: 4


### PR DESCRIPTION
Turn on clang-format's InsertBraces option so that single-statement control flow bodies (if/else/for/while/do) always get explicit braces when a file is formatted.

Why: unbraced bodies are a recurring source of subtle bugs, where adding a second statement, or a macro that expands to more than one statement, silently falls outside the intended block. Braces everywhere also keeps diffs smaller and more readable, since adding a line to a body no longer touches the surrounding lines.

This only affects code that clang-format actually reformats (the pre-commit hook covers .cpp/.h/.hpp), so existing code is converted gradually rather than in one sweeping reformat. The option requires clang-format 15+; .pre-commit-config.yaml already pins v21.1.8.
