### PR TITLE
Disallow field path updates to fast maps

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/derived/IndexingScript.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/IndexingScript.java
@@ -6,6 +6,7 @@ import com.yahoo.schema.document.GeoPos;
 import com.yahoo.schema.document.ImmutableSDField;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig.Ilscript.Builder;
+import com.yahoo.vespa.configdefinition.IlscriptsConfig.Ilscript.Complexfield;
 import com.yahoo.vespa.indexinglanguage.ExpressionConverter;
 import com.yahoo.vespa.indexinglanguage.ExpressionVisitor;
 import com.yahoo.vespa.indexinglanguage.expressions.AttributeExpression;
@@ -28,6 +29,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * An indexing language script derived from a schema. An indexing script contains a set of indexing
@@ -39,6 +41,8 @@ public final class IndexingScript extends Derived {
 
     private final List<String> docFields = new ArrayList<>();
     private final List<Expression> expressions = new ArrayList<>();
+    /** Sorted to keep the derived config stable. */
+    private final Set<String> fastMapSearchFields = new TreeSet<>();
     private List<ImmutableSDField> fieldsSettingLanguage;
     private final boolean isStreaming;
 
@@ -61,6 +65,11 @@ public final class IndexingScript extends Derived {
 
         if (field.hasFullIndexingDocprocRights())
             docFields.add(field.getName());
+
+        // Must be collected before the returns below, as a map field always uses a map.
+        if (field.hasFastMapSearch()) {
+            fastMapSearchFields.add(field.getName());
+        }
 
         if (field.usesStructOrMap() && ! GeoPos.isAnyPos(field)) return; // unsupported
         if (fieldsSettingLanguage.size() == 1 && fieldsSettingLanguage.get(0).equals(field)) return; // Already added
@@ -94,6 +103,9 @@ public final class IndexingScript extends Derived {
         IlscriptsConfig.Ilscript.Builder ilscriptBuilder = new IlscriptsConfig.Ilscript.Builder();
         ilscriptBuilder.doctype(getName());
         ilscriptBuilder.docfield(docFields);
+        for (String fieldName : fastMapSearchFields) {
+            ilscriptBuilder.complexfield(e -> e.name(fieldName).why(Complexfield.Why.FAST_MAP_SEARCH));
+        }
         addContentInOrder(ilscriptBuilder);
         configBuilder.ilscript(ilscriptBuilder);
     }

--- a/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/MapFastSearchTestCase.java
@@ -2,8 +2,10 @@
 package com.yahoo.schema;
 
 import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.schema.derived.IndexingScript;
 import com.yahoo.schema.document.SDField;
 import com.yahoo.schema.parser.ParseException;
+import com.yahoo.vespa.configdefinition.IlscriptsConfig;
 import org.junit.jupiter.api.Test;
 
 import static com.yahoo.config.model.test.TestUtil.joinLines;
@@ -73,6 +75,35 @@ public class MapFastSearchTestCase {
         assertTrue(fastMapSearchOf("field m type map<string, int> { map: fast-search }", true));
         assertTrue(fastMapSearchOf("field m type map<long, string> { map: fast-search }", true));
         assertTrue(fastMapSearchOf("field m type map<string, long> { map: fast-search }", true));
+    }
+
+    @Test
+    void requireFastMapFieldsAreListedInIlscriptsConfig() throws ParseException {
+        String fields = joinLines("field plain type map<string, string> { }",
+                                  "field fast type map<string, string> { map: fast-search }",
+                                  "field alsoFast type map<string, int> { map: fast-search }");
+        var config = ilscriptsConfigOf(build(getSd(fields), true));
+        assertEquals(1, config.ilscript().size());
+        var complexFields = config.ilscript(0).complexfield();
+        assertEquals(2, complexFields.size());
+        // Sorted by field name to keep the config stable.
+        assertEquals("alsoFast", complexFields.get(0).name());
+        assertEquals(IlscriptsConfig.Ilscript.Complexfield.Why.FAST_MAP_SEARCH, complexFields.get(0).why());
+        assertEquals("fast", complexFields.get(1).name());
+        assertEquals(IlscriptsConfig.Ilscript.Complexfield.Why.FAST_MAP_SEARCH, complexFields.get(1).why());
+    }
+
+    @Test
+    void requireNoComplexFieldsInIlscriptsConfigWithoutFastMapSearch() throws ParseException {
+        var config = ilscriptsConfigOf(build(getSd("field m type map<string, string> { }"), true));
+        assertEquals(1, config.ilscript().size());
+        assertTrue(config.ilscript(0).complexfield().isEmpty());
+    }
+
+    private static IlscriptsConfig ilscriptsConfigOf(Schema schema) {
+        var builder = new IlscriptsConfig.Builder();
+        new IndexingScript(schema, false).getConfig(builder);
+        return builder.build();
     }
 
     private static void assertRejected(String field, boolean flagEnabled, String expectedMessage) throws ParseException {

--- a/configdefinitions/src/vespa/ilscripts.def
+++ b/configdefinitions/src/vespa/ilscripts.def
@@ -16,3 +16,5 @@ maxReplacementCharacters int default=5000
 ilscript[].doctype    string
 ilscript[].docfield[] string
 ilscript[].content[]  string
+ilscript[].complexfield[].name string
+ilscript[].complexfield[].why  enum { FAST_MAP_SEARCH }

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/DocumentScript.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/DocumentScript.java
@@ -17,6 +17,7 @@ import com.yahoo.document.fieldpathupdate.FieldPathUpdate;
 import com.yahoo.document.update.FieldUpdate;
 import com.yahoo.document.update.MapValueUpdate;
 import com.yahoo.document.update.ValueUpdate;
+import com.yahoo.vespa.indexinglanguage.FieldPathUpdateHelper;
 import com.yahoo.vespa.indexinglanguage.FieldValuesFactory;
 import com.yahoo.vespa.indexinglanguage.expressions.Expression;
 import com.yahoo.vespa.indexinglanguage.expressions.InvalidInputException;
@@ -41,11 +42,14 @@ class DocumentScript {
     private final DocumentType documentType;
     private final Set<String> inputFields;
     private final ScriptExpression expression;
+    private final Set<String> fastMapSearchFields;
 
-    DocumentScript(DocumentType documentType, Collection<String> inputFields, ScriptExpression expression) {
+    DocumentScript(DocumentType documentType, Collection<String> inputFields, ScriptExpression expression,
+                   Set<String> fastMapSearchFields) {
         this.documentType = documentType;
         this.inputFields = new HashSet<>(inputFields);
         this.expression = expression;
+        this.fastMapSearchFields = Set.copyOf(fastMapSearchFields);
         expression.resolve(documentType);
     }
 
@@ -68,7 +72,9 @@ class DocumentScript {
             }
         }
         for (FieldPathUpdate fieldUpdate : update.fieldPathUpdates()) {
-            requireThatFieldIsDeclaredInDocument(fieldUpdate.getFieldPath().get(0).getFieldRef());
+            Field field = fieldUpdate.getFieldPath().get(0).getFieldRef();
+            requireThatFieldIsDeclaredInDocument(field);
+            requireThatFieldPathUpdateIsSupported(field, fieldUpdate);
             if (fieldUpdate instanceof AssignFieldPathUpdate) {
                 removeAnyLinguisticsSpanTree(((AssignFieldPathUpdate)fieldUpdate).getFieldValue());
             }
@@ -79,6 +85,22 @@ class DocumentScript {
     private void requireThatFieldIsDeclaredInDocument(Field field) {
         if (field != null && !inputFields.contains(field.getName()))
             throw new InvalidInputException("Field '" + field.getName() + "' is not part of the declared " + documentType);
+    }
+
+    /**
+     * A map with fast search is indexed into a synthetic key-value attribute derived from the whole map, so a
+     * field path update reaching into the map would leave that attribute holding only the updated entries.
+     * Assigning the whole field is fine, as it is turned into a regular field update which reruns the script.
+     */
+    private void requireThatFieldPathUpdateIsSupported(Field field, FieldPathUpdate fieldUpdate) {
+        if (field == null || !fastMapSearchFields.contains(field.getName())) {
+            return;
+        }
+        if (FieldPathUpdateHelper.isFieldValues(fieldUpdate)) {
+            return;
+        }
+        throw new InvalidInputException("Field '" + field.getName() + "' has 'map: fast-search', which does not " +
+                                        "support field path updates into the map. Assign the whole map instead.");
     }
 
     private void removeAnyLinguisticsSpanTree(ValueUpdate<?> valueUpdate) {

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/ScriptManager.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/ScriptManager.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Holds, per document type, the indexing language scripts to run for each input field,
@@ -100,6 +101,12 @@ class ScriptManager {
             InputExpression.FieldPathOptimizer fieldPathOptimizer = new InputExpression.FieldPathOptimizer(documentType);
             List<StatementExpression> allStatements = new ArrayList<>(ilscript.content().size());
             Map<String, DocumentScript> fieldScripts = new HashMap<>(ilscript.content().size());
+            Set<String> fastMapSearchFields =
+                    ilscript.complexfield()
+                            .stream()
+                            .filter(field -> field.why() == IlscriptsConfig.Ilscript.Complexfield.Why.FAST_MAP_SEARCH)
+                            .map(IlscriptsConfig.Ilscript.Complexfield::name)
+                            .collect(Collectors.toUnmodifiableSet());
             for (String content : ilscript.content()) {
                 StatementExpression statement = parse(documentType, parserContext, content);
                 allStatements.add(statement);
@@ -125,14 +132,14 @@ class ScriptManager {
                     } else {
                         fieldScript = new ScriptExpression(statement);
                     }
-                    fieldScripts.put(fieldName, new DocumentScript(documentType, List.of(fieldName), fieldScript));
+                    fieldScripts.put(fieldName, new DocumentScript(documentType, List.of(fieldName), fieldScript, fastMapSearchFields));
                 }
             }
 
             // One script that runs them all.
             var allScript = new ScriptExpression(allStatements);
             allScript.select(fieldPathOptimizer, fieldPathOptimizer);
-            fieldScripts.put(FULL, new DocumentScript(documentType, ilscript.docfield(), allScript));
+            fieldScripts.put(FULL, new DocumentScript(documentType, ilscript.docfield(), allScript, fastMapSearchFields));
             documentFieldScripts.put(ilscript.doctype(), Collections.unmodifiableMap(fieldScripts));
         }
         return Collections.unmodifiableMap(documentFieldScripts);

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/DocumentScriptTestCase.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -263,7 +264,8 @@ public class DocumentScriptTestCase {
     private static DocumentScript newScript(DocumentType type, String fieldName) {
         var script = new ScriptExpression();
         return new DocumentScript(type, List.of(fieldName),
-                                  new ScriptExpression(new StatementExpression(new InputExpression(fieldName), new IndexExpression(fieldName))));
+                                  new ScriptExpression(new StatementExpression(new InputExpression(fieldName), new IndexExpression(fieldName))),
+                                  Set.of());
     }
 
     private static DocumentScript newScript(DocumentType docType) {

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
@@ -1,19 +1,28 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.docprocs.indexing;
 
+import com.yahoo.document.DataType;
 import com.yahoo.document.DocumentType;
 import com.yahoo.document.DocumentTypeManager;
+import com.yahoo.document.DocumentUpdate;
+import com.yahoo.document.datatypes.MapFieldValue;
+import com.yahoo.document.datatypes.StringFieldValue;
+import com.yahoo.document.fieldpathupdate.AssignFieldPathUpdate;
 import com.yahoo.language.process.Chunker;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.language.process.FieldGenerator;
 import com.yahoo.metrics.simple.MetricReceiver;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
+import com.yahoo.vespa.indexinglanguage.FieldValuesFactory;
+import com.yahoo.vespa.indexinglanguage.expressions.InvalidInputException;
 import org.junit.Test;
 
 import java.util.Iterator;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author Simon Thoresen Hult
@@ -100,6 +109,69 @@ public class ScriptManagerTestCase {
         assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle"), "title"));
         assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle"), "weight"));
         assertNotNull(scriptMgr.getScript(typeMgr.getDocumentType("newsarticle"), "uri"));
+    }
+
+    @Test
+    public void requireThatFieldPathUpdateIntoFastSearchMapIsRejected() {
+        DocumentUpdate update = newUpdate();
+        update.addFieldPathUpdate(new AssignFieldPathUpdate(update.getDocumentType(), "myMap{key}",
+                                                            new StringFieldValue("value")));
+        try {
+            executeWithFastMapSearchOnMyMap(update);
+            fail("Expected exception");
+        }
+        catch (InvalidInputException e) {
+            assertEquals("Field 'myMap' has 'map: fast-search', which does not support field path updates " +
+                         "into the map. Assign the whole map instead.",
+                         e.getMessage());
+        }
+    }
+
+    @Test
+    public void requireThatFieldPathUpdateAssigningTheWholeFastSearchMapIsAccepted() {
+        MapFieldValue<StringFieldValue, StringFieldValue> map =
+                new MapFieldValue<>(DataType.getMap(DataType.STRING, DataType.STRING));
+        map.put(new StringFieldValue("key"), new StringFieldValue("value"));
+
+        DocumentUpdate update = newUpdate();
+        update.addFieldPathUpdate(new AssignFieldPathUpdate(update.getDocumentType(), "myMap", map));
+        executeWithFastMapSearchOnMyMap(update);
+    }
+
+    @Test
+    public void requireThatFieldPathUpdateToOtherFieldIsAccepted() {
+        DocumentUpdate update = newUpdate();
+        update.addFieldPathUpdate(new AssignFieldPathUpdate(update.getDocumentType(), "myOtherMap{key}",
+                                                            new StringFieldValue("value")));
+        executeWithFastMapSearchOnMyMap(update);
+    }
+
+    private static DocumentUpdate newUpdate() {
+        DocumentType docType = new DocumentType("myDocumentType");
+        docType.addField("myMap", DataType.getMap(DataType.STRING, DataType.STRING));
+        docType.addField("myOtherMap", DataType.getMap(DataType.STRING, DataType.STRING));
+        return new DocumentUpdate(docType, "id:ns:myDocumentType::");
+    }
+
+    /** Runs the given update through a script manager configured with 'map: fast-search' on 'myMap'. */
+    private static void executeWithFastMapSearchOnMyMap(DocumentUpdate update) {
+        DocumentType docType = update.getDocumentType();
+        var typeMgr = new DocumentTypeManager();
+        typeMgr.registerDocumentType(docType);
+
+        IlscriptsConfig.Builder config = new IlscriptsConfig.Builder();
+        config.ilscript(new IlscriptsConfig.Ilscript.Builder()
+                                .doctype(docType.getName())
+                                .docfield("myMap")
+                                .docfield("myOtherMap")
+                                .complexfield(field -> field.name("myMap")
+                                                            .why(IlscriptsConfig.Ilscript.Complexfield.Why.FAST_MAP_SEARCH)));
+        ScriptManager scriptMgr = new ScriptManager(typeMgr, new IlscriptsConfig(config), null,
+                                                    Chunker.throwsOnUse.asMap(),
+                                                    Embedder.throwsOnUse.asMap(),
+                                                    FieldGenerator.throwsOnUse.asMap(),
+                                                    MetricReceiver.nullImplementation);
+        scriptMgr.getScript(docType).execute(new FieldValuesFactory(), update, null);
     }
 
 }


### PR DESCRIPTION
Add a `ilscript[].complexfield[]` branch with `fieldName, why` pairs to the indexing language config (ilconfig). Then use this to reject field path updates when the map uses fast map search.

Field path updates are generally not supported for attribute vectors yet. Normal maps support it, however, by patching attribute vectors with the values computed in the doc store. This computation happens on the content node.

Fast maps transform only the key and value in the container, so we can't make a similar update for the "keyvalue" attribute.

Field path updates to maps with fast search currently update `field.key` and `field.value` but not `field.keyvalue`, so search would see only stale values. Therefore, we currently disallow field path updates with fast map search and encourage users to update the entire map in a partial update instead.