### PR TITLE
return quiet_NaN from missing float/double fields in streaming also

### DIFF
--- a/searchlib/src/vespa/searchlib/expression/documentfieldnode.h
+++ b/searchlib/src/vespa/searchlib/expression/documentfieldnode.h
@@ -20,7 +20,7 @@ public:
     }
     double onGetFloat(size_t index) const override {
         (void)index;
-        return 0;
+        return std::numeric_limits<double>::quiet_NaN();
     }
     ConstBufferRef onGetString(size_t index, BufferRef buf) const override {
         (void)index;


### PR DESCRIPTION
makes grouping in streaming a little bit closer to indexed