### PR TITLE
Add support for hitLimit annotation to string ranges

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -1719,10 +1719,13 @@
     ],
     "methods" : [
       "public void <init>(java.lang.String, boolean, java.lang.String, boolean, java.lang.String, boolean, com.yahoo.prelude.query.Substring)",
+      "public void <init>(java.lang.String, boolean, java.lang.String, boolean, int, java.lang.String, boolean, com.yahoo.prelude.query.Substring)",
       "public final java.lang.String getFrom()",
       "public final boolean isFromInclusive()",
       "public final java.lang.String getTo()",
       "public final boolean isToInclusive()",
+      "public final int getHitLimit()",
+      "public final void setHitLimit(int)",
       "public java.lang.String getIndexedString()",
       "public java.lang.String getRawWord()",
       "public com.yahoo.prelude.query.Item$ItemType getItemType()",

--- a/container-search/src/main/java/com/yahoo/prelude/query/StringRangeItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/StringRangeItem.java
@@ -26,6 +26,8 @@ public class StringRangeItem extends TermItem {
     /** Whether this interval is closed to the right, i.e., whether the left right is included. */
     private final boolean toInclusive;
 
+    private int hitLimit = 0;
+
     /**
      * Create a StringRangeItem.
      */
@@ -35,6 +37,14 @@ public class StringRangeItem extends TermItem {
         this.fromInclusive = fromInclusive && from != null; // Negative infinity cannot be included
         this.to = to;
         this.toInclusive = toInclusive && to != null; // Positive infinity cannot be included
+    }
+
+    /**
+     * Create a StringRangeItem with a hitLimit.
+     */
+    public StringRangeItem(String from, boolean fromInclusive, String to, boolean toInclusive, int hitLimit, String indexName, boolean isFromQuery, Substring origin) {
+        this(from, fromInclusive, to, toInclusive, indexName, isFromQuery, origin);
+        this.hitLimit = hitLimit;
     }
 
     /** Returns the left endpoint of this interval, where null means negative infinity. */
@@ -57,6 +67,27 @@ public class StringRangeItem extends TermItem {
         return toInclusive;
     }
 
+    /**
+     * Returns the number of hits this will match, or 0 if all should be matched.
+     * If this number is positive, the hits closest to <code>from</code> are returned, and if
+     * this number is negative the hits closest to <code>to</code> are returned.
+     */
+    public final int getHitLimit() {
+        return hitLimit;
+    }
+
+    /**
+     * Sets the number of hits this will match, or 0 if all should be
+     * matched. If this number is positive, the hits closest to
+     * <code>from</code> are returned, and if this number is negative the hits
+     * closest to <code>to</code> are returned.
+     *
+     * @param hitLimit number of hits to match for this operator
+     */
+    public final void setHitLimit(int hitLimit) {
+        this.hitLimit = hitLimit;
+    }
+
     /** Returns a string representation of this interval. Can be ambiguous and is only for printing purposes. */
     @Override
     public String getIndexedString() {
@@ -64,6 +95,9 @@ public class StringRangeItem extends TermItem {
         sb.append(this.fromInclusive ? "[" : "<" ).append(this.from != null ? "\"" + this.from + "\"" : "-Infinity");
         sb.append(";");
         sb.append(this.to != null ? "\"" + this.to+ "\"" : "Infinity").append(this.toInclusive ? "]" : ">" );
+        if (hitLimit != 0) {
+            sb.append(";").append(hitLimit);
+        }
         return sb.toString();
     }
 
@@ -153,6 +187,9 @@ public class StringRangeItem extends TermItem {
             builder.setUpperLimit(to);
         }
         builder.setUpperInclusive(toInclusive);
+        if (hitLimit != 0) {
+            builder.setRangeLimit(hitLimit);
+        }
         return SearchProtocol.QueryTreeItem.newBuilder()
                 .setItemStringRangeTerm(builder.build())
                 .build();

--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -775,7 +775,11 @@ public class SelectParser implements Parser {
                 if (hitLimit != null) {
                     number.setHitLimit(hitLimit);
                 }
-
+            } else if (out instanceof StringRangeItem stringRange && annotations != null) {
+                Integer hitLimit = getCappedRangeSearchParameter(annotations);
+                if (hitLimit != null) {
+                    stringRange.setHitLimit(hitLimit);
+                }
             }
         }
 

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -2305,6 +2305,11 @@ public class YqlParser implements Parser {
             if (hitLimit != null) {
                 number.setHitLimit(hitLimit);
             }
+        } else if (leaf instanceof StringRangeItem stringRange) {
+            Integer hitLimit = getCappedRangeSearchParameter(ast);
+            if (hitLimit != null) {
+                stringRange.setHitLimit(hitLimit);
+            }
         }
 
         return leaf;

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/StringRangeItemTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/StringRangeItemTestCase.java
@@ -42,6 +42,24 @@ public class StringRangeItemTestCase {
         assertFalse(range.isWords());
     }
 
+    @Test
+    void testHitLimit() {
+        StringRangeItem range = new StringRangeItem("aaa", true, "zzz", true, 42, "index", true, null);
+        assertEquals(42, range.getHitLimit());
+        assertEquals("[\"aaa\";\"zzz\"];42", range.getIndexedString());
+        assertEquals("[\"aaa\";\"zzz\"];42", range.getRawWord()); // fallback when no origin provided
+
+        range = new StringRangeItem("aaa", true, "zzz", true, -42, "index", true, null);
+        assertEquals(-42, range.getHitLimit());
+        assertEquals("[\"aaa\";\"zzz\"];-42", range.getIndexedString());
+        assertEquals("[\"aaa\";\"zzz\"];-42", range.getRawWord()); // fallback when no origin provided
+
+        range.setHitLimit(1234);
+        assertEquals(1234, range.getHitLimit());
+        assertEquals("[\"aaa\";\"zzz\"];1234", range.getIndexedString());
+        assertEquals("[\"aaa\";\"zzz\"];1234", range.getRawWord()); // fallback when no origin provided
+    }
+
 
     @Test
     void testStringRemembersOrigin() {

--- a/searchlib/src/protobuf/search_protocol.proto
+++ b/searchlib/src/protobuf/search_protocol.proto
@@ -270,6 +270,7 @@ message ItemStringRangeTerm {
     optional string upper_limit = 3;
     bool lower_inclusive = 4;
     bool upper_inclusive = 5;
+    optional int32 range_limit = 6;
 }
 
 // multi-terms:

--- a/searchlib/src/tests/attribute/searchcontext/searchcontext_test.cpp
+++ b/searchlib/src/tests/attribute/searchcontext/searchcontext_test.cpp
@@ -931,14 +931,16 @@ void SearchContextTest::fillForSearchIteratorUnpackingTest(IntegerAttribute* ia,
         ia->append(3, 10, 50);
     }
     ia->commit(CommitParam::UpdateStats::FORCE);
-    if (!extra)
+    if (!extra) {
         return;
+    }
     ia->addDocs(20);
     for (uint32_t d = 4; d < 24; ++d) {
-        if (ia->getCollectionType() == CollectionType::SINGLE)
+        if (ia->getCollectionType() == CollectionType::SINGLE) {
             ia->update(d, 10);
-        else
+        } else {
             ia->append(d, 10, 1);
+        }
     }
     ia->commit(CommitParam::UpdateStats::FORCE);
 }
@@ -1309,11 +1311,12 @@ std::string to_hex(uint32_t n) {
 }
 
 std::unique_ptr<QueryTermSimple> make_string_range_query_term(uint32_t left, bool left_closed, bool left_unbounded,
-                                                              uint32_t right, bool right_closed,
-                                                              bool right_unbounded) {
+                                                              uint32_t right, bool right_closed, bool right_unbounded,
+                                                              int32_t range_limit = 0) {
     return std::make_unique<QueryTermUCS4>(
-        QueryTermSimple::Type::WORD, std::make_unique<StringRangeSpec>(to_hex(left), left_closed, left_unbounded,
-                                                                       to_hex(right), right_closed, right_unbounded));
+        QueryTermSimple::Type::WORD,
+        std::make_unique<StringRangeSpec>(to_hex(left), left_closed, left_unbounded, to_hex(right), right_closed,
+                                          right_unbounded, range_limit));
 }
 
 DocSet make_range_doc_set(uint32_t n, uint32_t left, bool left_closed, bool left_unbounded, uint32_t right,
@@ -1381,6 +1384,55 @@ void SearchContextTest::test_lexical_range_search(const std::string& name, const
                            make_string_range_query_term(i, false, false, j, false, false),
                            make_range_doc_set(n, i, false, false, j, false, false));
         }
+    }
+
+    if (cfg.fastSearch()) {
+        // Test range_limit. More sophisticated testing in system test.
+
+        // Bounded, ascending
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, true, false, 8, true, false, 1),
+                       make_range_doc_set(n, 2, true, false, 2, true, false));
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, true, false, 8, true, false, 2),
+                       make_range_doc_set(n, 2, true, false, 3, true, false));
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, false, false, 8, true, false, 2),
+                       make_range_doc_set(n, 3, true, false, 4, true, false));
+
+        // Bounded, descending
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, true, false, 8, true, false, -1),
+                       make_range_doc_set(n, 8, true, false, 8, true, false));
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, true, false, 8, true, false, -2),
+                       make_range_doc_set(n, 7, true, false, 8, true, false));
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, true, false, 8, false, false, -2),
+                       make_range_doc_set(n, 6, true, false, 7, true, false));
+
+        // Unbounded, ascending: can yield more than the range limit
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, false, true, 8, true, false, 1),
+                       make_range_doc_set(n, 1, true, false, name == "s-fs-str" ? 1 : 2, true, false));
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, false, true, 8, true, false, 2),
+                       make_range_doc_set(n, 1, true, false, name == "s-fs-str" ? 2 : 3, true, false));
+        // Unbounded, descending: can yield more than the range limit
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, true, false, 8, false, true, -1),
+                       make_range_doc_set(n, name == "ws-fs-str" ? 15 : 14, true, false, 15, true, false));
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, true, false, 8, false, true, -2),
+                       make_range_doc_set(n, name == "ws-fs-str" ? 14 : 13, true, false, 15, true, false));
+    } else {
+        // Check that the range limit is ignored
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, true, false, 8, true, false, 1),
+                       make_range_doc_set(n, 2, true, false, 8, true, false));
+        perform_search(queryeval::ExecuteInfo::FULL, attr,
+                       make_string_range_query_term(2, true, false, 8, true, false, -1),
+                       make_range_doc_set(n, 2, true, false, 8, true, false));
     }
 
     // Long range, cf. testPrefixSearch
@@ -1719,8 +1771,9 @@ void SearchContextTest::requireThatSearchIsWorkingAfterLoadAndClearDoc(const std
         for (uint32_t i = 0; i < 14; ++i) {
             if (i < 5) {
                 EXPECT_EQ(i + 1, array[i].getDocId());
-            } else
+            } else {
                 EXPECT_EQ(i + 2, array[i].getDocId());
+            }
         }
     }
     ValueType buf;

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -46,7 +46,9 @@ std::vector<StringRange> string_ranges() {
     return {StringRange(std::make_unique<search::StringRangeSpec>("aaa", true, false, "zzz", false, false)),
             StringRange(std::make_unique<search::StringRangeSpec>("", true, true, "zzz", true, false)),
             StringRange(std::make_unique<search::StringRangeSpec>("aaa", false, false, "", false, true)),
-            StringRange(std::make_unique<search::StringRangeSpec>("", false, true, "", false, true))};
+            StringRange(std::make_unique<search::StringRangeSpec>("", false, true, "", false, true)),
+            StringRange(std::make_unique<search::StringRangeSpec>("aaa", true, false, "zzz", false, false, 42)),
+            StringRange(std::make_unique<search::StringRangeSpec>("aaa", true, false, "zzz", false, false, -42))};
 }
 
 PredicateQueryTerm::UP getPredicateQueryTerm() {

--- a/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_range_posting_search_context.hpp
@@ -38,6 +38,20 @@ StringRangePostingSearchContext<BaseSC, AttrT, DataT>::StringRangePostingSearchC
                 vespalib::datastore::PositiveInfinityUniqueStoreStringComparator<IEnumStore::InternalIndex>(
                     _enumStore.get_data_store()));
         }
+        if (!this->_dictionary.get_has_btree_dictionary()) {
+            return;
+        }
+        if (_range_spec->range_limit != 0) {
+            // If we the interval is open at a side (and not unbounded on that side),
+            // we have to add one since the end point might be filtered out later in use_dictionary_entry.
+            // Otherwise, we risk returning too few hits.
+            // The hitLimit annotations means that we should return "at least hitLimit" many hits,
+            // so returning more is fine.
+            int32_t sign = _range_spec->range_limit < 0 ? -1 : 1;
+            this->applyRangeLimit(_range_spec->range_limit +
+                                  sign * ((!_range_spec->left_closed || _range_spec->left_unbounded) +
+                                          (!_range_spec->right_closed || _range_spec->right_unbounded)));
+        }
         if (this->_uniqueValues == 1u) {
             if (!this->_lowerDictItr.valid() || use_single_dictionary_entry(this->_lowerDictItr)) {
                 this->lookupSingle();

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
@@ -25,15 +25,16 @@ SimpleQueryStackDumpIterator::~SimpleQueryStackDumpIterator() = default;
 
 std::string_view SimpleQueryStackDumpIterator::read_string_view(const char*& p) {
     uint64_t len = readCompressedPositiveInt(p);
-    if ((p + len) > _bufEnd)
+    if ((p + len) > _bufEnd) {
         throw false;
+    }
     std::string_view result(p, len);
     p += len;
     return result;
 }
 
 uint64_t SimpleQueryStackDumpIterator::readCompressedPositiveInt(const char*& p) {
-    if (p > _bufEnd || !vespalib::compress::Integer::check_decompress_space(p, _bufEnd - p)) {
+    if (p > _bufEnd || !vespalib::compress::Integer::check_decompress_positive_space(p, _bufEnd - p)) {
         throw false;
     }
     uint64_t tmp;
@@ -43,7 +44,7 @@ uint64_t SimpleQueryStackDumpIterator::readCompressedPositiveInt(const char*& p)
 }
 
 int64_t SimpleQueryStackDumpIterator::readCompressedInt(const char*& p) {
-    if (p > _bufEnd || !vespalib::compress::Integer::check_decompress_positive_space(p, _bufEnd - p)) {
+    if (p > _bufEnd || !vespalib::compress::Integer::check_decompress_space(p, _bufEnd - p)) {
         throw false;
     }
     int64_t tmp;
@@ -71,9 +72,10 @@ bool SimpleQueryStackDumpIterator::next() {
 }
 
 bool SimpleQueryStackDumpIterator::readNext() {
-    if ((_buf + _currEnd) >= _bufEnd)
+    if ((_buf + _currEnd) >= _bufEnd) {
         // End of buffer, so no more items available
         return false;
+    }
 
     // Set the position to the previous end. If just starting, sets pos to _buf
     _currPos = _currEnd;
@@ -104,8 +106,9 @@ bool SimpleQueryStackDumpIterator::readNext() {
     /** flags of the current item **/
     uint8_t currFlags = 0;
     if (__builtin_expect(ParseItem::getFeature_Flags(typefield), false)) {
-        if ((p + sizeof(uint8_t)) > _bufEnd)
+        if ((p + sizeof(uint8_t)) > _bufEnd) {
             return false;
+        }
         currFlags = (uint8_t)*p++;
     }
     _d.noRankFlag = (currFlags & ParseItem::ItemFlags::IFLAG_NORANK) != 0;

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
@@ -300,6 +300,7 @@ void SimpleQueryStackDumpIterator::read_string_range_term(const char*& p) {
     if (!spec->right_unbounded) {
         spec->right = std::string(read_string_view(p));
     }
+    spec->range_limit = static_cast<int32_t>(readCompressedInt(p));
     _d.stringRangeSpec = std::move(spec);
     _d.arity = 0;
 }

--- a/searchlib/src/vespa/searchlib/query/proto_tree_converter.hpp
+++ b/searchlib/src/vespa/searchlib/query/proto_tree_converter.hpp
@@ -402,6 +402,10 @@ public:
         spec->right = item.upper_limit();
         spec->right_closed = item.upper_inclusive();
 
+        if (item.has_range_limit()) {
+            spec->range_limit = item.range_limit();
+        }
+
         query::StringRange range(std::move(spec));
         auto&              term = _builder.add_string_range_term(range, d.index_view, d.uniqueId, d.weight);
         if (d.noRankFlag)

--- a/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/query/proto_tree_iterator.cpp
@@ -298,6 +298,7 @@ bool handle(const ItemStringRangeTerm& item, QueryStackIterator::Data& _d) {
     }
     spec->left_closed = item.lower_inclusive();
     spec->right_closed = item.upper_inclusive();
+    spec->range_limit = item.range_limit();
     _d.stringRangeSpec = std::move(spec);
     return true;
 }

--- a/searchlib/src/vespa/searchlib/query/string_range_spec.h
+++ b/searchlib/src/vespa/searchlib/query/string_range_spec.h
@@ -13,13 +13,16 @@ namespace search {
  */
 
 struct StringRangeSpec {
+    // The actual string range/interval
     std::string left;
     bool        left_closed = true;
     bool        left_unbounded = false;
     std::string right;
     bool        right_closed = true;
     bool        right_unbounded = false;
-    int32_t     range_limit = 0;
+
+    // The range limit from the hitLimit annotation
+    int32_t range_limit = 0;
 
     ~StringRangeSpec();
 

--- a/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
+++ b/searchlib/src/vespa/searchlib/query/tree/query_to_protobuf.h
@@ -363,6 +363,9 @@ private:
         }
         item->set_lower_inclusive(spec->left_closed);
         item->set_upper_inclusive(spec->right_closed);
+        if (spec->has_range_limit()) {
+            item->set_range_limit(spec->range_limit);
+        }
     }
 
     void visit(StringTerm& node) override {

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -261,14 +261,18 @@ class QueryNodeConverter : public QueryVisitor {
         bool        left_closed = (spec == nullptr) || spec->left_closed;
         bool        right_closed = (spec == nullptr) || spec->right_closed;
         uint8_t     flags = 0;
-        if (left_unbounded)
+        if (left_unbounded) {
             flags |= ParseItem::SRT_LEFT_UNBOUNDED;
-        if (right_unbounded)
+        }
+        if (right_unbounded) {
             flags |= ParseItem::SRT_RIGHT_UNBOUNDED;
-        if (left_closed)
+        }
+        if (left_closed) {
             flags |= ParseItem::SRT_LEFT_CLOSED;
-        if (right_closed)
+        }
+        if (right_closed) {
             flags |= ParseItem::SRT_RIGHT_CLOSED;
+        }
         appendByte(flags);
         if (!left_unbounded) {
             appendString(spec->left);
@@ -276,6 +280,7 @@ class QueryNodeConverter : public QueryVisitor {
         if (!right_unbounded) {
             appendString(spec->right);
         }
+        appendCompressedNumber(spec->range_limit);
     }
 
     void visit(StringTerm& node) override { createTerm(node, ParseItem::ITEM_TERM); }


### PR DESCRIPTION
This (in particular, testing this) became super ugly since one cannot necessarily express a string range as a closed interval. This means that one might have to return more than `hitLimit` many hits if we do not have a closed interval. The implementation seems to work as it is now and to always return at least `hitLimit` many hits. More testing in accompanying system test.

To make the unit tests of the protobuf serialization easier, I added the range limit also to the legacy stack dump. This led to the unit tests crashing, which turned out to be an old bug that Claude found (`readCompressedPositiveInt` and `readCompressedInt` apparently had their checks swapped). See the commit for that.