### PR TITLE
Honor soft deadlines while building numeric range bitmaps

### DIFF
--- a/searchlib/src/tests/attribute/posting_store/posting_store_test.cpp
+++ b/searchlib/src/tests/attribute/posting_store/posting_store_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/searchcommon/attribute/status.h>
 #include <vespa/searchlib/attribute/postingstore.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/doom.h>
 #include <vespa/vespalib/util/generationhandler.h>
 
 #include <vespa/searchlib/attribute/enumstore.hpp>
@@ -221,6 +222,56 @@ void PostingStoreTest::test_compact_btree_nodes(uint32_t sequence_length) {
 INSTANTIATE_TEST_SUITE_P(PostingStoreMultiTest, PostingStoreTest,
                          testing::Values(PostingStoreSetup(false), PostingStoreSetup(true)),
                          testing::PrintToStringParamName());
+
+TEST_P(PostingStoreTest, deadline_aware_traversal_preserves_all_postings) {
+    for (int length : {4, 30, 10000}) {
+        SCOPED_TRACE(length);
+        auto root = add_sequence(1, length + 1);
+        inc_generation();
+        std::vector<int> keys;
+        _store.foreach_frozen_key(root, [&](uint32_t key) { keys.push_back(key); }, vespalib::Doom::never());
+        EXPECT_EQ(make_exp_sequence(1, length + 1), keys);
+        _store.clear(root);
+        inc_generation();
+    }
+}
+
+TEST_P(PostingStoreTest, expired_deadline_skips_postings) {
+    std::atomic<vespalib::steady_time> now(vespalib::steady_time() + 2s);
+    vespalib::Doom                     doom(now, vespalib::steady_time() + 1s);
+    for (int length : {4, 30, 10000}) {
+        SCOPED_TRACE(length);
+        auto root = add_sequence(1, length + 1);
+        inc_generation();
+        std::vector<int> keys;
+        _store.foreach_frozen_key(root, [&](uint32_t key) { keys.push_back(key); }, doom);
+        EXPECT_TRUE(keys.empty());
+        _store.clear(root);
+        inc_generation();
+    }
+}
+
+TEST_P(PostingStoreTest, deadline_interrupts_a_large_posting_list) {
+    auto root = add_sequence(1, 10001);
+    inc_generation();
+    std::atomic<vespalib::steady_time> now{vespalib::steady_time()};
+    vespalib::Doom                     doom(now, vespalib::steady_time() + 1s);
+    std::vector<int>                   keys;
+    _store.foreach_frozen_key(
+        root,
+        [&](uint32_t key) {
+            keys.push_back(key);
+            if (key == 2000) {
+                now.store(vespalib::steady_time() + 2s);
+            }
+        },
+        doom);
+    EXPECT_GE(keys.size(), 2000u);
+    EXPECT_LE(keys.size(), 4096u);
+    EXPECT_EQ(make_exp_sequence(1, keys.size() + 1), keys);
+    _store.clear(root);
+    inc_generation();
+}
 
 TEST_P(PostingStoreTest, require_that_nodes_for_multiple_small_btrees_are_compacted) {
     test_compact_btree_nodes(30);

--- a/searchlib/src/tests/attribute/searchcontext/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/searchcontext/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_executable(searchlib_searchcontext_test_app TEST
     SOURCES
+    range_bitmap_timeout_test.cpp
     searchcontext_test.cpp
     DEPENDS
     vespa_searchlib

--- a/searchlib/src/tests/attribute/searchcontext/range_bitmap_timeout_test.cpp
+++ b/searchlib/src/tests/attribute/searchcontext/range_bitmap_timeout_test.cpp
@@ -1,0 +1,59 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchcommon/attribute/search_context_params.h>
+#include <vespa/searchlib/attribute/attributevector.h>
+#include <vespa/searchlib/attribute/search_context.h>
+#include <vespa/searchlib/fef/termfieldmatchdata.h>
+#include <vespa/searchlib/query/query_term_simple.h>
+#include <vespa/searchlib/queryeval/executeinfo.h>
+#include <vespa/searchlib/queryeval/simpleresult.h>
+#include <vespa/searchlib/test/attribute_builder.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/simple_thread_bundle.h>
+
+namespace search::attribute {
+namespace {
+
+class ExpiringThreadBundle : public vespalib::ThreadBundle {
+    std::atomic<vespalib::steady_time>& _now;
+    vespalib::SimpleThreadBundle        _threads;
+
+public:
+    ExpiringThreadBundle(std::atomic<vespalib::steady_time>& now, size_t threads) : _now(now), _threads(threads) {}
+    size_t size() const override { return _threads.size(); }
+    void run(vespalib::Runnable* const* targets, size_t count) override {
+        _now.store(vespalib::steady_time() + 2s);
+        _threads.run(targets, count);
+    }
+};
+
+TEST(RangeBitmapTimeoutTest, expiry_before_workers_run_stops_bitmap_construction) {
+    Config config(BasicType::INT32, CollectionType::SINGLE);
+    config.setFastSearch(true);
+    auto attribute = test::AttributeBuilder("range", config).fill({1, 2, 3, 4, 5, 6}).get();
+    for (size_t threads : {1, 3}) {
+        SCOPED_TRACE(threads);
+        std::atomic<vespalib::steady_time> now{vespalib::steady_time()};
+        vespalib::Doom                     doom(now, vespalib::steady_time() + 1s);
+        ExpiringThreadBundle               thread_bundle(now, threads);
+        auto context = attribute->getSearch(std::make_unique<QueryTermSimple>("[2;5]", QueryTermSimple::Type::WORD),
+                                            SearchContextParams());
+        context->fetchPostings(queryeval::ExecuteInfo::create(1.0, doom, thread_bundle), true);
+        fef::TermFieldMatchData match_data;
+        auto                    iterator = context->createIterator(&match_data, true);
+        queryeval::SimpleResult result;
+        result.search(*iterator, attribute->getCommittedDocIdLimit());
+        EXPECT_EQ(queryeval::SimpleResult(), result);
+    }
+    auto context = attribute->getSearch(std::make_unique<QueryTermSimple>("[2;5]", QueryTermSimple::Type::WORD),
+                                        SearchContextParams());
+    context->fetchPostings(queryeval::ExecuteInfo::FULL, true);
+    fef::TermFieldMatchData match_data;
+    auto                    iterator = context->createIterator(&match_data, true);
+    queryeval::SimpleResult result;
+    result.search(*iterator, attribute->getCommittedDocIdLimit());
+    EXPECT_EQ(queryeval::SimpleResult({2, 3, 4, 5}), result);
+}
+
+} // namespace
+} // namespace search::attribute

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
@@ -82,17 +82,19 @@ template <typename DataT> struct PostingListSearchContextT<DataT>::FillPart : pu
             _owned_bv = BitVector::create(_docIdLimit);
             _bv = _owned_bv.get();
         }
-        // TODO Add  && !_doom.soft_doom() to loop
-        for (; _from != _to; ++_from) {
-            addToBitVector(PostingListTraverser<PostingStore>(_posting_store, _from.getData().load_acquire()));
+        for (; _from != _to && !_doom.soft_doom(); ++_from) {
+            addToBitVector(_from.getData().load_acquire());
         }
     }
-    void addToBitVector(const PostingListTraverser<PostingStore>& postingList) {
-        postingList.foreach_key([this](uint32_t key) {
-            if (__builtin_expect(key < _docIdLimit, true)) {
-                _bv->setBit(key);
-            }
-        });
+    void addToBitVector(vespalib::datastore::EntryRef ref) {
+        _posting_store.foreach_frozen_key(
+            ref,
+            [this](uint32_t key) {
+                if (__builtin_expect(key < _docIdLimit, true)) {
+                    _bv->setBit(key);
+                }
+            },
+            _doom);
     }
     const vespalib::Doom       _doom;
     const PostingStore&        _posting_store;
@@ -121,6 +123,9 @@ template <typename DataT> void PostingListSearchContextT<DataT>::fillBitVector(c
                            _merger.getDocIdLimit());
     }
     thread_bundle.run(parts);
+    if (exec_info.doom().soft_doom()) {
+        return;
+    }
     std::vector<BitVector*> vectors;
     vectors.reserve(parts.size());
     for (const auto& part : parts) {

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
@@ -78,6 +78,9 @@ template <typename DataT> struct PostingListSearchContextT<DataT>::FillPart : pu
         _to += count;
     }
     void run() override {
+        if (_doom.soft_doom()) {
+            return;
+        }
         if (_bv == nullptr) {
             _owned_bv = BitVector::create(_docIdLimit);
             _bv = _owned_bv.get();

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.h
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.h
@@ -9,6 +9,10 @@
 
 #include <set>
 
+namespace vespalib {
+class Doom;
+}
+
 namespace search {
 class BitVector;
 class GrowableBitVector;
@@ -176,6 +180,10 @@ public:
     void beginFrozen(const EntryRef ref, std::vector<ConstIterator>& where) const;
 
     template <typename FunctionType> VESPA_DLL_LOCAL void foreach_frozen_key(EntryRef ref, FunctionType func) const;
+
+    // May stop before visiting all keys; callers must discard the query on expiry.
+    template <typename FunctionType>
+    VESPA_DLL_LOCAL void foreach_frozen_key(EntryRef ref, FunctionType func, const vespalib::Doom& doom) const;
 
     template <typename FunctionType> VESPA_DLL_LOCAL void foreach_frozen(EntryRef ref, FunctionType func) const;
 

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.hpp
@@ -4,8 +4,36 @@
 #include "postingstore.h"
 
 #include <vespa/searchlib/common/growablebitvector.h>
+#include <vespa/vespalib/util/doom.h>
 
 namespace search::attribute {
+
+template <typename DataT>
+template <typename FunctionType>
+void PostingStore<DataT>::foreach_frozen_key(EntryRef ref, FunctionType func, const vespalib::Doom& doom) const {
+    constexpr size_t chunk_size = 4096;
+    if (doom.soft_doom()) {
+        return;
+    }
+    if (frozenSize(ref) <= chunk_size) {
+        foreach_frozen_key(ref, func);
+    } else if (has_btree(ref)) {
+        auto it = beginFrozen(ref);
+        while (it.valid() && !doom.soft_doom()) {
+            auto end = it;
+            end += chunk_size;
+            it.foreach_key_range(end, func);
+            it = end;
+        }
+    } else {
+        const auto& bv = getBitVectorEntry(RefType(ref))->_bv->reader();
+        for (uint32_t docid = bv.getFirstTrueBit(1); docid < bv.size() && !doom.soft_doom();
+             docid = bv.getNextTrueBit(docid + 1))
+        {
+            func(docid);
+        }
+    }
+}
 
 template <typename DataT>
 template <typename FunctionType>


### PR DESCRIPTION
Numeric range queries can keep building synthetic filter bitmaps after their soft deadline, occupying search workers while callers time out and retry. `FillPart` already carries a `Doom`, but its posting-list loop never checks it.

Check expiry between posting lists and during traversal of a large individual list. Small lists retain the existing bulk visitor; large frozen B-trees use batches of at most 4,096 keys, and bitmap-only lists check expiry while advancing. Skip worker bitmap allocation and the final bitmap union after expiry. The existing matcher deadline check rejects expired setup before matching can use an incomplete filter.

Regression coverage exercises unchanged traversal, already-expired deadlines, expiry partway through a large posting list, both bitmap-only and tree-backed stores, and expiry before numeric-range bitmap workers run with one and three threads.

Validation:
- Built and passed `searchlib_posting_store_test_app` and `searchlib_searchcontext_test_app` locally.
- Restored the original `postinglistsearchcontext.hpp`: the new numeric-range regression fails for both one and three workers, demonstrating the previous deadline violation. Restoring the fix makes it pass.
- Changed C++ lines pass clang-format 23.1.1; the diff passes `git diff --check`.

🤖 Generated with [Codex](https://developers.openai.com/codex) (gpt-6-astra)
